### PR TITLE
Minankari design + 4-round vocab quiz + menu integration

### DIFF
--- a/src/Infrastructure/Telegram/BotCommands/MenuCommand.cs
+++ b/src/Infrastructure/Telegram/BotCommands/MenuCommand.cs
@@ -11,11 +11,13 @@ public class MenuCommand : IBotCommand
 {
     private readonly ITelegramBotClient _client;
     private readonly IMediator _mediator;
+    private readonly BotConfiguration _botConfig;
 
-    public MenuCommand(ITelegramBotClient client, IMediator mediator)
+    public MenuCommand(ITelegramBotClient client, IMediator mediator, BotConfiguration botConfig)
     {
         _client = client;
         _mediator = mediator;
+        _botConfig = botConfig;
     }
 
     public Task<bool> IsApplicable(TelegramRequest request, CancellationToken ct)
@@ -27,7 +29,10 @@ public class MenuCommand : IBotCommand
 
     public async Task Execute(TelegramRequest request, CancellationToken token)
     {
-        var keyboard = MenuKeyboard.GetMenuKeyboard(request.User!.Settings.CurrentLanguage);
+        var miniAppUrl = _botConfig.MiniAppEnabled && !string.IsNullOrEmpty(_botConfig.HostAddress)
+            ? $"{_botConfig.HostAddress}/"
+            : null;
+        var keyboard = MenuKeyboard.GetMenuKeyboard(request.User!.Settings.CurrentLanguage, miniAppUrl);
         
         // If request comes from a callback (button click), edit existing message
         if (request.RequestType == UpdateType.CallbackQuery)

--- a/src/Infrastructure/Telegram/CommonComponents/MenuKeyboard.cs
+++ b/src/Infrastructure/Telegram/CommonComponents/MenuKeyboard.cs
@@ -1,12 +1,13 @@
 using Domain.Entities;
 using Infrastructure.Telegram.Models;
+using Telegram.Bot.Types;
 using Telegram.Bot.Types.ReplyMarkups;
 
 namespace Infrastructure.Telegram.CommonComponents;
 
 public static class MenuKeyboard
 {
-    public static InlineKeyboardMarkup GetMenuKeyboard(Language currentLanguage)
+    public static InlineKeyboardMarkup GetMenuKeyboard(Language currentLanguage, string miniAppUrl = null)
     {
         var buttons = new List<InlineKeyboardButton[]>
         {
@@ -39,6 +40,16 @@ public static class MenuKeyboard
             });
         }
         
+        // Mini-app button — opens Бомбора in a WebApp overlay
+        if (!string.IsNullOrEmpty(miniAppUrl))
+        {
+            buttons.Add(new[]
+            {
+                InlineKeyboardButton.WithWebApp("🐶 Бомбора — учить грузинский",
+                    new WebAppInfo { Url = miniAppUrl })
+            });
+        }
+
         buttons.Add(new[]
         {
             InlineKeyboardButton.WithCallbackData($"{CommandNames.HowToIcon} Как пользоваться", CommandNames.HowTo)

--- a/src/Trale/Controllers/MiniAppController.cs
+++ b/src/Trale/Controllers/MiniAppController.cs
@@ -429,7 +429,41 @@ public class MiniAppController : Controller
             };
         }).ToList();
 
-        return Ok(new { questions = userQuestions });
+        // Word pairs + distractor pools for frontend-built rounds
+        // (GE→RU multi-choice, type-in both directions)
+        var wordPairs = selected.Select(entry =>
+        {
+            var (ge, ru) = GetSides(entry);
+            return new
+            {
+                wordId = entry.Id,
+                georgian = ge,
+                russian = ru
+            };
+        }).ToList();
+
+        var allGeorgian = allEntries
+            .Select(e => GetSides(e).georgian)
+            .Concat(starterWords)
+            .Where(w => !string.IsNullOrWhiteSpace(w))
+            .Distinct()
+            .ToList();
+
+        var starterRussian = _content.GetStarterVocabulary().Select(s => s.Definition).ToList();
+        var allRussian = allEntries
+            .Select(e => GetSides(e).russian)
+            .Concat(starterRussian)
+            .Where(w => !string.IsNullOrWhiteSpace(w))
+            .Distinct()
+            .ToList();
+
+        return Ok(new
+        {
+            questions = userQuestions,
+            wordPairs,
+            allGeorgian,
+            allRussian
+        });
     }
 
     public class VocabularyAnswerRequest

--- a/src/Trale/HostedServices/CreateWebhook.cs
+++ b/src/Trale/HostedServices/CreateWebhook.cs
@@ -30,20 +30,12 @@ public class CreateWebhook : IHostedService
             dropPendingUpdates: false,
             cancellationToken: cancellationToken);
 
-        // Mini-app chat menu button is feature-flagged. When disabled in config, we don't
-        // touch the existing menu button at all — prod users continue to see whatever
-        // they saw before. When enabled, we point the chat menu button to the SPA root,
-        // which auto-detects Telegram WebApp initData and shows the app (or the landing page otherwise).
-        if (_config.MiniAppEnabled)
-        {
-            await _telegramBotClient.SetChatMenuButtonAsync(
-                menuButton: new MenuButtonWebApp
-                {
-                    Text = "🐶 Бомбора",
-                    WebApp = new WebAppInfo { Url = $"{_config.HostAddress}/" }
-                },
-                cancellationToken: cancellationToken);
-        }
+        // Mini-app is accessible from the /menu inline keyboard (WebApp button),
+        // not from the chat menu button. Reset to the standard commands menu
+        // so the button next to the text input shows the command list, not a WebApp.
+        await _telegramBotClient.SetChatMenuButtonAsync(
+            menuButton: new MenuButtonCommands(),
+            cancellationToken: cancellationToken);
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)

--- a/src/Trale/miniapp-src/index.html
+++ b/src/Trale/miniapp-src/index.html
@@ -6,9 +6,9 @@
     <meta name="theme-color" content="#FF9B42" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <title>Бомбора — Грузинский</title>
+    <title>Бомбора — блокнот для изучения грузинского</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/Trale/miniapp-src/src/App.tsx
+++ b/src/Trale/miniapp-src/src/App.tsx
@@ -12,6 +12,7 @@ import VocabularyList from './screens/VocabularyList'
 import VocabularyPractice from './screens/VocabularyPractice'
 import LandingScreen from './screens/LandingScreen'
 import Mascot from './components/Mascot'
+import LoaderLetter from './components/LoaderLetter'
 
 function isInsideTelegram(): boolean {
   const tg = (window as any).Telegram?.WebApp
@@ -89,19 +90,37 @@ export default function App() {
 
   if (loadError) {
     return (
-      <div className="flex flex-col min-h-full items-center justify-center gap-4 p-6 text-center">
-        <Mascot mood="sleep" size={120} />
-        <div className="font-extrabold text-lg">Бомбора не дозвонился до сервера</div>
-        <div className="text-dog-muted">Проверь соединение и попробуй открыть ещё раз.</div>
+      <div
+        className="flex flex-col items-center justify-center gap-4 p-6 text-center bg-cream"
+        style={{
+          minHeight: '100dvh',
+          paddingTop: 'calc(var(--safe-t) + 24px)',
+          paddingBottom: 'calc(var(--safe-b) + 24px)'
+        }}
+      >
+        <Mascot mood="sleep" size={140} />
+        <div className="mn-eyebrow">связь потерялась</div>
+        <div className="font-sans text-[22px] font-bold text-jewelInk">
+          Бомбора не дозвонился
+        </div>
+        <div className="font-sans text-[14px] text-jewelInk-mid max-w-[280px]">
+          Проверь соединение и попробуй открыть блокнот ещё раз.
+        </div>
       </div>
     )
   }
 
   if (!catalog || screen.kind === 'loading') {
     return (
-      <div className="flex flex-col min-h-full items-center justify-center gap-4">
-        <Mascot mood="think" size={120} />
-        <div className="text-dog-muted">Бомбора раскладывает карточки...</div>
+      <div
+        className="flex flex-col items-center justify-center bg-cream"
+        style={{
+          minHeight: '100dvh',
+          paddingTop: 'var(--safe-t)',
+          paddingBottom: 'var(--safe-b)'
+        }}
+      >
+        <LoaderLetter />
       </div>
     )
   }

--- a/src/Trale/miniapp-src/src/api.ts
+++ b/src/Trale/miniapp-src/src/api.ts
@@ -74,8 +74,17 @@ export interface VocabularyQuizQuestion {
   isStarter: boolean
 }
 
+export interface VocabularyWordPair {
+  wordId: string
+  georgian: string
+  russian: string
+}
+
 export interface VocabularyQuizResponse {
   questions: VocabularyQuizQuestion[]
+  wordPairs?: VocabularyWordPair[]
+  allGeorgian?: string[]
+  allRussian?: string[]
 }
 
 export type VocabularyQuizMode = 'all' | 'new' | 'weak' | 'custom' | 'starter'

--- a/src/Trale/miniapp-src/src/components/Button.tsx
+++ b/src/Trale/miniapp-src/src/components/Button.tsx
@@ -8,22 +8,35 @@ interface Props {
   className?: string
 }
 
-export default function Button({ children, onClick, variant = 'primary', disabled, className = '' }: Props) {
-  const base =
-    'w-full rounded-2xl px-5 py-4 font-extrabold uppercase tracking-wide transition active:translate-y-1 disabled:opacity-50 disabled:active:translate-y-0'
+/**
+ * Minanka jewel button — solid fill, ink border, offset shadow, tactile press.
+ * Variants keep their legacy names so existing screen code keeps working.
+ */
+export default function Button({
+  children,
+  onClick,
+  variant = 'primary',
+  disabled,
+  className = ''
+}: Props) {
   const styles: Record<string, string> = {
-    primary: 'bg-dog-accent text-white shadow-btn',
-    green: 'bg-dog-green text-white shadow-btngreen',
-    blue: 'bg-dog-blue text-white shadow-btnblue',
-    ghost: 'bg-white text-dog-ink shadow-card'
+    // primary → navy (main CTA across the app)
+    primary: 'bg-navy text-cream',
+    // green → ruby (success/confirmation — stays bright)
+    green: 'bg-ruby text-cream',
+    // blue → gold-deep (secondary — warm highlight)
+    blue: 'bg-gold text-jewelInk',
+    // ghost → cream tile (neutral secondary)
+    ghost: 'bg-cream-tile text-jewelInk'
   }
+
   return (
     <button
       onClick={onClick}
       disabled={disabled}
-      className={`${base} ${styles[variant]} ${className}`}
+      className={`jewel-btn ${styles[variant]} w-full ${className}`}
     >
-      {children}
+      <span className="relative z-[1]">{children}</span>
     </button>
   )
 }

--- a/src/Trale/miniapp-src/src/components/GeoGlyph.tsx
+++ b/src/Trale/miniapp-src/src/components/GeoGlyph.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+interface Props {
+  char: string
+  className?: string
+  style?: React.CSSProperties
+}
+
+/**
+ * Large faded Georgian letter used as background decor.
+ */
+export default function GeoGlyph({ char, className = '', style }: Props) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`pointer-events-none select-none font-geo text-paper-shade/60 ${className}`}
+      style={style}
+    >
+      {char}
+    </span>
+  )
+}

--- a/src/Trale/miniapp-src/src/components/Header.tsx
+++ b/src/Trale/miniapp-src/src/components/Header.tsx
@@ -5,44 +5,72 @@ interface Props {
   progress: ProgressState
   onBack?: () => void
   title?: string
+  eyebrow?: string
 }
 
-export default function Header({ progress, onBack, title }: Props) {
+/**
+ * Minanka header — kilim signature on top, back button + title row,
+ * stats pills below. No italic. No decoration beyond the kilim strip.
+ */
+export default function Header({ progress, onBack, title, eyebrow }: Props) {
   return (
-    <div
-      className="sticky top-0 z-10 bg-dog-bg/95 backdrop-blur px-4 pb-3 border-b border-dog-line"
-      style={{ paddingTop: 'calc(var(--safe-t) + 12px)' }}
-    >
-      <div className="flex items-center gap-2">
+    <div className="sticky top-0 z-30 bg-cream/95 backdrop-blur-sm">
+      {/* Kilim signature — appears on every screen that uses Header */}
+      <div style={{ paddingTop: 'var(--safe-t)' }}>
+        <div className="mn-kilim" />
+      </div>
+
+      <div className="px-5 py-3 flex items-center gap-3">
         {onBack ? (
           <button
             onClick={onBack}
-            className="w-9 h-9 rounded-full bg-white shadow-card flex items-center justify-center text-lg font-bold text-dog-ink active:translate-y-0.5"
+            className="shrink-0 w-11 h-11 rounded-xl bg-cream-tile border-[1.5px] border-jewelInk flex items-center justify-center active:translate-x-0.5 active:translate-y-0.5 active:shadow-none transition-all duration-75"
+            style={{ boxShadow: '2px 2px 0 #15100A' }}
             aria-label="Назад"
           >
-            ‹
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M10 3 L4 8 L10 13"
+                stroke="#15100A"
+                strokeWidth="2.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
           </button>
         ) : (
-          <div className="w-9" />
+          <div className="w-11 shrink-0" />
         )}
-        <div className="flex-1 text-center font-extrabold text-dog-ink truncate">
-          {title ?? 'Бомбора учит грузинский'}
-        </div>
-        <div className="w-9" />
-      </div>
-      <div className="flex gap-2 mt-2 text-xs">
-        <Stat icon="🔥" label={`${progress.streak} дн.`} />
-        <Stat icon="⭐" label={`${progress.xp} XP`} />
-      </div>
-    </div>
-  )
-}
 
-function Stat({ icon, label }: { icon: string; label: string }) {
-  return (
-    <div className="bg-white rounded-full px-2.5 py-1 shadow-card flex items-center gap-1.5">
-      <span>{icon}</span>
-      <span className="font-extrabold text-dog-ink">{label}</span>
+        <div className="flex-1 text-center min-w-0">
+          {eyebrow && (
+            <div className="mn-eyebrow text-navy mb-0.5 truncate">{eyebrow}</div>
+          )}
+          <div className="font-sans text-[18px] font-extrabold text-jewelInk leading-tight truncate">
+            {title ?? 'Бомбора'}
+          </div>
+        </div>
+
+        {/* Compact stats on the right */}
+        <div className="shrink-0 flex flex-col items-end gap-0.5">
+          <div className="flex items-baseline gap-1">
+            <span className="font-sans text-[14px] font-extrabold text-ruby tabular-nums leading-none">
+              {progress.streak}
+            </span>
+            <span className="font-sans text-[9px] font-bold text-jewelInk-mid uppercase tracking-wider">
+              дн
+            </span>
+          </div>
+          <div className="flex items-baseline gap-1">
+            <span className="font-sans text-[14px] font-extrabold text-navy tabular-nums leading-none">
+              {progress.xp}
+            </span>
+            <span className="font-sans text-[9px] font-bold text-jewelInk-mid uppercase tracking-wider">
+              xp
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/Trale/miniapp-src/src/components/InkDivider.tsx
+++ b/src/Trale/miniapp-src/src/components/InkDivider.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+
+interface Props {
+  variant?: 'line' | 'wave' | 'ornament'
+  className?: string
+}
+
+/**
+ * Divider drawn in ink. Three flavours:
+ *  - line: thin ink rule with end-caps
+ *  - wave: hand-drawn wavy underline
+ *  - ornament: line — small flourish — line
+ */
+export default function InkDivider({ variant = 'ornament', className = '' }: Props) {
+  if (variant === 'line') {
+    return (
+      <svg
+        className={`w-full h-3 text-ink ${className}`}
+        viewBox="0 0 200 8"
+        preserveAspectRatio="none"
+      >
+        <line
+          x1="2"
+          y1="4"
+          x2="198"
+          y2="4"
+          stroke="currentColor"
+          strokeWidth="1.4"
+          strokeLinecap="round"
+        />
+        <circle cx="2" cy="4" r="1.5" fill="currentColor" />
+        <circle cx="198" cy="4" r="1.5" fill="currentColor" />
+      </svg>
+    )
+  }
+
+  if (variant === 'wave') {
+    return (
+      <svg
+        className={`w-full h-4 text-wine ${className}`}
+        viewBox="0 0 200 10"
+        preserveAspectRatio="none"
+      >
+        <path
+          d="M0 5 Q 12 1 24 5 T 48 5 T 72 5 T 96 5 T 120 5 T 144 5 T 168 5 T 200 5"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          fill="none"
+          strokeLinecap="round"
+        />
+      </svg>
+    )
+  }
+
+  // ornament — line / tiny flourish / line
+  return (
+    <div className={`flex items-center gap-3 text-ink/60 ${className}`}>
+      <div className="flex-1 h-px bg-current" />
+      <svg width="24" height="14" viewBox="0 0 24 14" className="text-wine shrink-0">
+        <path
+          d="M2 7 Q 6 2 10 7 T 18 7"
+          stroke="currentColor"
+          strokeWidth="1.4"
+          fill="none"
+          strokeLinecap="round"
+        />
+        <circle cx="12" cy="7" r="1.6" fill="currentColor" />
+        <circle cx="2" cy="7" r="1" fill="currentColor" />
+        <circle cx="22" cy="7" r="1" fill="currentColor" />
+      </svg>
+      <div className="flex-1 h-px bg-current" />
+    </div>
+  )
+}

--- a/src/Trale/miniapp-src/src/components/KilimProgress.tsx
+++ b/src/Trale/miniapp-src/src/components/KilimProgress.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+
+interface Props {
+  done: number
+  total: number
+  accent?: 'navy' | 'ruby' | 'gold'
+  size?: 'sm' | 'md'
+}
+
+/**
+ * Progress track drawn as a row of alternating up/down triangles — a kilim
+ * zigzag pattern, directly echoing the kilim strip at the top and bottom
+ * of every screen. Completed triangles are solid in the module's accent
+ * colour, the current one is gold (highlighted), upcoming ones are cream.
+ */
+export default function KilimProgress({
+  done,
+  total,
+  accent = 'navy',
+  size = 'md'
+}: Props) {
+  if (total <= 0) return null
+
+  const triWidth = size === 'sm' ? 11 : 14
+  const triHeight = size === 'md' ? 22 : 18
+  const strokeWidth = size === 'md' ? 1.5 : 1.2
+  const padding = 1 // stroke overflow
+  const w = triWidth * total + padding * 2
+  const h = triHeight + padding * 2
+
+  const accentColor =
+    accent === 'navy' ? '#1B5FB0' : accent === 'ruby' ? '#E01A3C' : '#F5B820'
+  const currentColor = '#F5B820' // always gold for "you are here"
+  const emptyColor = '#F5EFE0'
+
+  return (
+    <div className="relative">
+      <svg
+        width="100%"
+        height={h}
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio="xMinYMid meet"
+        style={{ maxWidth: `${w}px`, display: 'block' }}
+      >
+        {Array.from({ length: total }).map((_, i) => {
+          const x = padding + i * triWidth
+          const isDone = i < done
+          const isCurrent = i === done && done < total
+          const isUp = i % 2 === 0
+
+          // Up-pointing (apex at top): base at bottom
+          // Down-pointing (apex at bottom): base at top
+          const path = isUp
+            ? `M ${x} ${padding + triHeight} L ${x + triWidth / 2} ${padding} L ${x + triWidth} ${padding + triHeight} Z`
+            : `M ${x} ${padding} L ${x + triWidth / 2} ${padding + triHeight} L ${x + triWidth} ${padding} Z`
+
+          const fill = isDone ? accentColor : isCurrent ? currentColor : emptyColor
+
+          return (
+            <path
+              key={i}
+              d={path}
+              fill={fill}
+              stroke="#15100A"
+              strokeWidth={strokeWidth}
+              strokeLinejoin="round"
+              style={{ transition: 'fill 320ms ease-out' }}
+            />
+          )
+        })}
+      </svg>
+    </div>
+  )
+}

--- a/src/Trale/miniapp-src/src/components/LoaderLetter.tsx
+++ b/src/Trale/miniapp-src/src/components/LoaderLetter.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+interface Props {
+  label?: string
+  size?: number
+}
+
+/**
+ * Learning-first loader. A single big Georgian letter that breathes.
+ * The user sees it many times during loading — and later, when they reach
+ * it in the alphabet module, there's a reveal moment.
+ *
+ * Chosen letter: ქ (pronounced "k"), first letter of ქართული — "Georgian".
+ */
+export default function LoaderLetter({ label = 'ქართული...', size = 140 }: Props) {
+  return (
+    <div className="flex flex-col items-center gap-6">
+      {/* Letter — normal flow, no absolute positioning */}
+      <div
+        className="mn-loader-letter text-navy flex items-center justify-center"
+        style={{
+          fontSize: `${size}px`,
+          lineHeight: 1,
+          height: `${size}px`
+        }}
+      >
+        ქ
+      </div>
+
+      {/* Gold underline — sits below, separate element */}
+      <div
+        className="bg-gold rounded-full"
+        style={{
+          width: `${Math.round(size * 0.5)}px`,
+          height: '4px'
+        }}
+      />
+
+      {/* Label */}
+      <div className="mn-eyebrow text-jewelInk-mid tracking-wider">{label}</div>
+    </div>
+  )
+}

--- a/src/Trale/miniapp-src/src/components/Mascot.tsx
+++ b/src/Trale/miniapp-src/src/components/Mascot.tsx
@@ -1,67 +1,159 @@
 import React from 'react'
 
 interface Props {
-  mood?: 'happy' | 'cheer' | 'sleep' | 'think'
+  mood?: 'happy' | 'cheer' | 'sleep' | 'think' | 'guide'
   size?: number
+  className?: string
 }
 
 /**
- * Dog mascot — "Бомбора" (a friendly shiba-ish puppy).
- * Pure inline SVG, no external assets.
+ * Бомбора — Picture Book illustration.
+ * Flat shapes, thick ink outline, warm fur, ruby scarf.
+ * Designed as a book illustration: less detail, more character.
  */
-export default function Mascot({ mood = 'happy', size = 140 }: Props) {
-  const eyeY = mood === 'sleep' ? 92 : 86
-  const eyeShape = mood === 'sleep'
-    ? <><path d="M58 92 Q65 88 72 92" stroke="#1B1B2F" strokeWidth="3" fill="none" strokeLinecap="round"/><path d="M98 92 Q105 88 112 92" stroke="#1B1B2F" strokeWidth="3" fill="none" strokeLinecap="round"/></>
-    : <><circle cx="65" cy={eyeY} r="5" fill="#1B1B2F"/><circle cx="105" cy={eyeY} r="5" fill="#1B1B2F"/><circle cx="67" cy={eyeY - 2} r="1.5" fill="#fff"/><circle cx="107" cy={eyeY - 2} r="1.5" fill="#fff"/></>
+export default function Mascot({ mood = 'happy', size = 200, className = '' }: Props) {
+  const INK = '#2A1F18'
+  const FUR = '#E6AE78'
+  const FUR_DARK = '#C98B4A'
+  const CREAM = '#FDF6EA'
+  const CORAL = '#E01A3C'
+  const CORAL_DEEP = '#A61026'
+  const NOSE = '#2A1F18'
 
-  const mouth = mood === 'cheer'
-    ? <path d="M76 108 Q85 120 94 108" stroke="#1B1B2F" strokeWidth="3" fill="#E94F4F" strokeLinecap="round"/>
-    : <path d="M78 106 Q85 112 92 106" stroke="#1B1B2F" strokeWidth="3" fill="none" strokeLinecap="round"/>
+  const eyes =
+    mood === 'sleep' ? (
+      <g stroke={INK} strokeWidth="3" strokeLinecap="round" fill="none">
+        <path d="M72 102 Q80 96 88 102" />
+        <path d="M112 102 Q120 96 128 102" />
+      </g>
+    ) : mood === 'think' ? (
+      <g fill={INK}>
+        <ellipse cx="80" cy="100" rx="4" ry="5.5" />
+        <ellipse cx="122" cy="100" rx="4" ry="5.5" />
+        <circle cx="78.5" cy="98" r="1.3" fill="#fff" />
+        <circle cx="120.5" cy="98" r="1.3" fill="#fff" />
+      </g>
+    ) : (
+      <g fill={INK}>
+        <circle cx="80" cy="100" r="5.5" />
+        <circle cx="122" cy="100" r="5.5" />
+        <circle cx="82" cy="98" r="1.8" fill="#fff" />
+        <circle cx="124" cy="98" r="1.8" fill="#fff" />
+      </g>
+    )
+
+  const mouth =
+    mood === 'cheer' ? (
+      <g>
+        <path
+          d="M88 122 Q101 138 114 122 Q101 128 88 122 Z"
+          fill={CORAL_DEEP}
+          stroke={INK}
+          strokeWidth="3"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M93 128 Q101 133 109 128"
+          stroke={CORAL}
+          strokeWidth="2.5"
+          fill="none"
+          strokeLinecap="round"
+        />
+      </g>
+    ) : mood === 'sleep' ? (
+      <path
+        d="M93 122 Q101 126 109 122"
+        stroke={INK}
+        strokeWidth="2.8"
+        fill="none"
+        strokeLinecap="round"
+      />
+    ) : (
+      <path
+        d="M90 120 Q101 128 112 120"
+        stroke={INK}
+        strokeWidth="2.8"
+        fill="none"
+        strokeLinecap="round"
+      />
+    )
 
   return (
     <svg
       width={size}
       height={size}
-      viewBox="0 0 170 170"
-      className="anim-wag"
+      viewBox="0 0 200 200"
+      className={`pb-breath ${className}`}
       style={{ display: 'block' }}
     >
-      {/* ground shadow */}
-      <ellipse cx="85" cy="155" rx="48" ry="6" fill="#000" opacity="0.08" />
+      {/* Ground shadow */}
+      <ellipse cx="100" cy="188" rx="58" ry="5" fill="#2A1F18" opacity="0.08" />
 
-      {/* ears back layer */}
-      <path d="M30 50 Q25 20 55 30 L60 60 Z" fill="#C8782A" />
-      <path d="M140 50 Q145 20 115 30 L110 60 Z" fill="#C8782A" />
+      {/* Scarf — ruby wrap under chin */}
+      <g>
+        <path
+          d="M38 138 Q68 162 100 156 Q132 162 162 138 L168 176 Q132 186 100 180 Q68 186 32 176 Z"
+          fill={CORAL}
+          stroke={INK}
+          strokeWidth="3.5"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M68 152 Q100 160 132 152"
+          stroke={INK}
+          strokeWidth="2.5"
+          fill="none"
+          strokeLinecap="round"
+        />
+        <path
+          d="M50 172 Q44 184 56 192 L72 186 L68 172 Z"
+          fill={CORAL}
+          stroke={INK}
+          strokeWidth="3"
+          strokeLinejoin="round"
+        />
+      </g>
 
-      {/* head */}
-      <ellipse cx="85" cy="95" rx="58" ry="52" fill="#F4A95A" />
+      {/* Ears */}
+      <path d="M28 56 Q22 20 58 36 L66 66 Z" fill={FUR_DARK} stroke={INK} strokeWidth="3.5" strokeLinejoin="round" />
+      <path d="M172 56 Q178 20 142 36 L134 66 Z" fill={FUR_DARK} stroke={INK} strokeWidth="3.5" strokeLinejoin="round" />
 
-      {/* cheek markings (shiba style) */}
-      <ellipse cx="58" cy="110" rx="16" ry="12" fill="#FFFFFF" />
-      <ellipse cx="112" cy="110" rx="16" ry="12" fill="#FFFFFF" />
-      <ellipse cx="85" cy="122" rx="18" ry="12" fill="#FFFFFF" />
+      {/* Head */}
+      <ellipse cx="100" cy="108" rx="66" ry="60" fill={FUR} stroke={INK} strokeWidth="3.5" />
 
-      {/* inner ears */}
-      <path d="M38 48 Q36 30 52 36 L56 55 Z" fill="#FFD9B0" />
-      <path d="M132 48 Q134 30 118 36 L114 55 Z" fill="#FFD9B0" />
+      {/* Cream muzzle/cheeks */}
+      <path
+        d="M50 118 Q42 142 58 152 Q72 160 86 154 Q94 148 100 148 Q106 148 114 154 Q128 160 142 152 Q158 142 150 118 Q138 108 122 114 Q110 120 100 120 Q90 120 78 114 Q62 108 50 118 Z"
+        fill={CREAM}
+        stroke={INK}
+        strokeWidth="3"
+        strokeLinejoin="round"
+      />
 
-      {/* eyes */}
-      {eyeShape}
+      {/* Inner ears */}
+      <path d="M38 52 Q34 32 54 42 L58 62 Z" fill={CREAM} stroke={INK} strokeWidth="2.5" />
+      <path d="M162 52 Q166 32 146 42 L142 62 Z" fill={CREAM} stroke={INK} strokeWidth="2.5" />
 
-      {/* snout */}
-      <ellipse cx="85" cy="108" rx="10" ry="7" fill="#FFFFFF" />
-      <ellipse cx="85" cy="100" rx="5" ry="3.5" fill="#1B1B2F" />
+      {/* Eyebrows */}
+      <path d="M70 86 L82 84" stroke={INK} strokeWidth="3" strokeLinecap="round" />
+      <path d="M118 84 L130 86" stroke={INK} strokeWidth="3" strokeLinecap="round" />
 
-      {/* mouth */}
+      {/* Eyes */}
+      {eyes}
+
+      {/* Nose bridge */}
+      <path d="M100 118 L100 122" stroke={INK} strokeWidth="2.5" strokeLinecap="round" />
+
+      {/* Nose */}
+      <ellipse cx="100" cy="116" rx="6" ry="4.5" fill={NOSE} />
+      <ellipse cx="98" cy="114.5" rx="1.3" ry="1" fill="#fff" />
+
+      {/* Mouth */}
       {mouth}
 
-      {/* tongue peek when cheer */}
-      {mood === 'cheer' && <ellipse cx="85" cy="115" rx="4" ry="3" fill="#E94F4F" />}
-
-      {/* blush */}
-      <circle cx="48" cy="112" r="4" fill="#FFB5B5" opacity="0.7" />
-      <circle cx="122" cy="112" r="4" fill="#FFB5B5" opacity="0.7" />
+      {/* Blush cheeks */}
+      <circle cx="56" cy="132" r="5" fill={CORAL} opacity="0.35" />
+      <circle cx="144" cy="132" r="5" fill={CORAL} opacity="0.35" />
     </svg>
   )
 }

--- a/src/Trale/miniapp-src/src/components/SketchCard.tsx
+++ b/src/Trale/miniapp-src/src/components/SketchCard.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+interface Props {
+  children: React.ReactNode
+  tilt?: 'none' | 'left' | 'right'
+  corners?: boolean
+  className?: string
+  onClick?: () => void
+  as?: 'div' | 'button'
+  ariaLabel?: string
+}
+
+/**
+ * Paper card with ink border, subtle shadow, optional corner marks and tilt.
+ * Feels like a card slipped into a journal.
+ */
+export default function SketchCard({
+  children,
+  tilt = 'none',
+  corners = false,
+  className = '',
+  onClick,
+  as = 'div',
+  ariaLabel
+}: Props) {
+  const tiltClass = tilt === 'left' ? 'tilt-l' : tilt === 'right' ? 'tilt-r' : ''
+  const cornerClass = corners ? 'corner-marks' : ''
+  const base = `sketch-card ${tiltClass} ${cornerClass} ${className}`.trim()
+
+  if (as === 'button' || onClick) {
+    return (
+      <button
+        onClick={onClick}
+        aria-label={ariaLabel}
+        className={`${base} text-left w-full transition active:translate-y-0.5 active:shadow-paper`}
+      >
+        {children}
+      </button>
+    )
+  }
+
+  return <div className={base}>{children}</div>
+}

--- a/src/Trale/miniapp-src/src/components/Stamp.tsx
+++ b/src/Trale/miniapp-src/src/components/Stamp.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+interface Props {
+  children: React.ReactNode
+  color?: 'wine' | 'moss' | 'saffron' | 'sky' | 'ink'
+  tilt?: 'left' | 'right'
+  animate?: boolean
+  className?: string
+}
+
+/**
+ * Rubber stamp — double border, slight rotation, uppercase tracked caps.
+ */
+export default function Stamp({
+  children,
+  color = 'wine',
+  tilt = 'left',
+  animate = false,
+  className = ''
+}: Props) {
+  const colorClass =
+    color === 'wine'
+      ? 'text-wine border-wine'
+      : color === 'moss'
+      ? 'text-moss border-moss'
+      : color === 'saffron'
+      ? 'text-saffron-deep border-saffron-deep'
+      : color === 'sky'
+      ? 'text-sky-deep border-sky-deep'
+      : 'text-ink border-ink'
+
+  const tiltClass = tilt === 'left' ? 'rotate-xs' : 'rotate-xs-r'
+  const animClass = animate ? (tilt === 'left' ? 'anim-stamp' : 'anim-stamp-r') : tiltClass
+
+  return (
+    <span className={`stamp ${colorClass} ${animClass} ${className}`}>{children}</span>
+  )
+}

--- a/src/Trale/miniapp-src/src/index.css
+++ b/src/Trale/miniapp-src/src/index.css
@@ -5,16 +5,28 @@
 :root {
   --safe-t: env(safe-area-inset-top, 0px);
   --safe-b: env(safe-area-inset-bottom, 0px);
+  --paper: #F4EBD4;
+  --paper-dark: #E8DCB8;
+  --ink: #1A1612;
+  --ink-soft: #3B2F25;
+  --wine: #A03A2C;
+  --moss: #4A6B3A;
+  --saffron: #C9923A;
+  --sky: #7A9CB8;
 }
 
-html, body {
+html,
+body {
   height: 100%;
-  background: #FFF6E5;
-  font-family: 'Nunito', system-ui, sans-serif;
-  color: #2E2E3A;
+  background-color: #FBF6EC; /* cream */
+  font-family: 'Manrope', 'Noto Sans Georgian', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  color: #15100A; /* jewelInk */
   -webkit-tap-highlight-color: transparent;
   overscroll-behavior: none;
   overflow-x: hidden;
+  font-feature-settings: 'ss01', 'cv11', 'kern';
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 body {
@@ -27,34 +39,409 @@ body {
   min-height: 100dvh;
   max-width: 480px;
   margin: 0 auto;
+  position: relative;
 }
+
 
 button {
   font-family: inherit;
   user-select: none;
+  color: inherit;
 }
 
-@keyframes pop {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.08); }
-  100% { transform: scale(1); }
+input,
+textarea {
+  font-family: inherit;
 }
-.anim-pop { animation: pop 300ms ease-out; }
+
+h1, h2, h3, h4 {
+  font-family: 'Fraunces', 'Noto Serif Georgian', Georgia, serif;
+  font-variation-settings: 'opsz' 144, 'SOFT' 100, 'wght' 500;
+  letter-spacing: -0.02em;
+  color: #2A1F18;
+}
+
+/* Picture Book display utility — round, soft, confident */
+.pb-display {
+  font-family: 'Fraunces', 'Noto Serif Georgian', Georgia, serif;
+  font-variation-settings: 'opsz' 144, 'SOFT' 100, 'wght' 500;
+  letter-spacing: -0.025em;
+  line-height: 0.95;
+  color: #2A1F18;
+}
+
+.pb-eyebrow {
+  font-family: 'Figtree', sans-serif;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 11px;
+  color: #7A6654; /* warm-600 */
+}
+
+.pb-body {
+  font-family: 'Figtree', sans-serif;
+  font-weight: 400;
+  line-height: 1.55;
+  color: #3B2D23; /* warm-800 */
+}
+
+/* Utility: hand-drawn underline using wavy SVG */
+.ink-underline {
+  position: relative;
+  display: inline-block;
+}
+.ink-underline::after {
+  content: '';
+  position: absolute;
+  left: -2%;
+  right: -2%;
+  bottom: -6px;
+  height: 6px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 6' preserveAspectRatio='none'%3E%3Cpath d='M0 3 Q 10 0 20 3 T 40 3 T 60 3 T 80 3 T 100 3' stroke='%23A03A2C' stroke-width='2' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: repeat-x;
+  background-size: 80px 6px;
+}
+
+.ink-strike {
+  position: relative;
+}
+.ink-strike::after {
+  content: '';
+  position: absolute;
+  left: -4%;
+  right: -4%;
+  top: 50%;
+  height: 2px;
+  background: var(--ink);
+  transform: rotate(-2deg);
+  border-radius: 1px;
+}
+
+/* Stamp — slightly rotated, double border, imperfect */
+.stamp {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 2px solid currentColor;
+  border-radius: 2px;
+  font-family: 'Fraunces', serif;
+  font-variation-settings: 'opsz' 144, 'wght' 700;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  font-size: 11px;
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+}
+.stamp::before {
+  content: '';
+  position: absolute;
+  inset: -3px;
+  border: 1px dashed currentColor;
+  opacity: 0.35;
+  pointer-events: none;
+  border-radius: 2px;
+}
+
+/* Rotate modifiers */
+.rotate-xs { transform: rotate(-1.5deg); }
+.rotate-xs-r { transform: rotate(1.5deg); }
+.rotate-sm { transform: rotate(-3deg); }
+.rotate-sm-r { transform: rotate(3deg); }
+
+/* Card backgrounds that feel like paper slipped over the page */
+.sketch-card {
+  background: linear-gradient(180deg, #FBF4DE 0%, #F4EBD4 100%);
+  border: 1px solid rgba(60, 47, 37, 0.18);
+  box-shadow: 2px 3px 0 rgba(26, 22, 18, 0.08), 0 6px 18px rgba(26, 22, 18, 0.05);
+  border-radius: 3px;
+  position: relative;
+}
+.sketch-card.tilt-l { transform: rotate(-0.6deg); }
+.sketch-card.tilt-r { transform: rotate(0.6deg); }
+
+/* Corner marks for index-card feel */
+.corner-marks::before,
+.corner-marks::after {
+  content: '';
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border: 1.5px solid rgba(26, 22, 18, 0.3);
+  pointer-events: none;
+}
+.corner-marks::before {
+  top: 6px;
+  left: 6px;
+  border-right: 0;
+  border-bottom: 0;
+}
+.corner-marks::after {
+  bottom: 6px;
+  right: 6px;
+  border-left: 0;
+  border-top: 0;
+}
+
+/* Dashed journal divider */
+.ink-dash {
+  display: block;
+  height: 1px;
+  background-image: linear-gradient(to right, currentColor 50%, transparent 50%);
+  background-size: 8px 1px;
+  opacity: 0.4;
+}
+
+/* Animations */
+@keyframes stamp-in {
+  0% { transform: scale(1.8) rotate(-8deg); opacity: 0; }
+  60% { transform: scale(0.92) rotate(-2deg); opacity: 1; }
+  100% { transform: scale(1) rotate(-1.5deg); opacity: 1; }
+}
+.anim-stamp { animation: stamp-in 420ms cubic-bezier(0.2, 1.4, 0.4, 1) both; }
+
+@keyframes stamp-in-r {
+  0% { transform: scale(1.8) rotate(8deg); opacity: 0; }
+  60% { transform: scale(0.92) rotate(2deg); opacity: 1; }
+  100% { transform: scale(1) rotate(1.5deg); opacity: 1; }
+}
+.anim-stamp-r { animation: stamp-in-r 420ms cubic-bezier(0.2, 1.4, 0.4, 1) both; }
+
+@keyframes draw {
+  from { stroke-dashoffset: 1000; }
+  to { stroke-dashoffset: 0; }
+}
+.anim-draw path,
+.anim-draw line,
+.anim-draw circle {
+  stroke-dasharray: 1000;
+  animation: draw 900ms ease-out forwards;
+}
+
+@keyframes page-in {
+  0% { transform: translateY(18px) rotate(-0.5deg); opacity: 0; }
+  100% { transform: translateY(0) rotate(0); opacity: 1; }
+}
+.anim-page { animation: page-in 360ms ease-out both; }
 
 @keyframes wag {
-  0%, 100% { transform: rotate(-3deg); }
-  50% { transform: rotate(3deg); }
+  0%, 100% { transform: rotate(-2.5deg); }
+  50% { transform: rotate(2.5deg); }
 }
-.anim-wag { animation: wag 2s ease-in-out infinite; transform-origin: 50% 100%; }
+.anim-wag { animation: wag 3.2s ease-in-out infinite; transform-origin: 50% 100%; }
 
 @keyframes confetti {
-  0% { transform: translateY(-100%) rotate(0deg); opacity: 1; }
-  100% { transform: translateY(120vh) rotate(720deg); opacity: 0; }
+  0% { transform: translateY(-20%) rotate(0deg); opacity: 1; }
+  100% { transform: translateY(120vh) rotate(540deg); opacity: 0; }
 }
-.confetti { animation: confetti 1.6s ease-in forwards; }
+.confetti { animation: confetti 1.8s ease-in forwards; }
 
-@keyframes slideUp {
-  from { transform: translateY(20px); opacity: 0; }
-  to { transform: translateY(0); opacity: 1; }
+@keyframes slow-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
-.anim-slide { animation: slideUp 280ms ease-out; }
+.anim-fade { animation: slow-fade 600ms ease-out both; }
+
+/* Number counters and display treatments */
+.display-xl {
+  font-family: 'Fraunces', 'Noto Serif Georgian', serif;
+  font-variation-settings: 'opsz' 144, 'SOFT' 20, 'wght' 400;
+  font-size: clamp(44px, 12vw, 64px);
+  line-height: 0.92;
+  letter-spacing: -0.035em;
+}
+
+.display-lg {
+  font-family: 'Fraunces', 'Noto Serif Georgian', serif;
+  font-variation-settings: 'opsz' 144, 'wght' 500;
+  font-size: clamp(30px, 8vw, 40px);
+  line-height: 1;
+  letter-spacing: -0.025em;
+}
+
+.hand-note {
+  font-family: 'Caveat', cursive;
+  font-size: 22px;
+  color: var(--wine);
+  line-height: 1.1;
+  transform: rotate(-2deg);
+  display: inline-block;
+}
+
+.eyebrow {
+  font-family: 'Fraunces', serif;
+  font-variation-settings: 'opsz' 144, 'wght' 600;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 11px;
+  color: var(--wine);
+}
+
+.serif-caption {
+  font-style: italic;
+  font-variation-settings: 'opsz' 144, 'SOFT' 100;
+  color: var(--ink-soft);
+}
+
+/* Scrollbar — nearly invisible, paper feel */
+::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+/* Focus states */
+button:focus-visible,
+a:focus-visible,
+input:focus-visible {
+  outline: 2px solid #E86B4E;
+  outline-offset: 3px;
+  border-radius: 6px;
+}
+
+/* Picture Book: page-in transition */
+@keyframes pb-in {
+  0% { opacity: 0; transform: translateY(8px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+.pb-in { animation: pb-in 420ms cubic-bezier(0.2, 0.8, 0.2, 1) both; }
+.pb-in-1 { animation-delay: 60ms; }
+.pb-in-2 { animation-delay: 120ms; }
+.pb-in-3 { animation-delay: 180ms; }
+.pb-in-4 { animation-delay: 240ms; }
+.pb-in-5 { animation-delay: 300ms; }
+
+@keyframes pb-breath {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+.pb-breath { animation: pb-breath 4s ease-in-out infinite; }
+
+/* ════════════ Minanka / jewel utilities ════════════ */
+
+/* Jewel tile: solid cream, double-layer border (ink + gold hairline), offset shadow */
+.jewel-tile {
+  background: #FDFAEF;
+  border: 1.5px solid #15100A;
+  box-shadow: 3px 3px 0 #15100A;
+  border-radius: 14px;
+  position: relative;
+}
+.jewel-tile::before {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  border: 1px solid rgba(245, 184, 32, 0.5);
+  border-radius: 11px;
+  pointer-events: none;
+}
+
+/* Pressable state */
+.jewel-pressable {
+  transition: transform 80ms ease-out, box-shadow 80ms ease-out;
+}
+.jewel-pressable:active {
+  transform: translate(3px, 3px);
+  box-shadow: 0 0 0 #15100A;
+}
+
+/* Jewel button — solid fill + ink border + offset shadow (board game piece) */
+.jewel-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 14px 20px;
+  min-height: 56px;
+  border: 1.5px solid #15100A;
+  border-radius: 12px;
+  font-family: 'Manrope', 'Noto Sans Georgian', sans-serif;
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: 0.01em;
+  box-shadow: 3px 3px 0 #15100A;
+  transition: transform 80ms ease-out, box-shadow 80ms ease-out;
+  user-select: none;
+  position: relative;
+}
+.jewel-btn::before {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  border: 1px solid rgba(245, 184, 32, 0.6);
+  border-radius: 9px;
+  pointer-events: none;
+}
+.jewel-btn:active {
+  transform: translate(3px, 3px);
+  box-shadow: 0 0 0 #15100A;
+}
+.jewel-btn:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.jewel-btn-navy {
+  background: #1B5FB0;
+  color: #FBF6EC;
+}
+.jewel-btn-ruby {
+  background: #E01A3C;
+  color: #FBF6EC;
+}
+.jewel-btn-cream {
+  background: #FDFAEF;
+  color: #15100A;
+}
+.jewel-btn-gold {
+  background: #F5B820;
+  color: #15100A;
+}
+
+/* Eyebrow text utility */
+.mn-eyebrow {
+  font-family: 'Manrope', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 11px;
+  color: #5A4735;
+}
+
+/* Display number — big Georgian letter-as-number */
+.mn-geo-numeral {
+  font-family: 'Noto Sans Georgian', 'Manrope', sans-serif;
+  font-weight: 700;
+  font-feature-settings: 'ss01';
+}
+
+/* Loader letter — Georgian character that breathes while loading.
+   The user sees this many times and subconsciously memorizes its shape,
+   which gets "revealed" later when they reach that letter in the Alphabet module. */
+@keyframes mn-breathe {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.08); opacity: 0.82; }
+}
+.mn-loader-letter {
+  font-family: 'Noto Sans Georgian', 'Manrope', sans-serif;
+  font-weight: 800;
+  animation: mn-breathe 1.6s ease-in-out infinite;
+  display: inline-block;
+  transform-origin: center;
+}
+
+/* Reveal pulse — used when "old acquaintance" stamps appear */
+@keyframes mn-reveal {
+  0% { transform: scale(0.6) rotate(-8deg); opacity: 0; }
+  65% { transform: scale(1.08) rotate(1deg); opacity: 1; }
+  100% { transform: scale(1) rotate(0); opacity: 1; }
+}
+.mn-reveal { animation: mn-reveal 520ms cubic-bezier(0.2, 1.3, 0.3, 1) both; }
+
+/* Kilim border strip — tiny geometric motif repeated horizontally as a product signature */
+.mn-kilim {
+  height: 8px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 8' preserveAspectRatio='xMidYMid meet'%3E%3Cg fill='none' stroke='%231B5FB0' stroke-width='1.2'%3E%3Cpath d='M0 4 L4 0 L8 4 L4 8 Z'/%3E%3Cpath d='M8 4 L12 0 L16 4 L12 8 Z' stroke='%23E01A3C'/%3E%3Cpath d='M16 4 L20 0 L24 4 L20 8 Z' stroke='%23F5B820'/%3E%3Cpath d='M24 4 L28 0 L32 4 L28 8 Z'/%3E%3C/g%3E%3C/svg%3E");
+  background-repeat: repeat-x;
+  background-size: 32px 8px;
+}

--- a/src/Trale/miniapp-src/src/screens/Dashboard.tsx
+++ b/src/Trale/miniapp-src/src/screens/Dashboard.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import Header from '../components/Header'
 import Mascot from '../components/Mascot'
-import Button from '../components/Button'
+import KilimProgress from '../components/KilimProgress'
 import { CatalogDto, ProgressState, Screen } from '../types'
 
 interface Props {
@@ -10,75 +9,404 @@ interface Props {
   navigate: (s: Screen) => void
 }
 
+/**
+ * Dashboard — Minanka pilot.
+ *
+ * Board game tiles + Georgian enamel palette.
+ * Learning-design: module numbers use Georgian numeral letters (ა=1, ბ=2, გ=3),
+ * module icons use meaningful Georgian letters that tie into what's taught,
+ * product signature is a tiny kilim strip at the top.
+ */
 export default function Dashboard({ catalog, progress, navigate }: Props) {
   return (
-    <div className="flex flex-col min-h-full">
-      <Header progress={progress} title="Бомбора — გამარჯობა!" />
-      <div className="flex-1 p-5 flex flex-col gap-5 anim-slide">
-        <div className="bg-white rounded-3xl shadow-card p-5 flex items-center gap-4">
-          <Mascot mood="cheer" size={110} />
-          <div className="flex-1">
-            <div className="font-extrabold text-lg leading-tight">გამარჯობა, друг!</div>
-            <div className="text-dog-muted text-sm mt-1">
-              Я Бомбора 🐶 Буду учить тебя грузинскому — лапа даю, будет весело.
-            </div>
-          </div>
-        </div>
+    <div className="flex flex-col min-h-full bg-cream">
+      {/* ══ Kilim signature strip ══ */}
+      <div style={{ paddingTop: 'var(--safe-t)' }}>
+        <div className="mn-kilim" />
+      </div>
 
-        <div className="text-dog-ink font-extrabold uppercase text-xs tracking-wider opacity-60 px-1">
-          Модули
+      {/* ══ Stats bar ══ */}
+      <div className="px-5 pt-4 pb-2 flex items-center justify-between">
+        <div className="mn-eyebrow">блокнот</div>
+        <div className="flex items-center gap-3">
+          <StatPill value={progress.streak} label="дн" color="ruby" />
+          <StatPill value={progress.xp} label="xp" color="navy" />
         </div>
+      </div>
 
-        {catalog.modules.map((m) => {
+      {/* ══ Hero — dynamic greeting + lesson of the day ══ */}
+      <section className="px-5 pt-4 pb-6 pb-in">
+        {(() => {
+          const { greeting, mascotMood, suggestion } = computeHero(catalog, progress)
+          return (
+            <>
+              <div className="flex items-end gap-3">
+                <div className="shrink-0 -mb-2">
+                  <Mascot mood={mascotMood} size={148} />
+                </div>
+                <div className="flex-1 min-w-0 pb-3">
+                  <div className="font-geo text-[14px] text-jewelInk-mid leading-none mb-2 font-semibold">
+                    {greeting.geo}
+                  </div>
+                  <h1 className="font-sans font-extrabold text-[28px] leading-[1.05] text-jewelInk tracking-tight">
+                    {greeting.line1}
+                    <br />
+                    <span className="text-ruby">{greeting.line2}</span>
+                  </h1>
+                </div>
+              </div>
+
+              {suggestion && (
+                <button
+                  onClick={() => navigate(suggestion.screen)}
+                  className="jewel-tile jewel-pressable mt-4 w-full text-left px-5 py-4 flex items-center gap-4"
+                >
+                  <div className="relative z-[1] shrink-0">
+                    <div
+                      className="w-12 h-12 rounded-xl bg-ruby border-[1.5px] border-jewelInk flex items-center justify-center"
+                      style={{ boxShadow: '2px 2px 0 #15100A' }}
+                    >
+                      <span className="font-sans text-[20px] font-extrabold text-cream leading-none">▶</span>
+                    </div>
+                  </div>
+                  <div className="flex-1 min-w-0 relative z-[1]">
+                    <div className="mn-eyebrow text-ruby mb-0.5">{suggestion.eyebrow}</div>
+                    <div className="font-sans text-[16px] font-bold text-jewelInk leading-tight truncate">
+                      {suggestion.title}
+                    </div>
+                    <div className="font-sans text-[12px] text-jewelInk-mid mt-0.5 truncate">
+                      {suggestion.subtitle}
+                    </div>
+                  </div>
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" className="shrink-0 text-ruby relative z-[1]">
+                    <path d="M8 5 L16 12 L8 19" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </button>
+              )}
+            </>
+          )
+        })()}
+      </section>
+
+      {/* ══ Module section label ══ */}
+      <div className="px-5 pt-2 pb-3 flex items-center gap-3">
+        <div className="mn-eyebrow">разделы блокнота</div>
+        <div className="flex-1 h-px bg-jewelInk/15" />
+        <div className="font-sans text-[11px] font-semibold text-jewelInk-mid tabular-nums">
+          {catalog.modules.length}
+        </div>
+      </div>
+
+      {/* ══ Module tiles — board game pieces ══ */}
+      <section className="px-5 flex flex-col gap-4 pb-6">
+        {catalog.modules.map((m, idx) => {
           const hasLessons = m.lessons.length > 0
           const done = (progress.completedLessons[m.id] ?? []).length
-          const pct = hasLessons ? Math.round((done / m.lessons.length) * 100) : 0
+          const total = m.lessons.length
+          const pct = hasLessons ? Math.round((done / total) * 100) : 0
+          const isComplete = hasLessons && done === total
+
+          // Georgian numeral letters (historical Georgian numeric system)
+          // ა=1, ბ=2, გ=3, ... alphabetic order maps to numbers
+          const geoNumerals = ['ა', 'ბ', 'გ', 'დ', 'ე', 'ვ', 'ზ', 'ჱ', 'თ']
+          const geoNum = geoNumerals[idx] ?? '?'
+
+          // Module icons = Georgian letters that tie into what's taught
+          // Alphabet → ა (first letter), Verbs → ზ (ზმნა "verb"), Vocabulary → ლ (ლექსიკონი)
+          const moduleIcon =
+            m.id === 'alphabet'
+              ? 'ა'
+              : m.id === 'verbs-of-movement'
+              ? 'ზ'
+              : m.id === 'my-vocabulary'
+              ? 'ლ'
+              : '?'
+
+          const moduleGeo =
+            m.id === 'alphabet'
+              ? 'ანბანი'
+              : m.id === 'verbs-of-movement'
+              ? 'ზმნები'
+              : m.id === 'my-vocabulary'
+              ? 'ლექსიკონი'
+              : ''
+
+          // Each module gets one signature color from the jewel palette
+          const accent =
+            idx === 0 ? 'navy' : idx === 1 ? 'ruby' : 'gold'
+          const accentBg =
+            accent === 'navy' ? 'bg-navy' : accent === 'ruby' ? 'bg-ruby' : 'bg-gold'
+          const accentText =
+            accent === 'navy'
+              ? 'text-navy'
+              : accent === 'ruby'
+              ? 'text-ruby'
+              : 'text-gold-deep'
+
           return (
             <button
               key={m.id}
-              onClick={() =>
-                m.id === 'my-vocabulary'
-                  ? navigate({ kind: 'vocabulary-list' })
-                  : navigate({ kind: 'module', moduleId: m.id })
-              }
-              className="text-left bg-white rounded-3xl shadow-card p-4 active:translate-y-1 transition"
+              onClick={() => {
+                if (m.id === 'my-vocabulary') navigate({ kind: 'vocabulary-list' })
+                else navigate({ kind: 'module', moduleId: m.id })
+              }}
+              className="jewel-tile jewel-pressable text-left px-5 py-5 pb-in"
+              style={{ animationDelay: `${120 + idx * 70}ms` }}
             >
-              <div className="flex items-center gap-3">
-                <div className="w-14 h-14 rounded-2xl bg-dog-accent/15 flex items-center justify-center text-3xl">
-                  {m.emoji}
+              <div className="flex items-start gap-4 relative z-[1]">
+                {/* Georgian letter icon in colored medallion */}
+                <div className="shrink-0 relative">
+                  <div
+                    className={`w-14 h-14 rounded-xl ${accentBg} border-[1.5px] border-jewelInk flex items-center justify-center`}
+                    style={{ boxShadow: '2px 2px 0 #15100A' }}
+                  >
+                    <span className="font-geo text-[28px] font-extrabold text-cream leading-none">
+                      {moduleIcon}
+                    </span>
+                  </div>
+                  {/* Georgian numeral badge */}
+                  <div className="absolute -top-1.5 -right-1.5 w-6 h-6 rounded-full bg-cream border-[1.5px] border-jewelInk flex items-center justify-center">
+                    <span
+                      className={`font-geo text-[11px] font-bold ${accentText} leading-none`}
+                    >
+                      {geoNum}
+                    </span>
+                  </div>
                 </div>
-                <div className="flex-1 min-w-0">
-                  <div className="font-extrabold text-base">{m.title}</div>
-                  <div className="text-dog-muted text-sm truncate">{m.description}</div>
+
+                {/* Body */}
+                <div className="flex-1 min-w-0 pt-1">
+                  <div className="font-geo text-[11px] text-jewelInk-mid font-semibold uppercase tracking-wide">
+                    {moduleGeo}
+                  </div>
+                  <h2 className="font-sans text-[20px] font-extrabold text-jewelInk leading-tight mt-0.5 tracking-tight">
+                    {m.title}
+                  </h2>
+                  <p className="font-sans text-[13px] text-jewelInk-mid mt-1.5 leading-snug line-clamp-2">
+                    {m.description}
+                  </p>
                 </div>
               </div>
+
+              {/* Footer row: kilim zigzag progress or status */}
               {hasLessons ? (
-                <>
-                  <div className="mt-3 h-2 rounded-full bg-dog-line overflow-hidden">
-                    <div
-                      className="h-full bg-dog-green rounded-full transition-all"
-                      style={{ width: `${pct}%` }}
-                    />
+                <div className="mt-4 relative z-[1]">
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="mn-eyebrow">
+                      {isComplete ? (
+                        <span className="text-gold-deep">пройдено</span>
+                      ) : (
+                        'маршрут'
+                      )}
+                    </span>
+                    <span className="font-sans text-[11px] font-bold text-jewelInk tabular-nums">
+                      <span className={accentText}>{done}</span>
+                      <span className="text-jewelInk-hint"> / {total}</span>
+                    </span>
                   </div>
-                  <div className="text-xs text-dog-muted mt-1.5 font-bold">
-                    {done} / {m.lessons.length} · {pct}%
-                  </div>
-                </>
+                  <KilimProgress done={done} total={total} accent={accent} />
+                </div>
               ) : (
-                <div className="text-xs text-dog-muted mt-2 font-bold">
-                  Твои слова · квизы на выбор
+                <div className="mt-3 relative z-[1]">
+                  <span className="mn-eyebrow text-jewelInk-mid">
+                    твои слова · квизы на выбор
+                  </span>
                 </div>
               )}
             </button>
           )
         })}
+      </section>
 
-        <div className="pt-2">
-          <Button variant="ghost" onClick={() => navigate({ kind: 'profile' })}>
-            🐾 Мой профиль
-          </Button>
-        </div>
+      {/* ══ Profile button — smaller tile ══ */}
+      <div className="px-5 pb-6">
+        <button
+          onClick={() => navigate({ kind: 'profile' })}
+          className="jewel-tile jewel-pressable w-full text-left px-5 py-4 flex items-center justify-between"
+        >
+          <div className="flex items-center gap-3 relative z-[1]">
+            <div className="w-10 h-10 rounded-lg bg-cream-deep border-[1.5px] border-jewelInk flex items-center justify-center">
+              <span className="font-geo text-[18px] font-extrabold text-navy leading-none">
+                მ
+              </span>
+            </div>
+            <div>
+              <div className="mn-eyebrow">вкладка</div>
+              <div className="font-sans text-[16px] font-bold text-jewelInk leading-none mt-0.5">
+                мой профиль
+              </div>
+            </div>
+          </div>
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" className="text-navy relative z-[1]">
+            <path
+              d="M8 5 L16 12 L8 19"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
       </div>
+
+      {/* ══ Bottom kilim strip — symmetry with top ══ */}
+      <div className="mt-auto">
+        <div className="mn-kilim opacity-70" />
+      </div>
+
+      <div style={{ height: 'calc(var(--safe-b) + 12px)' }} />
+    </div>
+  )
+}
+
+/**
+ * Compute dynamic hero: greeting, mascot mood, and a "lesson of the day" suggestion.
+ */
+function computeHero(
+  catalog: CatalogDto,
+  progress: ProgressState
+): {
+  greeting: { geo: string; line1: string; line2: string }
+  mascotMood: 'happy' | 'cheer' | 'think' | 'guide'
+  suggestion: {
+    eyebrow: string
+    title: string
+    subtitle: string
+    screen: Screen
+  } | null
+} {
+  const totalDone = Object.values(progress.completedLessons).reduce(
+    (s, arr) => s + arr.length,
+    0
+  )
+  const totalAvailable = catalog.modules.reduce(
+    (s, m) => s + m.lessons.length,
+    0
+  )
+  const allDone = totalDone >= totalAvailable && totalAvailable > 0
+
+  // Find next incomplete lesson across modules (in order)
+  let nextModule: typeof catalog.modules[0] | null = null
+  let nextLesson: { id: number; title: string; short: string } | null = null
+  for (const m of catalog.modules) {
+    if (m.lessons.length === 0) continue
+    const done = new Set(progress.completedLessons[m.id] ?? [])
+    const incomplete = m.lessons.find((l) => !done.has(l.id))
+    if (incomplete) {
+      nextModule = m
+      nextLesson = incomplete
+      break
+    }
+  }
+
+  // Days since last played
+  const daysSincePlayed = progress.lastPlayedDate
+    ? Math.floor(
+        (Date.now() - new Date(progress.lastPlayedDate).getTime()) /
+          (1000 * 60 * 60 * 24)
+      )
+    : -1
+
+  // Dynamic greeting
+  let greeting: { geo: string; line1: string; line2: string }
+  let mascotMood: 'happy' | 'cheer' | 'think' | 'guide'
+
+  if (totalDone === 0) {
+    greeting = {
+      geo: 'გამარჯობა!',
+      line1: 'Привет!',
+      line2: 'Давай начнём'
+    }
+    mascotMood = 'cheer'
+  } else if (allDone) {
+    greeting = {
+      geo: 'ყოჩაღ!',
+      line1: 'Все уроки пройдены!',
+      line2: 'Повторяем и растём'
+    }
+    mascotMood = 'cheer'
+  } else if (daysSincePlayed > 2) {
+    greeting = {
+      geo: 'მოგესალმებით!',
+      line1: 'Давно не виделись!',
+      line2: 'Давай продолжим'
+    }
+    mascotMood = 'think'
+  } else if (daysSincePlayed === 1) {
+    greeting = {
+      geo: 'მოგესალმებით!',
+      line1: 'Вчера было хорошо',
+      line2: 'Сегодня ещё лучше'
+    }
+    mascotMood = 'happy'
+  } else if (progress.streak >= 3) {
+    greeting = {
+      geo: 'შესანიშნავია!',
+      line1: `${progress.streak} дней подряд!`,
+      line2: 'Так держать'
+    }
+    mascotMood = 'cheer'
+  } else {
+    greeting = {
+      geo: 'გამარჯობა!',
+      line1: 'Хорошо идёшь',
+      line2: 'Продолжаем'
+    }
+    mascotMood = 'happy'
+  }
+
+  // Suggestion
+  let suggestion: {
+    eyebrow: string
+    title: string
+    subtitle: string
+    screen: Screen
+  } | null = null
+
+  if (nextModule && nextLesson) {
+    suggestion = {
+      eyebrow: 'урок дня',
+      title: nextLesson.title,
+      subtitle: `${nextModule.title} · урок ${nextLesson.id}`,
+      screen: {
+        kind: 'lesson-theory',
+        moduleId: nextModule.id,
+        lessonId: nextLesson.id
+      }
+    }
+  } else if (allDone) {
+    suggestion = {
+      eyebrow: 'повторение',
+      title: 'Прокачай словарь',
+      subtitle: 'Квиз по твоим словам',
+      screen: { kind: 'vocabulary-list' }
+    }
+  }
+
+  return { greeting, mascotMood, suggestion }
+}
+
+function StatPill({
+  value,
+  label,
+  color
+}: {
+  value: number
+  label: string
+  color: 'navy' | 'ruby'
+}) {
+  const colorClass = color === 'navy' ? 'bg-navy' : 'bg-ruby'
+  return (
+    <div
+      className={`${colorClass} text-cream border-[1.5px] border-jewelInk rounded-full px-3 py-1 flex items-baseline gap-1.5`}
+      style={{ boxShadow: '2px 2px 0 #15100A' }}
+    >
+      <span className="font-sans text-[15px] font-extrabold tabular-nums leading-none">
+        {value}
+      </span>
+      <span className="font-sans text-[10px] font-bold uppercase tracking-wider opacity-90">
+        {label}
+      </span>
     </div>
   )
 }

--- a/src/Trale/miniapp-src/src/screens/LandingScreen.tsx
+++ b/src/Trale/miniapp-src/src/screens/LandingScreen.tsx
@@ -6,93 +6,172 @@ interface Props {
 }
 
 /**
- * Public landing page for TraleBot Kutya.
- * Shown when the site is opened outside of Telegram (no initData).
+ * Public landing page — rendered when the SPA is opened outside of Telegram.
+ * Same Minanka system as the app, with a marketing tone.
  */
 export default function LandingScreen({ botUsername }: Props) {
-  const tgLink = botUsername
-    ? `https://t.me/${botUsername}`
-    : 'https://t.me/traletest_bot'
+  const tgLink = `https://t.me/${botUsername ?? 'trale_bot'}`
 
   return (
-    <div className="flex flex-col min-h-full anim-slide">
-      {/* Hero */}
-      <div
-        className="px-6 flex flex-col items-center text-center"
-        style={{
-          paddingTop: 'calc(var(--safe-t) + 48px)',
-          paddingBottom: 36
-        }}
-      >
-        <Mascot mood="cheer" size={180} />
-        <h1 className="mt-4 text-4xl font-black leading-tight text-dog-ink">
-          Бомбора
+    <div className="flex flex-col min-h-full bg-cream">
+      {/* Kilim top strip */}
+      <div style={{ paddingTop: 'var(--safe-t)' }}>
+        <div className="mn-kilim" />
+      </div>
+
+      {/* ══ Hero ══ */}
+      <section className="px-6 pt-10 pb-8 text-center">
+        <div className="mn-eyebrow text-navy mb-3">ბომბორა · bombora</div>
+
+        <h1 className="font-sans text-[44px] font-extrabold text-jewelInk leading-[0.95] tracking-tight">
+          Блокнот для
+          <br />
+          <span className="text-ruby">грузинского</span>
         </h1>
-        <div className="mt-1 text-dog-muted font-extrabold uppercase tracking-wider text-xs">
-          Учит грузинский
+
+        <div className="mt-8 flex justify-center">
+          <Mascot mood="cheer" size={190} />
         </div>
-        <p className="mt-5 text-[15px] leading-relaxed text-dog-ink/80 max-w-[340px]">
-          Маленький щенок-репетитор, который проведёт тебя от первой буквы
-          <span className="whitespace-nowrap"> ქართული </span>
-          до живого разговора. Без стрессов, без сердечек, без платных воскрешений.
+
+        <p className="mt-5 font-sans text-[15px] text-jewelInk-soft leading-snug max-w-[340px] mx-auto">
+          Маленький щенок-гид проведёт тебя от первой буквы{' '}
+          <span className="font-geo font-bold text-jewelInk">ქართული</span> до
+          живого разговора в тбилисском дворе.
         </p>
-      </div>
+      </section>
 
-      {/* Feature cards */}
-      <div className="px-5 flex flex-col gap-3">
-        <Feature
-          emoji="🔤"
-          title="Алфавит по урокам"
-          text="33 буквы, разбитые на 7 коротких уроков. Теория с примерами и практика на распознавание."
+      {/* ══ Feature tiles ══ */}
+      <section className="px-5 flex flex-col gap-4 pb-8">
+        <div className="mn-eyebrow text-center">что внутри</div>
+
+        <FeatureTile
+          num="ა"
+          numLabel="1"
+          accent="navy"
+          geo="ანბანი"
+          title="Алфавит"
+          body="33 буквы, разложенные по семи страницам. Теория и практика на узнавание."
         />
-        <Feature
-          emoji="🚶"
-          title="Грамматика — глаголы движения"
-          text="11 уроков про направления, времена и спряжения. Самый капризный кусок грузинского — шаг за шагом."
+        <FeatureTile
+          num="ბ"
+          numLabel="2"
+          accent="ruby"
+          geo="ზმნები"
+          title="Глаголы движения"
+          body="Одиннадцать уроков про направления, времена и приставки — капризный кусок языка, разобранный шаг за шагом."
         />
-        <Feature
-          emoji="📘"
-          title="Мой словарь"
-          text="Слова, которые ты переводил через бота, прогоняются в квизах. Продуктивное направление: видишь русское — вспоминаешь грузинское."
+        <FeatureTile
+          num="გ"
+          numLabel="3"
+          accent="gold"
+          geo="ლექსიკონი"
+          title="Твой словарь"
+          body="Слова, которые ты переводил через бота, приходят на экран как персональная колода."
         />
-        <Feature
-          emoji="🐾"
+        <FeatureTile
+          num="დ"
+          numLabel="4"
+          accent="navy"
+          geo="თავისუფლად"
           title="По твоему темпу"
-          text="Никакой потери жизней, никаких напоминаний-угроз. Купил — учишь. Знаешь алфавит — пропускаешь и идёшь сразу к словам."
+          body="Никаких потерянных жизней и напоминаний-угроз. Купил — учишь. Знаешь алфавит — пропускаешь."
         />
-      </div>
+      </section>
 
-      {/* CTA */}
-      <div
-        className="px-6 mt-8 flex flex-col items-center gap-3 text-center"
-        style={{ paddingBottom: 'calc(var(--safe-b) + 40px)' }}
+      {/* ══ Philosophy ══ */}
+      <section className="px-6 mb-10">
+        <div className="jewel-tile px-5 py-6 text-center">
+          <div className="relative z-[1]">
+            <div className="mn-eyebrow mb-3">философия</div>
+            <p className="font-sans text-[16px] text-jewelInk leading-[1.5]">
+              Блокнот путешественника, в который Бомбора складывает страницы
+              по одной. Ни стыда, ни штрафов. Только буквы, слова и тёплый
+              тбилисский двор.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ══ CTA ══ */}
+      <section
+        className="px-6 text-center flex flex-col items-center gap-4"
+        style={{ paddingBottom: 'calc(var(--safe-b) + 48px)' }}
       >
+        <div className="mn-eyebrow">начать путь</div>
+
         <a
           href={tgLink}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-2.5 px-8 py-4 rounded-2xl bg-dog-accent text-white font-extrabold uppercase tracking-wide shadow-btn active:translate-y-1 transition text-base"
+          className="jewel-btn bg-navy text-cream w-full max-w-[320px]"
         >
           <TgIcon />
-          Открыть в Telegram
+          <span className="relative z-[1]">открыть в telegram</span>
         </a>
-        <div className="text-dog-muted text-xs font-bold mt-1">
-          Мини-аб работает внутри Telegram-бота
+
+        <div className="font-sans text-[12px] text-jewelInk-mid mt-1 max-w-[300px] leading-snug">
+          Блокнот работает внутри телеграм-бота.
+          <br />
+          Поставь · листай · повторяй.
         </div>
-      </div>
+
+        <div className="mt-8 font-sans text-[10px] font-bold text-jewelInk-hint uppercase tracking-widest">
+          ბომბორა · 2026
+        </div>
+      </section>
+
+      <div className="mn-kilim opacity-70" />
+      <div style={{ height: 'var(--safe-b)' }} />
     </div>
   )
 }
 
-function Feature({ emoji, title, text }: { emoji: string; title: string; text: string }) {
+function FeatureTile({
+  num,
+  numLabel,
+  accent,
+  geo,
+  title,
+  body
+}: {
+  num: string
+  numLabel: string
+  accent: 'navy' | 'ruby' | 'gold'
+  geo: string
+  title: string
+  body: string
+}) {
+  const accentBg =
+    accent === 'navy' ? 'bg-navy' : accent === 'ruby' ? 'bg-ruby' : 'bg-gold'
+  const numColor = accent === 'gold' ? 'text-jewelInk' : 'text-cream'
+
   return (
-    <div className="bg-white rounded-3xl shadow-card p-4 flex gap-3">
-      <div className="w-12 h-12 rounded-2xl bg-dog-accent/15 flex items-center justify-center text-2xl shrink-0">
-        {emoji}
+    <div className="jewel-tile px-5 py-4 flex items-start gap-4">
+      <div className="shrink-0 relative z-[1]">
+        <div
+          className={`w-14 h-14 rounded-xl ${accentBg} border-[1.5px] border-jewelInk flex items-center justify-center`}
+          style={{ boxShadow: '2px 2px 0 #15100A' }}
+        >
+          <span className={`font-geo text-[28px] font-extrabold leading-none ${numColor}`}>
+            {num}
+          </span>
+        </div>
+        <div className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-cream border-[1.5px] border-jewelInk flex items-center justify-center">
+          <span className="font-sans text-[9px] font-extrabold text-jewelInk leading-none tabular-nums">
+            {numLabel}
+          </span>
+        </div>
       </div>
-      <div className="flex-1 min-w-0">
-        <div className="font-extrabold text-dog-ink">{title}</div>
-        <div className="text-dog-muted text-sm mt-0.5 leading-snug">{text}</div>
+      <div className="flex-1 min-w-0 relative z-[1] pt-1">
+        <div className="font-geo text-[11px] text-jewelInk-mid font-semibold uppercase tracking-wide">
+          {geo}
+        </div>
+        <h3 className="font-sans text-[18px] font-extrabold text-jewelInk leading-tight mt-0.5">
+          {title}
+        </h3>
+        <p className="font-sans text-[13px] text-jewelInk-soft mt-1 leading-snug">
+          {body}
+        </p>
       </div>
     </div>
   )
@@ -100,7 +179,13 @@ function Feature({ emoji, title, text }: { emoji: string; title: string; text: s
 
 function TgIcon() {
   return (
-    <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className="relative z-[1] shrink-0"
+    >
       <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4.64 6.8c-.15 1.58-.8 5.42-1.13 7.19-.14.75-.42 1-.68 1.03-.58.05-1.02-.38-1.58-.75-.88-.58-1.38-.94-2.23-1.5-.99-.65-.35-1.01.22-1.59.15-.15 2.71-2.48 2.76-2.69a.2.2 0 00-.05-.18c-.06-.05-.14-.03-.21-.02-.09.02-1.49.95-4.22 2.79-.4.27-.76.41-1.08.4-.36-.01-1.04-.2-1.55-.37-.63-.2-1.12-.31-1.08-.66.02-.18.27-.36.74-.55 2.92-1.27 4.86-2.11 5.83-2.51 2.78-1.16 3.35-1.36 3.73-1.36.08 0 .27.02.39.12.1.08.13.19.14.27-.01.06.01.24 0 .38z" />
     </svg>
   )

--- a/src/Trale/miniapp-src/src/screens/LessonTheory.tsx
+++ b/src/Trale/miniapp-src/src/screens/LessonTheory.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import Header from '../components/Header'
-import Mascot from '../components/Mascot'
 import Button from '../components/Button'
 import { CatalogDto, ProgressState, Screen, TheoryBlockDto } from '../types'
 
@@ -12,19 +11,25 @@ interface Props {
   navigate: (s: Screen) => void
 }
 
-export default function LessonTheory({ catalog, moduleId, lessonId, progress, navigate }: Props) {
+export default function LessonTheory({
+  catalog,
+  moduleId,
+  lessonId,
+  progress,
+  navigate
+}: Props) {
   const module = catalog.modules.find((m) => m.id === moduleId)
   const lesson = module?.lessons.find((l) => l.id === lessonId)
 
   if (!module || !lesson) {
     return (
-      <div className="flex flex-col min-h-full">
+      <div className="flex flex-col min-h-full bg-cream">
         <Header
           progress={progress}
           onBack={() => navigate({ kind: 'module', moduleId })}
           title={`Урок ${lessonId}`}
         />
-        <div className="p-5 text-dog-muted">Урок не найден.</div>
+        <div className="p-5 text-jewelInk-mid">Урок не найден.</div>
       </div>
     )
   }
@@ -32,42 +37,54 @@ export default function LessonTheory({ catalog, moduleId, lessonId, progress, na
   const theory = lesson.theory
 
   return (
-    <div className="flex flex-col min-h-full">
+    <div className="flex flex-col min-h-full bg-cream">
       <Header
         progress={progress}
         onBack={() => navigate({ kind: 'module', moduleId })}
-        title={`Урок ${lessonId}`}
+        eyebrow={`урок ${lessonId} из ${module.lessons.length}`}
+        title={module.title}
       />
-      <div className="flex-1 p-5 pb-32 anim-slide">
-        <div className="bg-white rounded-3xl shadow-card p-5">
-          <div className="flex items-start gap-3">
-            <Mascot mood="think" size={80} />
-            <div className="flex-1">
-              <div className="text-dog-muted uppercase text-xs font-extrabold tracking-wider">
-                Урок {lessonId}
-              </div>
-              <div className="font-extrabold text-lg leading-tight mt-0.5">{theory.title}</div>
-              <div className="text-dog-muted text-sm mt-2">🎯 {theory.goal}</div>
+
+      <article
+        className="flex-1 px-5 pt-6 pb-in"
+        style={{ paddingBottom: 'calc(var(--safe-b) + 110px)' }}
+      >
+        {/* Title card */}
+        <div className="jewel-tile px-5 py-5 mb-5">
+          <div className="relative z-[1]">
+            <div className="mn-eyebrow mb-2">
+              урок № <span className="font-bold tabular-nums">{lessonId}</span>
+            </div>
+            <h1 className="font-sans text-[26px] font-extrabold text-jewelInk leading-tight">
+              {theory.title}
+            </h1>
+            <div className="mt-3 pt-3 border-t border-jewelInk/10">
+              <div className="mn-eyebrow mb-1">цель</div>
+              <p className="font-sans text-[14px] text-jewelInk-soft leading-snug">
+                {theory.goal}
+              </p>
             </div>
           </div>
-
-          <div className="mt-5 flex flex-col gap-3">
-            {theory.blocks.map((b, i) => (
-              <TheoryBlock key={i} block={b} />
-            ))}
-          </div>
         </div>
-      </div>
 
+        {/* Theory blocks */}
+        <div className="flex flex-col gap-4">
+          {theory.blocks.map((b, i) => (
+            <TheoryBlock key={i} block={b} />
+          ))}
+        </div>
+      </article>
+
+      {/* Action bar */}
       <div
-        className="fixed bottom-0 left-0 right-0 max-w-[480px] mx-auto px-4 pt-4 bg-dog-bg/95 backdrop-blur border-t border-dog-line"
+        className="fixed bottom-0 left-0 right-0 max-w-[480px] mx-auto px-5 pt-4 bg-cream/95 backdrop-blur-sm border-t border-jewelInk/15 z-20"
         style={{ paddingBottom: 'calc(var(--safe-b) + 16px)' }}
       >
         <Button
-          variant="green"
+          variant="primary"
           onClick={() => navigate({ kind: 'practice', moduleId, lessonId })}
         >
-          ▶ Начать практику
+          к практике →
         </Button>
       </div>
     </div>
@@ -76,47 +93,97 @@ export default function LessonTheory({ catalog, moduleId, lessonId, progress, na
 
 function TheoryBlock({ block }: { block: TheoryBlockDto }) {
   if (block.type === 'paragraph') {
-    return <p className="text-dog-ink leading-relaxed text-[15px]">{block.text}</p>
+    return (
+      <div className="px-2">
+        <p className="font-sans text-[15px] text-jewelInk leading-[1.6]">
+          {block.text}
+        </p>
+      </div>
+    )
   }
+
   if (block.type === 'list' && block.items) {
     return (
-      <ul className="flex flex-col gap-2">
-        {block.items.map((item, j) => (
-          <li key={j} className="bg-dog-accent/10 rounded-xl px-3 py-2 text-[15px] font-semibold">
-            {item}
-          </li>
-        ))}
-      </ul>
+      <div className="jewel-tile px-4 py-4">
+        <div className="relative z-[1]">
+          <div className="mn-eyebrow mb-2.5">запомним</div>
+          <ul className="flex flex-col gap-2">
+            {block.items.map((item, j) => (
+              <li key={j} className="flex items-start gap-3">
+                <span className="shrink-0 w-6 h-6 rounded-md bg-navy text-cream font-sans text-[11px] font-bold flex items-center justify-center tabular-nums mt-0.5">
+                  {j + 1}
+                </span>
+                <span className="flex-1 font-sans text-[14px] text-jewelInk leading-[1.5]">
+                  {item}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
     )
   }
+
   if (block.type === 'example') {
     return (
-      <div className="rounded-xl border-2 border-dog-line p-3 flex flex-col gap-1">
-        <div className="font-extrabold text-dog-ink">{block.ge}</div>
-        <div className="text-dog-muted text-sm">— {block.ru}</div>
-      </div>
-    )
-  }
-  if (block.type === 'letters' && block.letters) {
-    return (
-      <div className="grid grid-cols-2 gap-3">
-        {block.letters.map((l) => (
-          <div
-            key={l.letter}
-            className="rounded-2xl border-2 border-dog-line p-3 flex flex-col items-center gap-1 bg-dog-bg/40"
-          >
-            <div className="text-5xl font-black text-dog-ink">{l.letter}</div>
-            <div className="text-xs text-dog-muted font-bold">
-              {l.name} · «{l.translit}»
-            </div>
-            <div className="mt-1 text-center">
-              <div className="font-extrabold text-dog-ink">{l.exampleGe}</div>
-              <div className="text-xs text-dog-muted">{l.exampleRu}</div>
+      <div className="jewel-tile px-4 py-4 relative">
+        <div
+          className="absolute -top-2 left-4 bg-cream px-2 py-0.5 border-[1.5px] border-jewelInk rounded-md"
+          style={{ boxShadow: '1px 1px 0 #15100A' }}
+        >
+          <span className="font-sans text-[9px] font-extrabold uppercase tracking-wider text-ruby">
+            пример
+          </span>
+        </div>
+        <div className="relative z-[1] pt-2">
+          <div className="font-geo text-[22px] font-bold text-jewelInk leading-tight">
+            {block.ge}
+          </div>
+          <div className="flex items-center gap-2 mt-2">
+            <div className="w-4 h-px bg-jewelInk/30" />
+            <div className="font-sans text-[13px] text-jewelInk-soft">
+              {block.ru}
             </div>
           </div>
-        ))}
+        </div>
       </div>
     )
   }
+
+  if (block.type === 'letters' && block.letters) {
+    return (
+      <div>
+        <div className="mn-eyebrow mb-3 px-2">карточки букв</div>
+        <div className="grid grid-cols-2 gap-3">
+          {block.letters.map((l) => (
+            <div key={l.letter} className="jewel-tile p-4 flex flex-col items-center">
+              <div className="relative z-[1] flex flex-col items-center w-full">
+                <div className="font-geo text-[52px] font-extrabold text-navy leading-none">
+                  {l.letter}
+                </div>
+                <div className="mt-1 px-2 py-0.5 bg-ruby text-cream rounded-md">
+                  <span className="font-sans text-[10px] font-bold uppercase tracking-wider">
+                    {l.translit}
+                  </span>
+                </div>
+                <div className="mt-1 font-sans text-[10px] text-jewelInk-mid uppercase tracking-wide">
+                  {l.name}
+                </div>
+                <div className="mt-3 w-full pt-3 border-t border-dashed border-jewelInk/20 text-center">
+                  <div className="font-geo text-[14px] font-bold text-jewelInk leading-tight">
+                    {l.exampleGe}
+                  </div>
+                  <div className="font-sans text-[11px] text-jewelInk-mid mt-0.5">
+                    {l.exampleRu}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
   return null
 }

--- a/src/Trale/miniapp-src/src/screens/ModuleMap.tsx
+++ b/src/Trale/miniapp-src/src/screens/ModuleMap.tsx
@@ -39,18 +39,55 @@ export default function ModuleMap({ catalog, moduleId, progress, navigate }: Pro
           </div>
         </div>
 
-        <div className="relative flex flex-col items-center gap-4">
+        <div className="relative flex flex-col items-center">
+          {/* Dotted path connectors between lesson circles */}
+          {lessons.slice(0, -1).map((_, idx) => {
+            const prevDone = completed.has(lessons[idx].id)
+            const nextDone = completed.has(lessons[idx + 1].id)
+            const pathDone = prevDone && nextDone
+            const goesRight = idx % 2 === 0 // even→odd = left to right
+            return (
+              <div
+                key={`path-${idx}`}
+                className="absolute pointer-events-none"
+                style={{
+                  top: idx * 140 + 40,
+                  left: '50%',
+                  width: 96,
+                  height: 140,
+                  marginLeft: goesRight ? -48 : -48,
+                  zIndex: 0,
+                }}
+              >
+                <svg width="96" height="140" viewBox="0 0 96 140" fill="none">
+                  <path
+                    d={goesRight ? 'M 0 0 C 0 70, 96 70, 96 140' : 'M 96 0 C 96 70, 0 70, 0 140'}
+                    stroke={pathDone ? '#58CC02' : '#E5D5B0'}
+                    strokeWidth="3"
+                    strokeDasharray="8 8"
+                    strokeLinecap="round"
+                    fill="none"
+                  />
+                </svg>
+              </div>
+            )
+          })}
+
           {lessons.map((lesson, idx) => {
             const isDone = completed.has(lesson.id)
             const isCurrent = lesson.id === firstIncomplete
             const offset = idx % 2 === 0 ? '-translate-x-12' : 'translate-x-12'
             return (
-              <div key={lesson.id} className={`w-full flex justify-center ${offset}`}>
+              <div
+                key={lesson.id}
+                className={`relative w-full flex justify-center ${offset}`}
+                style={{ zIndex: 1, minHeight: 140 }}
+              >
                 <button
                   onClick={() =>
                     navigate({ kind: 'lesson-theory', moduleId, lessonId: lesson.id })
                   }
-                  className="group relative flex flex-col items-center"
+                  className="group relative flex flex-col items-center pt-2"
                 >
                   <div
                     className={`w-20 h-20 rounded-full flex items-center justify-center font-extrabold text-2xl shadow-card border-4 transition active:translate-y-1

--- a/src/Trale/miniapp-src/src/screens/ModuleMap.tsx
+++ b/src/Trale/miniapp-src/src/screens/ModuleMap.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Header from '../components/Header'
-import Mascot from '../components/Mascot'
+import KilimProgress from '../components/KilimProgress'
 import { CatalogDto, ProgressState, Screen } from '../types'
 
 interface Props {
@@ -10,105 +10,183 @@ interface Props {
   navigate: (s: Screen) => void
 }
 
-export default function ModuleMap({ catalog, moduleId, progress, navigate }: Props) {
+export default function ModuleMap({
+  catalog,
+  moduleId,
+  progress,
+  navigate
+}: Props) {
   const module = catalog.modules.find((m) => m.id === moduleId)
   if (!module) {
     return (
-      <div className="flex flex-col min-h-full">
-        <Header progress={progress} onBack={() => navigate({ kind: 'dashboard' })} title="Модуль" />
-        <div className="p-5 text-dog-muted">Модуль не найден.</div>
+      <div className="flex flex-col min-h-full bg-cream">
+        <Header
+          progress={progress}
+          onBack={() => navigate({ kind: 'dashboard' })}
+          title="Раздел"
+        />
+        <div className="px-5 pt-6 font-sans text-jewelInk-mid">
+          Раздел не найден.
+        </div>
       </div>
     )
   }
 
   const lessons = module.lessons
   const completed = new Set(progress.completedLessons[moduleId] ?? [])
+  const done = completed.size
   const firstIncomplete = lessons.find((l) => !completed.has(l.id))?.id ?? -1
 
+  const geoLabel =
+    module.id === 'alphabet'
+      ? 'ანბანი'
+      : module.id === 'verbs-of-movement'
+      ? 'ზმნები'
+      : module.title
+
+  const accent: 'navy' | 'ruby' | 'gold' =
+    module.id === 'alphabet' ? 'navy' : module.id === 'verbs-of-movement' ? 'ruby' : 'gold'
+
+  const accentBg =
+    accent === 'navy' ? 'bg-navy' : accent === 'ruby' ? 'bg-ruby' : 'bg-gold'
+  const accentText =
+    accent === 'navy'
+      ? 'text-navy'
+      : accent === 'ruby'
+      ? 'text-ruby'
+      : 'text-gold-deep'
+
   return (
-    <div className="flex flex-col min-h-full">
-      <Header progress={progress} onBack={() => navigate({ kind: 'dashboard' })} title={module.title} />
-      <div className="flex-1 p-5 pb-12 anim-slide">
-        <div className="bg-white rounded-3xl shadow-card p-4 mb-5 flex items-center gap-3">
-          <Mascot mood="think" size={80} />
-          <div className="flex-1">
-            <div className="font-extrabold">
-              {module.title} {module.emoji}
+    <div className="flex flex-col min-h-full bg-cream">
+      <Header
+        progress={progress}
+        onBack={() => navigate({ kind: 'dashboard' })}
+        eyebrow={geoLabel}
+        title={module.title}
+      />
+
+      <div
+        className="flex-1 px-5 pt-6 pb-in"
+        style={{ paddingBottom: 'calc(var(--safe-b) + 40px)' }}
+      >
+        {/* Overview card */}
+        <div className="jewel-tile px-5 py-4 mb-6">
+          <div className="flex items-center justify-between gap-3 relative z-[1]">
+            <div className="flex-1 min-w-0">
+              <div className="mn-eyebrow mb-1">глава</div>
+              <div className="font-sans text-[22px] font-extrabold text-jewelInk leading-tight truncate">
+                {module.title}
+              </div>
+              <div className="mt-1 font-sans text-[13px] text-jewelInk-mid leading-snug">
+                {module.description}
+              </div>
             </div>
-            <div className="text-dog-muted text-sm">{module.description}</div>
+          </div>
+
+          <div className="mt-4 relative z-[1]">
+            <div className="flex items-center justify-between mb-2">
+              <span className="mn-eyebrow">маршрут</span>
+              <span className="font-sans text-[11px] font-bold tabular-nums">
+                <span className={accentText}>{done}</span>
+                <span className="text-jewelInk-hint"> / {lessons.length}</span>
+              </span>
+            </div>
+            <KilimProgress done={done} total={lessons.length} accent={accent} />
           </div>
         </div>
 
-        <div className="relative flex flex-col items-center">
-          {/* Dotted path connectors between lesson circles */}
-          {lessons.slice(0, -1).map((_, idx) => {
-            const prevDone = completed.has(lessons[idx].id)
-            const nextDone = completed.has(lessons[idx + 1].id)
-            const pathDone = prevDone && nextDone
-            const goesRight = idx % 2 === 0 // even→odd = left to right
-            return (
-              <div
-                key={`path-${idx}`}
-                className="absolute pointer-events-none"
-                style={{
-                  top: idx * 140 + 40,
-                  left: '50%',
-                  width: 96,
-                  height: 140,
-                  marginLeft: goesRight ? -48 : -48,
-                  zIndex: 0,
-                }}
-              >
-                <svg width="96" height="140" viewBox="0 0 96 140" fill="none">
-                  <path
-                    d={goesRight ? 'M 0 0 C 0 70, 96 70, 96 140' : 'M 96 0 C 96 70, 0 70, 0 140'}
-                    stroke={pathDone ? '#58CC02' : '#E5D5B0'}
-                    strokeWidth="3"
-                    strokeDasharray="8 8"
-                    strokeLinecap="round"
-                    fill="none"
-                  />
-                </svg>
-              </div>
-            )
-          })}
-
+        {/* Lesson list */}
+        <div className="mn-eyebrow mb-3">уроки</div>
+        <ol className="flex flex-col gap-2.5">
           {lessons.map((lesson, idx) => {
             const isDone = completed.has(lesson.id)
             const isCurrent = lesson.id === firstIncomplete
-            const offset = idx % 2 === 0 ? '-translate-x-12' : 'translate-x-12'
+
             return (
-              <div
-                key={lesson.id}
-                className={`relative w-full flex justify-center ${offset}`}
-                style={{ zIndex: 1, minHeight: 140 }}
-              >
+              <li key={lesson.id}>
                 <button
                   onClick={() =>
-                    navigate({ kind: 'lesson-theory', moduleId, lessonId: lesson.id })
+                    navigate({
+                      kind: 'lesson-theory',
+                      moduleId,
+                      lessonId: lesson.id
+                    })
                   }
-                  className="group relative flex flex-col items-center pt-2"
+                  className="jewel-tile jewel-pressable w-full text-left px-4 py-4 flex items-center gap-3.5"
                 >
-                  <div
-                    className={`w-20 h-20 rounded-full flex items-center justify-center font-extrabold text-2xl shadow-card border-4 transition active:translate-y-1
-                      ${isDone ? 'bg-dog-green text-white border-dog-green' : ''}
-                      ${isCurrent ? 'bg-dog-accent text-white border-dog-accent anim-pop' : ''}
-                      ${!isDone && !isCurrent ? 'bg-white text-dog-ink border-dog-line' : ''}`}
+                  {/* Lesson number medallion */}
+                  <div className="shrink-0 relative z-[1]">
+                    <div
+                      className={`w-12 h-12 rounded-xl border-[1.5px] border-jewelInk flex items-center justify-center ${
+                        isDone
+                          ? 'bg-navy'
+                          : isCurrent
+                          ? 'bg-gold'
+                          : 'bg-cream-deep'
+                      }`}
+                      style={{ boxShadow: '2px 2px 0 #15100A' }}
+                    >
+                      {isDone ? (
+                        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+                          <path
+                            d="M4 10 L8 14 L16 5"
+                            stroke="#FBF6EC"
+                            strokeWidth="2.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                      ) : (
+                        <span
+                          className={`font-sans text-[18px] font-extrabold tabular-nums leading-none ${
+                            isCurrent ? 'text-jewelInk' : 'text-jewelInk-mid'
+                          }`}
+                        >
+                          {lesson.id}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex-1 min-w-0 relative z-[1]">
+                    <div className="font-sans text-[16px] font-bold text-jewelInk leading-tight">
+                      {lesson.title}
+                    </div>
+                    <div className="font-sans text-[12px] text-jewelInk-mid mt-0.5 leading-snug line-clamp-1">
+                      {lesson.short}
+                    </div>
+                  </div>
+
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    className="shrink-0 text-navy relative z-[1]"
                   >
-                    {isDone ? '✓' : lesson.id}
-                  </div>
-                  <div className="text-center text-xs mt-2 font-extrabold max-w-[160px] leading-tight">
-                    {lesson.title}
-                  </div>
-                  <div className="text-center text-[10px] mt-0.5 text-dog-muted max-w-[160px] leading-tight">
-                    {lesson.short}
-                  </div>
+                    <path
+                      d="M8 5 L16 12 L8 19"
+                      stroke="currentColor"
+                      strokeWidth="2.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
                 </button>
-              </div>
+              </li>
             )
           })}
+        </ol>
+
+        <div className="mt-8 text-center">
+          <div className="mn-eyebrow text-jewelInk-mid">
+            все уроки открыты — выбирай любой
+          </div>
         </div>
       </div>
+
+      <div className="mn-kilim opacity-70" />
+      <div style={{ height: 'calc(var(--safe-b) + 4px)' }} />
     </div>
   )
 }

--- a/src/Trale/miniapp-src/src/screens/Practice.tsx
+++ b/src/Trale/miniapp-src/src/screens/Practice.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
-import Header from '../components/Header'
-import Mascot from '../components/Mascot'
 import Button from '../components/Button'
+import LoaderLetter from '../components/LoaderLetter'
 import { ProgressState, QuizQuestion, Screen } from '../types'
 import { progressFromDto } from '../progress'
 import { api } from '../api'
@@ -17,7 +16,14 @@ interface Props {
 
 type Phase = 'loading' | 'answering' | 'checked' | 'error'
 
-export default function Practice({ moduleId, lessonId, progress, setProgress, authenticated, navigate }: Props) {
+export default function Practice({
+  moduleId,
+  lessonId,
+  progress,
+  setProgress,
+  authenticated,
+  navigate
+}: Props) {
   const [questions, setQuestions] = useState<QuizQuestion[]>([])
   const [index, setIndex] = useState(0)
   const [phase, setPhase] = useState<Phase>('loading')
@@ -55,34 +61,42 @@ export default function Practice({ moduleId, lessonId, progress, setProgress, au
 
   if (phase === 'loading') {
     return (
-      <div className="flex flex-col min-h-full">
-        <Header progress={progress} title={`Урок ${lessonId} — Практика`} />
-        <div className="flex-1 flex flex-col items-center justify-center gap-4">
-          <Mascot mood="think" size={120} />
-          <div className="text-dog-muted">Бомбора достаёт карточки...</div>
-        </div>
+      <div
+        className="flex flex-col items-center justify-center bg-cream"
+        style={{
+          minHeight: '100dvh',
+          paddingTop: 'var(--safe-t)',
+          paddingBottom: 'var(--safe-b)'
+        }}
+      >
+        <LoaderLetter label="карточки..." />
       </div>
     )
   }
 
   if (phase === 'error') {
     return (
-      <div className="flex flex-col min-h-full">
-        <Header
-          progress={progress}
-          onBack={() => navigate({ kind: 'lesson-theory', moduleId, lessonId })}
-          title={`Урок ${lessonId}`}
-        />
-        <div className="flex-1 flex flex-col items-center justify-center gap-4 p-5">
-          <Mascot mood="sleep" size={120} />
-          <div className="text-center text-dog-muted">
-            Не получилось загрузить вопросы. Попробуй позже.
-          </div>
+      <div
+        className="flex flex-col items-center justify-center bg-cream px-6 text-center gap-5"
+        style={{
+          minHeight: '100dvh',
+          paddingTop: 'calc(var(--safe-t) + 24px)',
+          paddingBottom: 'calc(var(--safe-b) + 24px)'
+        }}
+      >
+        <div className="mn-eyebrow">страница не раскрылась</div>
+        <div className="font-sans text-[20px] font-extrabold text-jewelInk">
+          Вопросы не загрузились
+        </div>
+        <div className="font-sans text-[14px] text-jewelInk-mid max-w-[300px]">
+          Попробуй вернуться на страницу урока и открыть практику ещё раз.
+        </div>
+        <div className="w-full max-w-[280px] mt-2">
           <Button
             variant="ghost"
             onClick={() => navigate({ kind: 'lesson-theory', moduleId, lessonId })}
           >
-            Назад
+            ← назад
           </Button>
         </div>
       </div>
@@ -159,55 +173,111 @@ export default function Practice({ moduleId, lessonId, progress, setProgress, au
   }
 
   return (
-    <div className="flex flex-col min-h-full">
+    <div className="flex flex-col min-h-full bg-cream">
+      {/* Top: close + progress */}
       <div
-        className="sticky top-0 z-10 bg-dog-bg/95 backdrop-blur px-4 pb-3 border-b border-dog-line"
-        style={{ paddingTop: 'calc(var(--safe-t) + 12px)' }}
+        className="sticky top-0 z-30 bg-cream/95 backdrop-blur-sm"
+        style={{ paddingTop: 'var(--safe-t)' }}
       >
-        <div className="flex items-center gap-2">
+        <div className="mn-kilim" />
+        <div className="px-5 py-3 flex items-center gap-3">
           <button
             onClick={() => navigate({ kind: 'lesson-theory', moduleId, lessonId })}
-            className="w-9 h-9 rounded-full bg-white shadow-card flex items-center justify-center text-lg font-bold text-dog-ink active:translate-y-0.5"
+            className="shrink-0 w-11 h-11 rounded-xl bg-cream-tile border-[1.5px] border-jewelInk flex items-center justify-center active:translate-x-0.5 active:translate-y-0.5 active:shadow-none transition-all duration-75"
+            style={{ boxShadow: '2px 2px 0 #15100A' }}
             aria-label="Закрыть"
           >
-            ✕
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M3 3 L13 13 M13 3 L3 13"
+                stroke="#15100A"
+                strokeWidth="2.2"
+                strokeLinecap="round"
+              />
+            </svg>
           </button>
-          <div className="flex-1 h-3 rounded-full bg-dog-line overflow-hidden">
+
+          <div
+            className="flex-1 h-3 bg-cream-deep border-[1.5px] border-jewelInk rounded-full overflow-hidden"
+            style={{ boxShadow: 'inset 1px 1px 0 rgba(21,16,10,0.1)' }}
+          >
             <div
-              className="h-full bg-dog-green rounded-full transition-all duration-300"
+              className="h-full bg-navy transition-all duration-300"
               style={{ width: `${pct}%` }}
             />
           </div>
-          <div className="w-9" />
+
+          <div className="shrink-0 font-sans text-[13px] font-bold text-jewelInk tabular-nums min-w-[38px] text-right">
+            <span>{questionNumber}</span>
+            <span className="text-jewelInk-hint">/{total}</span>
+          </div>
         </div>
       </div>
 
-      <div className="flex-1 p-5 anim-slide">
-        <div className="text-dog-muted text-xs font-extrabold uppercase tracking-wider">
-          Вопрос {questionNumber} из {total}
-        </div>
-        <div className="mt-2 text-xl font-extrabold leading-tight">{current.question}</div>
+      {/* Question + options */}
+      <div
+        className="flex-1 px-5 pt-6"
+        style={{ paddingBottom: 'calc(var(--safe-b) + 110px)' }}
+      >
+        <div className="mn-eyebrow mb-2">вопрос № {questionNumber}</div>
+        <h2 className="font-sans text-[22px] font-extrabold text-jewelInk leading-tight">
+          {current.question}
+        </h2>
 
-        <div className="mt-5 flex flex-col gap-3">
+        <div className="mt-6 flex flex-col gap-3">
           {current.options.map((opt, i) => {
             const isSelected = i === selected
             const isAnswer = i === current.answerIndex
-            let cls = 'bg-white border-2 border-dog-line'
+
+            let tileClasses =
+              'bg-cream-tile border-jewelInk text-jewelInk'
+            let shadowStyle = '3px 3px 0 #15100A'
+
             if (phase === 'answering' && isSelected) {
-              cls = 'bg-dog-accent/10 border-2 border-dog-accent'
+              tileClasses = 'bg-navy border-jewelInk text-cream'
             }
             if (phase === 'checked') {
-              if (isAnswer) cls = 'bg-dog-green/20 border-2 border-dog-green'
-              else if (isSelected) cls = 'bg-dog-red/20 border-2 border-dog-red'
+              if (isAnswer) {
+                tileClasses = 'bg-navy border-jewelInk text-cream'
+              } else if (isSelected) {
+                tileClasses = 'bg-ruby border-jewelInk text-cream'
+                shadowStyle = '1px 1px 0 #15100A'
+              } else {
+                tileClasses = 'bg-cream-tile border-jewelInk/25 text-jewelInk/40'
+                shadowStyle = 'none'
+              }
             }
+
             return (
               <button
                 key={i}
                 disabled={phase === 'checked'}
                 onClick={() => setSelected(i)}
-                className={`w-full text-left rounded-2xl px-4 py-4 font-semibold text-[15px] transition ${cls}`}
+                className={`w-full text-left px-4 py-4 border-[1.5px] rounded-xl font-sans text-[15px] font-semibold transition-all duration-75 active:translate-x-0.5 active:translate-y-0.5 flex items-center gap-3 ${tileClasses}`}
+                style={{ boxShadow: shadowStyle }}
               >
-                {opt}
+                <span
+                  className={`shrink-0 w-7 h-7 rounded-md border-[1.5px] flex items-center justify-center font-sans text-[12px] font-extrabold uppercase ${
+                    phase === 'checked' && isAnswer
+                      ? 'bg-cream text-ruby border-cream'
+                      : 'bg-cream-deep text-jewelInk border-jewelInk/30'
+                  }`}
+                >
+                  {String.fromCharCode(97 + i)}
+                </span>
+                <span className="flex-1">{opt}</span>
+                {phase === 'checked' && isAnswer && (
+                  <svg width="18" height="18" viewBox="0 0 18 18" className="text-cream shrink-0">
+                    <path
+                      d="M3 9 L7 13 L15 4"
+                      stroke="currentColor"
+                      strokeWidth="2.8"
+                      fill="none"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                )}
               </button>
             )
           })}
@@ -215,31 +285,38 @@ export default function Practice({ moduleId, lessonId, progress, setProgress, au
 
         {phase === 'checked' && (
           <div
-            className={`mt-5 rounded-2xl p-4 ${
-              isCorrect ? 'bg-dog-green/15' : 'bg-dog-red/15'
+            className={`mt-6 p-4 border-[1.5px] rounded-xl relative ${
+              isCorrect
+                ? 'bg-navy border-jewelInk text-cream'
+                : 'bg-ruby border-jewelInk text-cream'
             }`}
+            style={{ boxShadow: '2px 2px 0 #15100A' }}
           >
-            <div className="font-extrabold">
-              {isCorrect ? '✓ Правильно!' : '✗ Не совсем'}
+            <div className="font-sans text-[13px] font-extrabold uppercase tracking-wider mb-1 opacity-90">
+              {isCorrect ? 'верно' : 'ещё раз'}
             </div>
-            {current.explanation && (
-              <div className="text-sm mt-1 text-dog-ink/80">{current.explanation}</div>
-            )}
+            <div className="font-sans text-[14px] leading-snug">
+              {current.explanation ||
+                (isCorrect
+                  ? 'Хорошо запомнил — так держать.'
+                  : 'Запомни правильный вариант и идём дальше.')}
+            </div>
           </div>
         )}
       </div>
 
+      {/* Action bar */}
       <div
-        className="fixed bottom-0 left-0 right-0 max-w-[480px] mx-auto px-4 pt-4 bg-dog-bg/95 backdrop-blur border-t border-dog-line"
+        className="fixed bottom-0 left-0 right-0 max-w-[480px] mx-auto px-5 pt-4 bg-cream/95 backdrop-blur-sm border-t border-jewelInk/15 z-20"
         style={{ paddingBottom: 'calc(var(--safe-b) + 16px)' }}
       >
         {phase === 'answering' ? (
-          <Button variant="green" disabled={selected === null} onClick={check}>
-            Проверить
+          <Button variant="primary" disabled={selected === null} onClick={check}>
+            проверить
           </Button>
         ) : (
           <Button variant={isCorrect ? 'green' : 'primary'} onClick={next}>
-            {index + 1 >= total ? 'Завершить' : 'Продолжить'}
+            {index + 1 >= total ? 'итог →' : 'дальше →'}
           </Button>
         )}
       </div>

--- a/src/Trale/miniapp-src/src/screens/Profile.tsx
+++ b/src/Trale/miniapp-src/src/screens/Profile.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Header from '../components/Header'
 import Mascot from '../components/Mascot'
-import Button from '../components/Button'
+import KilimProgress from '../components/KilimProgress'
 import { CatalogDto, ProgressState, Screen } from '../types'
 
 interface Props {
@@ -11,66 +11,171 @@ interface Props {
   navigate: (s: Screen) => void
 }
 
-export default function Profile({ catalog, progress, setProgress, navigate }: Props) {
+export default function Profile({ catalog, progress, navigate }: Props) {
   const modules = catalog.modules
-  const totalDone = Object.values(progress.completedLessons).reduce((s, arr) => s + arr.length, 0)
+  const totalDone = Object.values(progress.completedLessons).reduce(
+    (s, arr) => s + arr.length,
+    0
+  )
+  const totalAvailable = modules.reduce((s, m) => s + m.lessons.length, 0)
 
   return (
-    <div className="flex flex-col min-h-full">
-      <Header progress={progress} onBack={() => navigate({ kind: 'dashboard' })} title="Профиль" />
-      <div className="flex-1 p-5 flex flex-col gap-4 anim-slide">
-        <div className="bg-white rounded-3xl shadow-card p-5 flex items-center gap-4">
-          <Mascot mood="happy" size={110} />
-          <div className="flex-1">
-            <div className="font-extrabold text-lg">Бомбора твой друг</div>
-            <div className="text-dog-muted text-sm">Старается — а значит растёт</div>
+    <div className="flex flex-col min-h-full bg-cream">
+      <Header
+        progress={progress}
+        onBack={() => navigate({ kind: 'dashboard' })}
+        eyebrow="вкладка"
+        title="Мой профиль"
+      />
+
+      <div
+        className="flex-1 px-5 pt-6 pb-in"
+        style={{ paddingBottom: 'calc(var(--safe-b) + 40px)' }}
+      >
+        {/* Passport card */}
+        <div className="jewel-tile px-5 py-5 mb-6">
+          <div className="relative z-[1] flex items-center gap-4">
+            <div className="shrink-0">
+              <Mascot mood="happy" size={96} />
+            </div>
+            <div className="flex-1">
+              <div className="mn-eyebrow mb-1">владелец</div>
+              <div className="font-sans text-[20px] font-extrabold text-jewelInk leading-none">
+                ученик
+              </div>
+              <div className="font-geo text-[13px] font-bold text-jewelInk-mid mt-1.5">
+                ქართული
+              </div>
+            </div>
+          </div>
+
+          <div className="relative z-[1] mt-5 pt-4 border-t border-jewelInk/15 grid grid-cols-3 gap-3">
+            <PassportField
+              label="стрик"
+              value={`${progress.streak}`}
+              unit="дн"
+              accent="ruby"
+            />
+            <PassportField
+              label="опыт"
+              value={`${progress.xp}`}
+              unit="xp"
+              accent="navy"
+            />
+            <PassportField
+              label="уроков"
+              value={`${totalDone}`}
+              unit={`/ ${totalAvailable}`}
+              accent="gold"
+            />
           </div>
         </div>
 
-        <div className="grid grid-cols-3 gap-3">
-          <Tile icon="🔥" label="Стрик" value={`${progress.streak}`} />
-          <Tile icon="⭐" label="XP" value={`${progress.xp}`} />
-          <Tile icon="📚" label="Уроков" value={`${totalDone}`} />
-        </div>
+        {/* Module progress */}
+        <div className="mn-eyebrow mb-3">разделы блокнота</div>
+        <div className="flex flex-col gap-4">
+          {modules.map((m) => {
+            const total = m.lessons.length
+            const done = (progress.completedLessons[m.id] ?? []).length
+            const accent: 'navy' | 'ruby' | 'gold' =
+              m.id === 'alphabet'
+                ? 'navy'
+                : m.id === 'verbs-of-movement'
+                ? 'ruby'
+                : 'gold'
+            const accentText =
+              accent === 'navy'
+                ? 'text-navy'
+                : accent === 'ruby'
+                ? 'text-ruby'
+                : 'text-gold-deep'
 
-        <div className="bg-white rounded-3xl shadow-card p-4">
-          <div className="font-extrabold text-dog-ink">Прогресс по модулям</div>
-          <div className="mt-3 flex flex-col gap-3">
-            {modules.map((m) => {
-              const total = m.lessons.length
-              if (total === 0) return null
-              const done = (progress.completedLessons[m.id] ?? []).length
-              const pct = Math.round((done / total) * 100)
+            if (total === 0) {
               return (
-                <div key={m.id}>
-                  <div className="flex justify-between text-sm font-bold">
-                    <span>
-                      {m.emoji} {m.title}
-                    </span>
-                    <span className="text-dog-muted">
-                      {done} / {total}
-                    </span>
-                  </div>
-                  <div className="mt-1 h-2 rounded-full bg-dog-line overflow-hidden">
-                    <div className="h-full bg-dog-green" style={{ width: `${pct}%` }} />
+                <div
+                  key={m.id}
+                  className="jewel-tile px-4 py-3 flex items-center justify-between"
+                >
+                  <div className="relative z-[1]">
+                    <div className="font-sans text-[15px] font-bold text-jewelInk">
+                      {m.title}
+                    </div>
+                    <div className="font-sans text-[11px] text-jewelInk-mid">
+                      живой словарь
+                    </div>
                   </div>
                 </div>
               )
-            })}
-          </div>
+            }
+
+            const isDone = done === total
+            return (
+              <div key={m.id} className="jewel-tile px-4 py-4">
+                <div className="relative z-[1]">
+                  <div className="flex items-baseline justify-between mb-2 gap-2">
+                    <div className="font-sans text-[15px] font-bold text-jewelInk truncate">
+                      {m.title}
+                    </div>
+                    <div className="shrink-0 font-sans text-[12px] font-bold tabular-nums">
+                      {isDone ? (
+                        <span className="text-gold-deep">
+                          ✓ {done} / {total}
+                        </span>
+                      ) : (
+                        <>
+                          <span className={accentText}>{done}</span>
+                          <span className="text-jewelInk-hint"> / {total}</span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  <KilimProgress done={done} total={total} accent={accent} />
+                </div>
+              </div>
+            )
+          })}
         </div>
 
+        <div className="mt-8 text-center">
+          <div className="mn-eyebrow text-jewelInk-mid">
+            учись в своём темпе — блокнот ждёт
+          </div>
+          <div className="mt-4 font-sans text-[10px] font-bold text-jewelInk-hint uppercase tracking-widest">
+            ბომბორა · 2026
+          </div>
+        </div>
       </div>
+
+      <div className="mn-kilim opacity-70" />
+      <div style={{ height: 'calc(var(--safe-b) + 4px)' }} />
     </div>
   )
 }
 
-function Tile({ icon, label, value }: { icon: string; label: string; value: string }) {
+function PassportField({
+  label,
+  value,
+  unit,
+  accent
+}: {
+  label: string
+  value: string
+  unit: string
+  accent: 'navy' | 'ruby' | 'gold'
+}) {
+  const accentText =
+    accent === 'navy' ? 'text-navy' : accent === 'ruby' ? 'text-ruby' : 'text-gold-deep'
   return (
-    <div className="bg-white rounded-2xl shadow-card p-3 text-center">
-      <div className="text-2xl">{icon}</div>
-      <div className="text-xs text-dog-muted font-bold uppercase mt-1">{label}</div>
-      <div className="text-xl font-black text-dog-ink">{value}</div>
+    <div className="text-center">
+      <div className="mn-eyebrow text-jewelInk-mid mb-1">{label}</div>
+      <div
+        className={`font-sans text-[22px] font-extrabold tabular-nums leading-none ${accentText}`}
+      >
+        {value}
+      </div>
+      <div className="font-sans text-[10px] font-bold text-jewelInk-hint uppercase tracking-wider mt-0.5">
+        {unit}
+      </div>
     </div>
   )
 }

--- a/src/Trale/miniapp-src/src/screens/Result.tsx
+++ b/src/Trale/miniapp-src/src/screens/Result.tsx
@@ -12,72 +12,129 @@ interface Props {
   navigate: (s: Screen) => void
 }
 
-export default function Result({ moduleId, lessonId, correct, total, xpEarned, navigate }: Props) {
+export default function Result({
+  moduleId,
+  lessonId,
+  correct,
+  total,
+  xpEarned,
+  navigate
+}: Props) {
   const pct = Math.round((correct / total) * 100)
   const isGreat = pct >= 80
-  const mood = isGreat ? 'cheer' : 'happy'
+  const isOK = pct >= 50 && !isGreat
+
+  const mood: 'cheer' | 'happy' | 'think' = isGreat ? 'cheer' : isOK ? 'happy' : 'think'
+  const title = isGreat ? 'Отлично' : isOK ? 'Неплохо' : 'Ещё раз'
+
+  // Georgian stamp words — user learns by seeing them repeatedly
+  const stampGeo = isGreat ? 'მშვენივრად' : isOK ? 'კარგი' : 'ცადე'
+  const stampTrans = isGreat ? 'превосходно' : isOK ? 'хорошо' : 'попробуй'
 
   return (
-    <div
-      className="flex flex-col min-h-full items-center px-6"
-      style={{
-        paddingTop: 'calc(var(--safe-t) + 24px)',
-        paddingBottom: 'calc(var(--safe-b) + 200px)'
-      }}
-    >
-      {/* confetti */}
+    <div className="flex flex-col bg-cream" style={{ minHeight: '100dvh' }}>
+      {/* Kilim top strip */}
+      <div style={{ paddingTop: 'var(--safe-t)' }}>
+        <div className="mn-kilim" />
+      </div>
+
+      {/* Confetti only on great result */}
       {isGreat && (
-        <div className="absolute inset-0 pointer-events-none overflow-hidden">
-          {Array.from({ length: 24 }).map((_, i) => (
+        <div className="absolute inset-0 pointer-events-none overflow-hidden z-0">
+          {Array.from({ length: 32 }).map((_, i) => (
             <div
               key={i}
-              className="confetti absolute top-0 w-2 h-3 rounded-sm"
+              className="confetti absolute top-0 w-2.5 h-4"
               style={{
-                left: `${(i * 4.3) % 100}%`,
-                background: ['#FF9B42', '#58CC02', '#3AB8FF', '#FFC800', '#E94F4F'][i % 5],
-                animationDelay: `${(i % 8) * 80}ms`
+                left: `${(i * 3.2) % 100}%`,
+                background: ['#1B5FB0', '#E01A3C', '#F5B820', '#FBF6EC'][i % 4],
+                border: '1px solid #15100A',
+                transform: `rotate(${(i * 23) % 360}deg)`,
+                animationDelay: `${(i % 10) * 70}ms`
               }}
             />
           ))}
         </div>
       )}
 
-      <div className="mt-6 anim-slide flex flex-col items-center">
-        <Mascot mood={mood} size={160} />
-        <div className="text-3xl font-black mt-3">
-          {isGreat ? 'Отлично!' : 'Неплохо!'}
-        </div>
-        <div className="text-dog-muted mt-1">
-          {moduleId === 'vocabulary' ? 'Квиз по словарю завершён' : `Урок ${lessonId} пройден`}
-        </div>
-      </div>
-
-      <div className="mt-8 w-full grid grid-cols-3 gap-3">
-        <Stat icon="✓" label="Верно" value={`${correct} / ${total}`} color="bg-dog-green" />
-        <Stat icon="⭐" label="XP" value={`+${xpEarned}`} color="bg-dog-gold text-dog-ink" />
-        <Stat icon="🎯" label="Точность" value={`${pct}%`} color="bg-dog-blue" />
-      </div>
-
       <div
-        className="fixed bottom-0 left-0 right-0 max-w-[480px] mx-auto px-4 pt-4 bg-dog-bg/95 backdrop-blur border-t border-dog-line flex flex-col gap-3"
+        className="relative z-[1] flex-1 flex flex-col items-center px-5 pt-8"
+        style={{ paddingBottom: 'calc(var(--safe-b) + 160px)' }}
+      >
+        {/* Mascot + stamp */}
+        <div className="relative mb-5">
+          <Mascot mood={mood} size={170} />
+          <div
+            className="absolute -top-1 -right-4 mn-reveal px-3 py-2 bg-cream border-[1.5px] border-jewelInk rounded-lg rotate-[6deg] text-center"
+            style={{ boxShadow: '2px 2px 0 #15100A' }}
+          >
+            <div className="font-geo text-[14px] font-extrabold text-ruby leading-none">
+              {stampGeo}
+            </div>
+            <div className="font-sans text-[8px] font-bold text-jewelInk-mid uppercase tracking-wider mt-0.5">
+              {stampTrans}
+            </div>
+          </div>
+        </div>
+
+        <div className="mn-eyebrow mb-2">итог страницы</div>
+        <h1 className="font-sans text-[44px] font-extrabold text-jewelInk leading-[0.95] text-center tracking-tight">
+          {title}
+        </h1>
+        <div className="mt-2 font-sans text-[14px] text-jewelInk-mid">
+          {moduleId === 'vocabulary'
+            ? 'квиз по словарю завершён'
+            : `страница ${lessonId} закрыта`}
+        </div>
+
+        {/* Stats — three jewel tiles */}
+        <div className="w-full grid grid-cols-3 gap-3 mt-8">
+          <StatTile label="верно" value={`${correct}/${total}`} accent="navy" />
+          <StatTile label="xp" value={`+${xpEarned}`} accent="ruby" />
+          <StatTile label="точность" value={`${pct}%`} accent="gold" />
+        </div>
+
+        {/* Comment */}
+        <div className="mt-8 text-center max-w-[320px]">
+          <p className="font-sans text-[14px] text-jewelInk-soft leading-snug">
+            {isGreat &&
+              'Так держать. Блокнот пополняется с каждой страницей.'}
+            {isOK &&
+              'Не всё с первого раза — это нормально. Повторение закрепит.'}
+            {!isOK &&
+              !isGreat &&
+              'Перечитай теорию и возвращайся без напряжения.'}
+          </p>
+        </div>
+      </div>
+
+      {/* Action bar */}
+      <div
+        className="fixed bottom-0 left-0 right-0 max-w-[480px] mx-auto px-5 pt-4 bg-cream/95 backdrop-blur-sm border-t border-jewelInk/15 z-20 flex flex-col gap-3"
         style={{ paddingBottom: 'calc(var(--safe-b) + 16px)' }}
       >
         {moduleId === 'vocabulary' ? (
           <>
-            <Button variant="green" onClick={() => navigate({ kind: 'vocabulary-list' })}>
-              К словарю
+            <Button variant="primary" onClick={() => navigate({ kind: 'vocabulary-list' })}>
+              к словарю →
             </Button>
             <Button variant="ghost" onClick={() => navigate({ kind: 'dashboard' })}>
-              На главную
+              на главную
             </Button>
           </>
         ) : (
           <>
-            <Button variant="green" onClick={() => navigate({ kind: 'module', moduleId })}>
-              К карте уроков
+            <Button
+              variant="primary"
+              onClick={() => navigate({ kind: 'module', moduleId })}
+            >
+              к карте уроков →
             </Button>
-            <Button variant="ghost" onClick={() => navigate({ kind: 'practice', moduleId, lessonId })}>
-              Повторить
+            <Button
+              variant="ghost"
+              onClick={() => navigate({ kind: 'practice', moduleId, lessonId })}
+            >
+              пройти ещё раз
             </Button>
           </>
         )}
@@ -86,22 +143,27 @@ export default function Result({ moduleId, lessonId, correct, total, xpEarned, n
   )
 }
 
-function Stat({
-  icon,
+function StatTile({
   label,
   value,
-  color
+  accent
 }: {
-  icon: string
   label: string
   value: string
-  color: string
+  accent: 'navy' | 'ruby' | 'gold'
 }) {
+  const accentText =
+    accent === 'navy' ? 'text-navy' : accent === 'ruby' ? 'text-ruby' : 'text-gold-deep'
   return (
-    <div className={`rounded-2xl ${color} text-white p-3 text-center shadow-card`}>
-      <div className="text-xl">{icon}</div>
-      <div className="text-xs opacity-90 font-bold mt-1">{label}</div>
-      <div className="text-lg font-black">{value}</div>
+    <div className="jewel-tile px-2 py-3 text-center">
+      <div className="relative z-[1]">
+        <div className="mn-eyebrow text-jewelInk-mid">{label}</div>
+        <div
+          className={`mt-1.5 font-sans text-[20px] font-extrabold tabular-nums leading-none ${accentText}`}
+        >
+          {value}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/Trale/miniapp-src/src/screens/VocabularyList.tsx
+++ b/src/Trale/miniapp-src/src/screens/VocabularyList.tsx
@@ -110,7 +110,7 @@ export default function VocabularyList({ progress, navigate }: Props) {
           <Mascot mood="sleep" size={120} />
           <div className="font-extrabold text-lg">Открывай через Telegram</div>
           <div className="text-dog-muted">
-            Чтобы Бомбора узнал твой словарь, зайди в мини-аб через кнопку «🐶 Бомбора» в боте.
+            Чтобы Бомбора узнал твой словарь, зайди в мини-апп через кнопку «🐶 Бомбора» в боте.
           </div>
           <Button variant="ghost" onClick={() => navigate({ kind: 'dashboard' })}>
             На главную

--- a/src/Trale/miniapp-src/src/screens/VocabularyList.tsx
+++ b/src/Trale/miniapp-src/src/screens/VocabularyList.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import Header from '../components/Header'
-import Mascot from '../components/Mascot'
 import Button from '../components/Button'
+import LoaderLetter from '../components/LoaderLetter'
 import { ProgressState, Screen } from '../types'
 import { api, ApiError, VocabularyItem, VocabularyQuizMode } from '../api'
 
@@ -53,7 +53,12 @@ export default function VocabularyList({ progress, navigate }: Props) {
     const lowered = search.trim().toLowerCase()
     return items.filter((item) => {
       if (filter === 'new') {
-        if (item.successCount > 0 || item.successReverseCount > 0 || item.failedCount > 0) return false
+        if (
+          item.successCount > 0 ||
+          item.successReverseCount > 0 ||
+          item.failedCount > 0
+        )
+          return false
       }
       if (filter === 'weak') {
         if (item.mastery === 'MasteredInBothDirections') return false
@@ -92,11 +97,18 @@ export default function VocabularyList({ progress, navigate }: Props) {
 
   if (phase === 'loading') {
     return (
-      <div className="flex flex-col min-h-full">
-        <Header progress={progress} onBack={() => navigate({ kind: 'dashboard' })} title="Мой словарь" />
-        <div className="flex-1 flex flex-col items-center justify-center gap-4">
-          <Mascot mood="think" size={120} />
-          <div className="text-dog-muted">Бомбора роется в твоём словарике...</div>
+      <div className="flex flex-col min-h-full bg-cream">
+        <Header
+          progress={progress}
+          onBack={() => navigate({ kind: 'dashboard' })}
+          eyebrow="ლექსიკონი"
+          title="Мой словарь"
+        />
+        <div
+          className="flex-1 flex flex-col items-center justify-center"
+          style={{ minHeight: '50vh' }}
+        >
+          <LoaderLetter label="словарь..." size={120} />
         </div>
       </div>
     )
@@ -104,17 +116,26 @@ export default function VocabularyList({ progress, navigate }: Props) {
 
   if (phase === 'auth-required') {
     return (
-      <div className="flex flex-col min-h-full">
-        <Header progress={progress} onBack={() => navigate({ kind: 'dashboard' })} title="Мой словарь" />
-        <div className="flex-1 flex flex-col items-center justify-center gap-4 p-5 text-center">
-          <Mascot mood="sleep" size={120} />
-          <div className="font-extrabold text-lg">Открывай через Telegram</div>
-          <div className="text-dog-muted">
-            Чтобы Бомбора узнал твой словарь, зайди в мини-апп через кнопку «🐶 Бомбора» в боте.
+      <div className="flex flex-col min-h-full bg-cream">
+        <Header
+          progress={progress}
+          onBack={() => navigate({ kind: 'dashboard' })}
+          eyebrow="ლექსიკონი"
+          title="Мой словарь"
+        />
+        <div className="flex-1 flex flex-col items-center justify-center px-6 text-center gap-5 py-12">
+          <div className="mn-eyebrow">нужен Telegram</div>
+          <div className="font-sans text-[20px] font-extrabold text-jewelInk max-w-[300px]">
+            Словарь живёт в Telegram
           </div>
-          <Button variant="ghost" onClick={() => navigate({ kind: 'dashboard' })}>
-            На главную
-          </Button>
+          <div className="font-sans text-[14px] text-jewelInk-mid max-w-[320px]">
+            Открой мини-апп через кнопку «🐶 Бомбора» в чате с ботом.
+          </div>
+          <div className="w-full max-w-[280px]">
+            <Button variant="ghost" onClick={() => navigate({ kind: 'dashboard' })}>
+              ← на главную
+            </Button>
+          </div>
         </div>
       </div>
     )
@@ -122,120 +143,208 @@ export default function VocabularyList({ progress, navigate }: Props) {
 
   if (phase === 'error') {
     return (
-      <div className="flex flex-col min-h-full">
-        <Header progress={progress} onBack={() => navigate({ kind: 'dashboard' })} title="Мой словарь" />
-        <div className="flex-1 flex flex-col items-center justify-center gap-4 p-5 text-center">
-          <Mascot mood="sleep" size={120} />
-          <div className="text-dog-muted">Что-то пошло не так. Попробуй ещё раз позже.</div>
-          <Button variant="ghost" onClick={() => navigate({ kind: 'dashboard' })}>
-            На главную
-          </Button>
+      <div className="flex flex-col min-h-full bg-cream">
+        <Header
+          progress={progress}
+          onBack={() => navigate({ kind: 'dashboard' })}
+          eyebrow="ლექსიკონი"
+          title="Мой словарь"
+        />
+        <div className="flex-1 flex flex-col items-center justify-center px-6 text-center gap-5 py-12">
+          <div className="mn-eyebrow">ой</div>
+          <div className="font-sans text-[14px] text-jewelInk-mid">
+            Что-то пошло не так. Попробуй вернуться позже.
+          </div>
+          <div className="w-full max-w-[280px]">
+            <Button variant="ghost" onClick={() => navigate({ kind: 'dashboard' })}>
+              ← на главную
+            </Button>
+          </div>
         </div>
       </div>
     )
   }
 
   return (
-    <div className="flex flex-col min-h-full">
-      <Header progress={progress} onBack={() => navigate({ kind: 'dashboard' })} title="Мой словарь" />
-      <div className="flex-1 p-5 pb-36 anim-slide">
-        <div className="bg-white rounded-3xl shadow-card p-4 mb-4 flex items-center gap-3">
-          <Mascot mood={isStarterMode ? 'think' : 'happy'} size={72} />
-          <div className="flex-1">
-            <div className="font-extrabold">
-              {isStarterMode
-                ? 'Твой словарь пока пуст'
-                : `${items.length} ${pluralizeWord(items.length)} в словаре`}
+    <div className="flex flex-col min-h-full bg-cream">
+      <Header
+        progress={progress}
+        onBack={() => navigate({ kind: 'dashboard' })}
+        eyebrow="ლექსიკონი"
+        title="Мой словарь"
+      />
+
+      <div
+        className="flex-1 px-5 pt-5 pb-in"
+        style={{ paddingBottom: 'calc(var(--safe-b) + 150px)' }}
+      >
+        {/* Intro card */}
+        <div className="jewel-tile px-5 py-4 mb-5">
+          <div className="relative z-[1]">
+            <div className="mn-eyebrow mb-1">
+              {isStarterMode ? 'стартовая колода' : 'твоя колода'}
             </div>
-            <div className="text-dog-muted text-sm">
+            <div className="font-sans text-[22px] font-extrabold text-jewelInk leading-tight">
               {isStarterMode
-                ? 'Начни с базового набора слов от Бомборы, а свои слова добавляй через бота'
-                : 'Выбери слова галочками или жми готовые наборы ниже'}
+                ? 'Словарь пока пуст'
+                : `${items.length} ${pluralizeWord(items.length)}`}
+            </div>
+            <div className="font-sans text-[13px] text-jewelInk-mid mt-1 leading-snug">
+              {isStarterMode
+                ? 'Начни с базового набора от Бомборы. Свои слова добавляй через чат.'
+                : 'Отметь слова или выбери готовый набор снизу.'}
             </div>
           </div>
         </div>
 
-        <input
-          className="w-full bg-white rounded-2xl shadow-card px-4 py-3 font-semibold outline-none border-2 border-transparent focus:border-dog-accent"
-          placeholder="Поиск по слову или переводу"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
+        {!isStarterMode && (
+          <>
+            {/* Search */}
+            <div className="relative mb-3">
+              <svg
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-jewelInk/40"
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+              >
+                <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.8" />
+                <path
+                  d="M11 11 L14 14"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  strokeLinecap="round"
+                />
+              </svg>
+              <input
+                className="w-full bg-cream-tile border-[1.5px] border-jewelInk rounded-xl pl-9 pr-3 py-3 font-sans text-[14px] text-jewelInk placeholder:text-jewelInk-hint outline-none focus:border-navy"
+                style={{ boxShadow: '2px 2px 0 #15100A' }}
+                placeholder="поиск по слову"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </div>
 
-        <div className="grid grid-cols-4 gap-1.5 mt-3">
-          <Chip active={filter === 'all'} onClick={() => setFilter('all')}>Все</Chip>
-          <Chip active={filter === 'new'} onClick={() => setFilter('new')}>Новые</Chip>
-          <Chip active={filter === 'weak'} onClick={() => setFilter('weak')}>Сложные</Chip>
-          <Chip active={filter === 'mastered'} onClick={() => setFilter('mastered')}>Изучено</Chip>
-        </div>
+            {/* Filter chips */}
+            <div className="grid grid-cols-4 gap-1.5 mb-5">
+              <FilterChip active={filter === 'all'} onClick={() => setFilter('all')}>
+                все
+              </FilterChip>
+              <FilterChip active={filter === 'new'} onClick={() => setFilter('new')}>
+                новые
+              </FilterChip>
+              <FilterChip active={filter === 'weak'} onClick={() => setFilter('weak')}>
+                сложные
+              </FilterChip>
+              <FilterChip
+                active={filter === 'mastered'}
+                onClick={() => setFilter('mastered')}
+              >
+                изучено
+              </FilterChip>
+            </div>
+          </>
+        )}
 
-        <div className="mt-4 flex flex-col gap-2">
-          {filtered.map((item) => {
+        {/* Word list */}
+        <div className="flex flex-col gap-2">
+          {filtered.map((item, idx) => {
             const isSelected = selected.has(item.id)
-            const masteryDot =
-              item.mastery === 'MasteredInBothDirections'
-                ? 'bg-dog-green'
-                : item.mastery === 'MasteredInForwardDirection'
-                ? 'bg-dog-gold'
-                : 'bg-dog-line'
             const { georgian, russian } = sides(item)
+            const masteryColor =
+              item.mastery === 'MasteredInBothDirections'
+                ? 'bg-gold'
+                : item.mastery === 'MasteredInForwardDirection'
+                ? 'bg-navy'
+                : 'bg-jewelInk/15'
             return (
               <button
                 key={item.id}
-                onClick={() => toggle(item.id)}
-                className={`text-left bg-white rounded-2xl shadow-card p-3 flex items-center gap-3 transition active:translate-y-1 border-2 ${
-                  isSelected ? 'border-dog-accent' : 'border-transparent'
+                onClick={() => !isStarterMode && toggle(item.id)}
+                className={`w-full text-left jewel-tile jewel-pressable px-4 py-3 flex items-center gap-3 ${
+                  isSelected ? '!bg-ruby/10' : ''
                 }`}
               >
+                <div className="relative z-[1] shrink-0 font-sans text-[10px] font-bold text-jewelInk-mid tabular-nums w-6">
+                  {String(idx + 1).padStart(2, '0')}
+                </div>
+
+                {!isStarterMode && (
+                  <div
+                    className={`relative z-[1] shrink-0 w-6 h-6 rounded-md border-[1.5px] flex items-center justify-center ${
+                      isSelected
+                        ? 'bg-ruby border-jewelInk'
+                        : 'bg-cream-deep border-jewelInk/40'
+                    }`}
+                  >
+                    {isSelected && (
+                      <svg width="12" height="12" viewBox="0 0 18 18" fill="none">
+                        <path
+                          d="M3 9 L7 13 L15 4"
+                          stroke="#FBF6EC"
+                          strokeWidth="2.8"
+                          fill="none"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    )}
+                  </div>
+                )}
+
+                <div className="relative z-[1] flex-1 min-w-0">
+                  <div className="font-geo text-[18px] font-bold text-jewelInk leading-tight truncate">
+                    {georgian}
+                  </div>
+                  <div className="font-sans text-[12px] text-jewelInk-mid truncate leading-snug mt-0.5">
+                    {russian}
+                  </div>
+                </div>
+
                 <div
-                  className={`w-6 h-6 rounded-lg flex items-center justify-center font-extrabold text-xs ${
-                    isSelected ? 'bg-dog-accent text-white' : 'bg-dog-line text-transparent'
-                  }`}
-                >
-                  ✓
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="font-extrabold truncate">{georgian}</div>
-                  <div className="text-dog-muted text-sm truncate">{russian}</div>
-                </div>
-                <div className={`w-2.5 h-2.5 rounded-full ${masteryDot}`} />
+                  className={`relative z-[1] w-2.5 h-2.5 rounded-full shrink-0 ${masteryColor} border border-jewelInk/30`}
+                />
               </button>
             )
           })}
+
           {filtered.length === 0 && (
-            <div className="text-center text-dog-muted p-6">Ничего не нашлось</div>
+            <div className="py-10 text-center font-sans text-[14px] text-jewelInk-mid">
+              ничего не нашлось
+            </div>
           )}
         </div>
       </div>
 
+      {/* Action bar */}
       <div
-        className="fixed bottom-0 left-0 right-0 max-w-[480px] mx-auto px-4 pt-4 bg-dog-bg/95 backdrop-blur border-t border-dog-line flex flex-col gap-2"
+        className="fixed bottom-0 left-0 right-0 max-w-[480px] mx-auto px-5 pt-4 bg-cream/95 backdrop-blur-sm border-t border-jewelInk/15 z-20 flex flex-col gap-2.5"
         style={{ paddingBottom: 'calc(var(--safe-b) + 16px)' }}
       >
         {isStarterMode ? (
-          <Button variant="green" onClick={() => startQuiz('starter')}>
-            ▶ Пробный квиз ({items.length} слов)
+          <Button variant="primary" onClick={() => startQuiz('starter')}>
+            пробный квиз →
           </Button>
         ) : selected.size > 0 ? (
           <>
-            <Button variant="green" onClick={() => startQuiz('custom')}>
-              ▶ Квиз по выбранным ({selected.size})
+            <Button variant="primary" onClick={() => startQuiz('custom')}>
+              квиз по выбранным ({selected.size})
             </Button>
             <Button variant="ghost" onClick={() => setSelected(new Set())}>
-              Снять выделение
+              снять выделение
             </Button>
           </>
         ) : (
           <div className="grid grid-cols-3 gap-2">
-            <QuickQuizButton variant="green" onClick={() => startQuiz('all')}>
-              Все
-            </QuickQuizButton>
-            <QuickQuizButton variant="blue" onClick={() => startQuiz('new')}>
-              Новые
-            </QuickQuizButton>
-            <QuickQuizButton variant="primary" onClick={() => startQuiz('weak')}>
-              Сложные
-            </QuickQuizButton>
+            <TinyButton color="navy" onClick={() => startQuiz('all')}>
+              все
+            </TinyButton>
+            <TinyButton color="gold" onClick={() => startQuiz('new')}>
+              новые
+            </TinyButton>
+            <TinyButton color="ruby" onClick={() => startQuiz('weak')}>
+              сложные
+            </TinyButton>
           </div>
         )}
       </div>
@@ -243,24 +352,49 @@ export default function VocabularyList({ progress, navigate }: Props) {
   )
 }
 
-function QuickQuizButton({
+function TinyButton({
   children,
-  variant,
+  color,
   onClick
 }: {
   children: React.ReactNode
-  variant: 'green' | 'blue' | 'primary'
+  color: 'navy' | 'gold' | 'ruby'
   onClick: () => void
 }) {
   const styles: Record<string, string> = {
-    green: 'bg-dog-green text-white shadow-btngreen',
-    blue: 'bg-dog-blue text-white shadow-btnblue',
-    primary: 'bg-dog-accent text-white shadow-btn'
+    navy: 'bg-navy text-cream',
+    gold: 'bg-gold text-jewelInk',
+    ruby: 'bg-ruby text-cream'
   }
   return (
     <button
       onClick={onClick}
-      className={`rounded-2xl px-2 py-3 font-extrabold uppercase text-xs tracking-tight transition active:translate-y-1 text-center ${styles[variant]}`}
+      className={`px-2 py-3 rounded-xl border-[1.5px] border-jewelInk font-sans text-[12px] font-extrabold uppercase tracking-wide text-center transition-all duration-75 active:translate-x-0.5 active:translate-y-0.5 active:shadow-none ${styles[color]}`}
+      style={{ boxShadow: '2px 2px 0 #15100A' }}
+    >
+      {children}
+    </button>
+  )
+}
+
+function FilterChip({
+  children,
+  active,
+  onClick
+}: {
+  children: React.ReactNode
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded-lg border-[1.5px] px-2 py-1.5 text-center font-sans text-[11px] font-bold uppercase tracking-wider transition-all duration-75 ${
+        active
+          ? 'bg-navy text-cream border-jewelInk'
+          : 'bg-cream-tile text-jewelInk-mid border-jewelInk/25'
+      }`}
+      style={active ? { boxShadow: '2px 2px 0 #15100A' } : {}}
     >
       {children}
     </button>
@@ -288,25 +422,4 @@ function sides(item: VocabularyItem): { georgian: string; russian: string } {
     return { georgian: item.word, russian: item.definition }
   }
   return { georgian: item.definition, russian: item.word }
-}
-
-function Chip({
-  children,
-  active,
-  onClick
-}: {
-  children: React.ReactNode
-  active: boolean
-  onClick: () => void
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={`rounded-full px-2 py-1.5 text-xs font-extrabold shadow-card text-center ${
-        active ? 'bg-dog-accent text-white' : 'bg-white text-dog-ink'
-      }`}
-    >
-      {children}
-    </button>
-  )
 }

--- a/src/Trale/miniapp-src/src/screens/VocabularyPractice.tsx
+++ b/src/Trale/miniapp-src/src/screens/VocabularyPractice.tsx
@@ -1,8 +1,14 @@
-import React, { useEffect, useState } from 'react'
-import Mascot from '../components/Mascot'
+import React, { useEffect, useMemo, useState } from 'react'
 import Button from '../components/Button'
+import LoaderLetter from '../components/LoaderLetter'
 import { ProgressState, Screen } from '../types'
-import { api, ApiError, VocabularyQuizMode, VocabularyQuizQuestion } from '../api'
+import {
+  api,
+  ApiError,
+  VocabularyQuizMode,
+  VocabularyQuizQuestion,
+  VocabularyWordPair
+} from '../api'
 import { progressFromDto } from '../progress'
 
 interface Props {
@@ -14,93 +20,202 @@ interface Props {
   navigate: (s: Screen) => void
 }
 
+/**
+ * 4-round vocabulary quiz — like the original bot:
+ *  Round 1: multi-choice GE → RU
+ *  Round 2: multi-choice RU → GE
+ *  Round 3: type-in GE → RU
+ *  Round 4: type-in RU → GE
+ */
+
+interface QuizItem {
+  wordId: string | null
+  prompt: string
+  correct: string
+  options?: string[] // present for multi-choice, absent for type-in
+  direction: 'ge-to-ru' | 'ru-to-ge'
+  type: 'multi-choice' | 'type-in'
+  roundLabel: string
+}
+
 type Phase = 'loading' | 'answering' | 'checked' | 'error' | 'empty' | 'auth-required'
 
-export default function VocabularyPractice({ mode, wordIds, progress, setProgress, authenticated, navigate }: Props) {
-  const [questions, setQuestions] = useState<VocabularyQuizQuestion[]>([])
+export default function VocabularyPractice({
+  mode,
+  wordIds,
+  progress,
+  setProgress,
+  authenticated,
+  navigate
+}: Props) {
+  const [allItems, setAllItems] = useState<QuizItem[]>([])
   const [index, setIndex] = useState(0)
   const [phase, setPhase] = useState<Phase>('loading')
   const [selected, setSelected] = useState<number | null>(null)
+  const [typedAnswer, setTypedAnswer] = useState('')
   const [correctCount, setCorrectCount] = useState(0)
+  const [isCurrentCorrect, setIsCurrentCorrect] = useState(false)
 
   useEffect(() => {
     let cancelled = false
     api
-      .startVocabularyQuiz({ mode, wordIds, count: 10 })
+      .startVocabularyQuiz({ mode, wordIds, count: 5 })
       .then((r) => {
         if (cancelled) return
         if (!r.questions.length) {
           setPhase('empty')
           return
         }
-        setQuestions(r.questions)
+
+        const pairs = r.wordPairs ?? []
+        const poolRu = r.allRussian ?? []
+        const poolGe = r.allGeorgian ?? []
+
+        // Build 4 rounds
+        const items: QuizItem[] = []
+
+        // Round 1: multi-choice GE → RU
+        for (const p of pairs) {
+          const distractors = shuffle(poolRu.filter((w) => w !== p.russian)).slice(0, 3)
+          const options = shuffle([...distractors, p.russian])
+          items.push({
+            wordId: p.wordId,
+            prompt: p.georgian,
+            correct: p.russian,
+            options,
+            direction: 'ge-to-ru',
+            type: 'multi-choice',
+            roundLabel: 'ქართული → русский'
+          })
+        }
+
+        // Round 2: multi-choice RU → GE (use existing questions)
+        for (const q of r.questions) {
+          items.push({
+            wordId: q.wordId,
+            prompt: q.question,
+            correct: q.options[q.answerIndex],
+            options: q.options,
+            direction: 'ru-to-ge',
+            type: 'multi-choice',
+            roundLabel: 'русский → ქართული'
+          })
+        }
+
+        // Round 3: type-in GE → RU
+        for (const p of pairs) {
+          items.push({
+            wordId: p.wordId,
+            prompt: p.georgian,
+            correct: p.russian,
+            direction: 'ge-to-ru',
+            type: 'type-in',
+            roundLabel: 'напиши перевод'
+          })
+        }
+
+        // Round 4: type-in RU → GE
+        for (const p of pairs) {
+          items.push({
+            wordId: p.wordId,
+            prompt: p.russian,
+            correct: p.georgian,
+            direction: 'ru-to-ge',
+            type: 'type-in',
+            roundLabel: 'напиши по-грузински'
+          })
+        }
+
+        setAllItems(items)
         setPhase('answering')
       })
       .catch((e) => {
         if (cancelled) return
-        setPhase(e instanceof ApiError && e.status === 401 ? 'auth-required' : 'error')
+        setPhase(
+          e instanceof ApiError && e.status === 401 ? 'auth-required' : 'error'
+        )
       })
     return () => {
       cancelled = true
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode])
 
   if (phase === 'loading') {
     return (
-      <CenteredMascot mood="think" text="Бомбора мешает карточки..." />
+      <FullScreen>
+        <LoaderLetter label="словарь..." />
+      </FullScreen>
     )
   }
 
   if (phase === 'empty') {
     return (
-      <div className="flex flex-col min-h-full p-5 items-center justify-center gap-4 text-center">
-        <Mascot mood="sleep" size={120} />
-        <div className="font-extrabold text-lg">Нечего спрашивать</div>
-        <div className="text-dog-muted">В выбранной категории пусто — попробуй другой набор слов.</div>
-        <Button variant="ghost" onClick={() => navigate({ kind: 'vocabulary-list' })}>
-          Назад к словарю
-        </Button>
-      </div>
+      <FullScreen>
+        <div className="mn-eyebrow">тут пусто</div>
+        <div className="font-sans text-[20px] font-extrabold text-jewelInk max-w-[300px] text-center">
+          Нет слов для квиза
+        </div>
+        <div className="w-full max-w-[280px] mt-4">
+          <Button variant="ghost" onClick={() => navigate({ kind: 'vocabulary-list' })}>
+            ← к словарю
+          </Button>
+        </div>
+      </FullScreen>
     )
   }
 
   if (phase === 'error' || phase === 'auth-required') {
     return (
-      <div className="flex flex-col min-h-full p-5 items-center justify-center gap-4 text-center">
-        <Mascot mood="sleep" size={120} />
-        <div className="text-dog-muted">
+      <FullScreen>
+        <div className="mn-eyebrow">{phase === 'auth-required' ? 'нужен telegram' : 'ой'}</div>
+        <div className="font-sans text-[14px] text-jewelInk-mid max-w-[320px] text-center">
           {phase === 'auth-required'
-            ? 'Открой мини-апп через кнопку «🎓 Грузинский» в Telegram-боте.'
+            ? 'Открой мини-апп через кнопку «🐶 Бомбора» в боте.'
             : 'Что-то сломалось. Попробуй ещё раз.'}
         </div>
-        <Button variant="ghost" onClick={() => navigate({ kind: 'dashboard' })}>
-          На главную
-        </Button>
-      </div>
+        <div className="w-full max-w-[280px] mt-4">
+          <Button variant="ghost" onClick={() => navigate({ kind: 'dashboard' })}>
+            ← на главную
+          </Button>
+        </div>
+      </FullScreen>
     )
   }
 
-  const current = questions[index]
-  const total = questions.length
+  const current = allItems[index]
+  const total = allItems.length
   const questionNumber = index + 1
   const pct = Math.round((questionNumber / total) * 100)
-  const isCorrect = selected !== null && selected === current.answerIndex
 
-  function check() {
-    if (selected === null) return
+  function checkMultiChoice() {
+    if (selected === null || !current.options) return
     setPhase('checked')
-    const isRight = selected === current.answerIndex
-    if (isRight) {
-      setCorrectCount((c) => c + 1)
-    }
+    const correct = current.options[selected] === current.correct
+    setIsCurrentCorrect(correct)
+    if (correct) setCorrectCount((c) => c + 1)
     if (current.wordId) {
-      api
-        .recordVocabularyAnswer({
-          wordId: current.wordId,
-          correct: isRight,
-          direction: current.direction
-        })
-        .catch(() => {})
+      api.recordVocabularyAnswer({
+        wordId: current.wordId,
+        correct,
+        direction: current.direction
+      }).catch(() => {})
+    }
+  }
+
+  function checkTypeIn() {
+    const trimmed = typedAnswer.trim()
+    if (!trimmed) return
+    setPhase('checked')
+    const correct = trimmed.toLowerCase() === current.correct.toLowerCase()
+    setIsCurrentCorrect(correct)
+    if (correct) setCorrectCount((c) => c + 1)
+    if (current.wordId) {
+      api.recordVocabularyAnswer({
+        wordId: current.wordId,
+        correct,
+        direction: current.direction
+      }).catch(() => {})
     }
   }
 
@@ -120,16 +235,10 @@ export default function VocabularyPractice({ mode, wordIds, progress, setProgres
           setProgress(progressFromDto(r.progress))
           xpEarned = r.xpEarned
         } catch {
-          setProgress({
-            ...progress,
-            xp: progress.xp + xpEarned
-          })
+          setProgress({ ...progress, xp: progress.xp + xpEarned })
         }
       } else {
-        setProgress({
-          ...progress,
-          xp: progress.xp + xpEarned
-        })
+        setProgress({ ...progress, xp: progress.xp + xpEarned })
       }
 
       navigate({
@@ -144,96 +253,209 @@ export default function VocabularyPractice({ mode, wordIds, progress, setProgres
     }
     setIndex((i) => i + 1)
     setSelected(null)
+    setTypedAnswer('')
+    setIsCurrentCorrect(false)
     setPhase('answering')
   }
 
   return (
-    <div className="flex flex-col min-h-full">
+    <div className="flex flex-col min-h-full bg-cream">
+      {/* Top bar */}
       <div
-        className="sticky top-0 z-10 bg-dog-bg/95 backdrop-blur px-4 pb-3 border-b border-dog-line"
-        style={{ paddingTop: 'calc(var(--safe-t) + 12px)' }}
+        className="sticky top-0 z-30 bg-cream/95 backdrop-blur-sm"
+        style={{ paddingTop: 'var(--safe-t)' }}
       >
-        <div className="flex items-center gap-2">
+        <div className="mn-kilim" />
+        <div className="px-5 py-3 flex items-center gap-3">
           <button
             onClick={() => navigate({ kind: 'vocabulary-list' })}
-            className="w-9 h-9 rounded-full bg-white shadow-card flex items-center justify-center text-lg font-bold text-dog-ink active:translate-y-0.5"
+            className="shrink-0 w-11 h-11 rounded-xl bg-cream-tile border-[1.5px] border-jewelInk flex items-center justify-center active:translate-x-0.5 active:translate-y-0.5 active:shadow-none transition-all duration-75"
+            style={{ boxShadow: '2px 2px 0 #15100A' }}
             aria-label="Закрыть"
           >
-            ✕
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+              <path d="M3 3 L13 13 M13 3 L3 13" stroke="#15100A" strokeWidth="2.2" strokeLinecap="round" />
+            </svg>
           </button>
-          <div className="flex-1 h-3 rounded-full bg-dog-line overflow-hidden">
+
+          <div
+            className="flex-1 h-3 bg-cream-deep border-[1.5px] border-jewelInk rounded-full overflow-hidden"
+            style={{ boxShadow: 'inset 1px 1px 0 rgba(21,16,10,0.1)' }}
+          >
             <div
-              className="h-full bg-dog-green rounded-full transition-all duration-300"
+              className="h-full bg-gold transition-all duration-300"
               style={{ width: `${pct}%` }}
             />
           </div>
-          <div className="bg-white rounded-full px-2.5 py-1 shadow-card text-xs font-extrabold text-dog-ink">
-            {questionNumber}/{total}
+
+          <div className="shrink-0 font-sans text-[13px] font-bold text-jewelInk tabular-nums min-w-[38px] text-right">
+            <span>{questionNumber}</span>
+            <span className="text-jewelInk-hint">/{total}</span>
           </div>
         </div>
       </div>
 
-      <div className="flex-1 p-5 anim-slide">
-        <div className="text-dog-muted text-xs font-extrabold uppercase tracking-wider">
-          {current.direction === 'ge-to-ru' ? 'Грузинский → Русский' : 'Русский → Грузинский'}
-        </div>
-        <div className="mt-2 text-xl font-extrabold leading-tight">{current.question}</div>
+      {/* Question */}
+      <div
+        className="flex-1 px-5 pt-6"
+        style={{ paddingBottom: 'calc(var(--safe-b) + 110px)' }}
+      >
+        <div className="mn-eyebrow mb-2">{current.roundLabel}</div>
 
-        <div className="mt-5 flex flex-col gap-3">
-          {current.options.map((opt, i) => {
-            const isSelected = i === selected
-            const isAnswer = i === current.answerIndex
-            let cls = 'bg-white border-2 border-dog-line'
-            if (phase === 'answering' && isSelected) {
-              cls = 'bg-dog-accent/10 border-2 border-dog-accent'
-            }
-            if (phase === 'checked') {
-              if (isAnswer) cls = 'bg-dog-green/20 border-2 border-dog-green'
-              else if (isSelected) cls = 'bg-dog-red/20 border-2 border-dog-red'
-            }
-            return (
-              <button
-                key={i}
-                disabled={phase === 'checked'}
-                onClick={() => setSelected(i)}
-                className={`w-full text-left rounded-2xl px-4 py-4 font-semibold text-[15px] transition ${cls}`}
-              >
-                {opt}
-              </button>
-            )
-          })}
-        </div>
+        {current.type === 'multi-choice' && current.direction === 'ge-to-ru' ? (
+          <h2 className="font-geo text-[28px] font-extrabold text-jewelInk leading-tight">
+            {current.prompt}
+          </h2>
+        ) : current.type === 'multi-choice' ? (
+          <h2 className="font-sans text-[22px] font-extrabold text-jewelInk leading-tight">
+            {current.prompt}
+          </h2>
+        ) : (
+          <div>
+            <div className="font-sans text-[14px] text-jewelInk-mid mb-2">
+              {current.direction === 'ge-to-ru'
+                ? 'Напиши перевод на русский:'
+                : 'Напиши по-грузински:'}
+            </div>
+            <h2
+              className={`text-[28px] font-extrabold text-jewelInk leading-tight ${
+                current.direction === 'ge-to-ru' ? 'font-geo' : 'font-sans'
+              }`}
+            >
+              {current.prompt}
+            </h2>
+          </div>
+        )}
 
+        {/* Multi-choice options */}
+        {current.type === 'multi-choice' && current.options && (
+          <div className="mt-6 flex flex-col gap-3">
+            {current.options.map((opt, i) => {
+              const isSelected = i === selected
+              const isAnswer = opt === current.correct
+
+              let tileClasses = 'bg-cream-tile border-jewelInk text-jewelInk'
+              let shadowStyle = '3px 3px 0 #15100A'
+
+              if (phase === 'answering' && isSelected) {
+                tileClasses = 'bg-navy border-jewelInk text-cream'
+              }
+              if (phase === 'checked') {
+                if (isAnswer) {
+                  tileClasses = 'bg-navy border-jewelInk text-cream'
+                } else if (isSelected) {
+                  tileClasses = 'bg-ruby border-jewelInk text-cream'
+                  shadowStyle = '1px 1px 0 #15100A'
+                } else {
+                  tileClasses = 'bg-cream-tile border-jewelInk/25 text-jewelInk/40'
+                  shadowStyle = 'none'
+                }
+              }
+
+              const fontClass =
+                current.direction === 'ge-to-ru' ? 'font-sans text-[16px]' : 'font-geo text-[17px]'
+
+              return (
+                <button
+                  key={i}
+                  disabled={phase === 'checked'}
+                  onClick={() => setSelected(i)}
+                  className={`w-full text-left px-4 py-4 border-[1.5px] rounded-xl transition-all duration-75 active:translate-x-0.5 active:translate-y-0.5 flex items-center gap-3 ${tileClasses}`}
+                  style={{ boxShadow: shadowStyle }}
+                >
+                  <span className="shrink-0 w-7 h-7 rounded-md border-[1.5px] flex items-center justify-center font-sans text-[12px] font-extrabold uppercase bg-cream-deep text-jewelInk border-jewelInk/30">
+                    {String.fromCharCode(97 + i)}
+                  </span>
+                  <span className={`flex-1 font-semibold ${fontClass}`}>{opt}</span>
+                  {phase === 'checked' && isAnswer && (
+                    <svg width="18" height="18" viewBox="0 0 18 18" className="shrink-0 text-cream">
+                      <path d="M3 9 L7 13 L15 4" stroke="currentColor" strokeWidth="2.8" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        )}
+
+        {/* Type-in input */}
+        {current.type === 'type-in' && (
+          <div className="mt-6">
+            <input
+              className={`w-full bg-cream-tile border-[1.5px] rounded-xl px-4 py-4 font-semibold text-[17px] outline-none transition-all ${
+                phase === 'checked'
+                  ? isCurrentCorrect
+                    ? 'border-navy bg-navy/5 text-navy'
+                    : 'border-ruby bg-ruby/5 text-ruby'
+                  : 'border-jewelInk text-jewelInk focus:border-navy'
+              } ${current.direction === 'ru-to-ge' ? 'font-geo' : 'font-sans'}`}
+              style={{ boxShadow: phase === 'checked' ? 'none' : '3px 3px 0 #15100A' }}
+              placeholder={
+                current.direction === 'ge-to-ru' ? 'введи перевод...' : 'введи слово...'
+              }
+              value={typedAnswer}
+              onChange={(e) => setTypedAnswer(e.target.value)}
+              disabled={phase === 'checked'}
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && phase === 'answering') checkTypeIn()
+              }}
+            />
+          </div>
+        )}
+
+        {/* Feedback */}
         {phase === 'checked' && (
           <div
-            className={`mt-5 rounded-2xl p-4 ${
-              isCorrect ? 'bg-dog-green/15' : 'bg-dog-red/15'
+            className={`mt-6 p-4 border-[1.5px] rounded-xl ${
+              isCurrentCorrect
+                ? 'bg-navy border-jewelInk text-cream'
+                : 'bg-ruby border-jewelInk text-cream'
             }`}
+            style={{ boxShadow: '2px 2px 0 #15100A' }}
           >
-            <div className="font-extrabold">
-              {isCorrect ? '✓ Правильно!' : '✗ Правильный ответ:'}
+            <div className="font-sans text-[13px] font-extrabold uppercase tracking-wider mb-1 opacity-90">
+              {isCurrentCorrect ? 'верно' : 'правильный ответ'}
             </div>
-            {!isCorrect && (
-              <div className="mt-1 font-extrabold">{current.options[current.answerIndex]}</div>
-            )}
-            {current.explanation && (
-              <div className="text-sm mt-1 text-dog-ink/80">{current.explanation}</div>
+            {!isCurrentCorrect && (
+              <div
+                className={`text-[18px] font-bold ${
+                  current.direction === 'ru-to-ge' ? 'font-geo' : 'font-sans'
+                }`}
+              >
+                {current.correct}
+              </div>
             )}
           </div>
         )}
       </div>
 
+      {/* Action bar */}
       <div
-        className="fixed bottom-0 left-0 right-0 max-w-[480px] mx-auto px-4 pt-4 bg-dog-bg/95 backdrop-blur border-t border-dog-line"
+        className="fixed bottom-0 left-0 right-0 max-w-[480px] mx-auto px-5 pt-4 bg-cream/95 backdrop-blur-sm border-t border-jewelInk/15 z-20"
         style={{ paddingBottom: 'calc(var(--safe-b) + 16px)' }}
       >
         {phase === 'answering' ? (
-          <Button variant="green" disabled={selected === null} onClick={check}>
-            Проверить
-          </Button>
+          current.type === 'multi-choice' ? (
+            <Button
+              variant="primary"
+              disabled={selected === null}
+              onClick={checkMultiChoice}
+            >
+              проверить
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              disabled={!typedAnswer.trim()}
+              onClick={checkTypeIn}
+            >
+              проверить
+            </Button>
+          )
         ) : (
-          <Button variant={isCorrect ? 'green' : 'primary'} onClick={next}>
-            {index + 1 >= total ? 'Завершить' : 'Продолжить'}
+          <Button variant={isCurrentCorrect ? 'green' : 'primary'} onClick={next}>
+            {index + 1 >= total ? 'итог →' : 'дальше →'}
           </Button>
         )}
       </div>
@@ -241,11 +463,26 @@ export default function VocabularyPractice({ mode, wordIds, progress, setProgres
   )
 }
 
-function CenteredMascot({ mood, text }: { mood: 'think' | 'happy'; text: string }) {
+function FullScreen({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex flex-col min-h-full items-center justify-center gap-4">
-      <Mascot mood={mood} size={120} />
-      <div className="text-dog-muted">{text}</div>
+    <div
+      className="flex flex-col items-center justify-center bg-cream px-6 text-center gap-5"
+      style={{
+        minHeight: '100dvh',
+        paddingTop: 'calc(var(--safe-t) + 24px)',
+        paddingBottom: 'calc(var(--safe-b) + 24px)'
+      }}
+    >
+      {children}
     </div>
   )
+}
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr]
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
+  }
+  return a
 }

--- a/src/Trale/miniapp-src/src/screens/VocabularyPractice.tsx
+++ b/src/Trale/miniapp-src/src/screens/VocabularyPractice.tsx
@@ -70,7 +70,7 @@ export default function VocabularyPractice({ mode, wordIds, progress, setProgres
         <Mascot mood="sleep" size={120} />
         <div className="text-dog-muted">
           {phase === 'auth-required'
-            ? 'Открой мини-аб через кнопку «🎓 Грузинский» в Telegram-боте.'
+            ? 'Открой мини-апп через кнопку «🎓 Грузинский» в Telegram-боте.'
             : 'Что-то сломалось. Попробуй ещё раз.'}
         </div>
         <Button variant="ghost" onClick={() => navigate({ kind: 'dashboard' })}>

--- a/src/Trale/miniapp-src/tailwind.config.js
+++ b/src/Trale/miniapp-src/tailwind.config.js
@@ -4,29 +4,140 @@ export default {
   theme: {
     extend: {
       colors: {
-        dog: {
-          bg: '#FFF6E5',
-          accent: '#FF9B42',
-          accent2: '#FFB86B',
-          dark: '#1B1B2F',
-          ink: '#2E2E3A',
-          card: '#FFFFFF',
-          muted: '#8A8A9A',
-          line: '#F0E6D0',
-          green: '#58CC02',
-          red: '#E94F4F',
-          blue: '#3AB8FF',
-          gold: '#FFC800'
+        // ══════ Minanka palette (active — Georgian enamel jewels) ══════
+        cream: {
+          DEFAULT: '#FBF6EC',
+          deep: '#F5EFE0',
+          tile: '#FDFAEF',
+          edge: '#E8DEC5'
+        },
+        jewelInk: {
+          DEFAULT: '#15100A',
+          soft: '#3A2B1F',
+          mid: '#5A4735',
+          hint: '#7A6B52',
+          faint: '#B5A68B'
+        },
+        navy: {
+          DEFAULT: '#1B5FB0',
+          deep: '#0E3F7D',
+          light: '#3A7FCC',
+          wash: '#C9DBF0'
+        },
+        ruby: {
+          DEFAULT: '#E01A3C',
+          deep: '#A61026',
+          light: '#F0506C',
+          wash: '#F7D4DB'
+        },
+        gold: {
+          DEFAULT: '#F5B820',
+          deep: '#C68F10',
+          light: '#FCD76D',
+          wash: '#F9EAC1'
+        },
+
+        // ══════ Picture Book palette (legacy, kept alongside) ══════
+        peach: {
+          50: '#FDF6EA',
+          100: '#FBEAD6',
+          200: '#F6D9B6',
+          300: '#EFC598',
+          400: '#E6AE78'
+        },
+        warm: {
+          900: '#2A1F18',
+          800: '#3B2D23',
+          700: '#5A4735',
+          600: '#7A6654',
+          500: '#9E8670',
+          400: '#B5A28A'
+        },
+        coral: {
+          50: '#FDEEE6',
+          100: '#FBD9CC',
+          200: '#F6B49E',
+          400: '#EC8369',
+          500: '#E86B4E',
+          600: '#D4563B',
+          700: '#A8432C'
+        },
+        ochre: {
+          500: '#D99844',
+          600: '#B87B2F'
+        },
+        sage: {
+          100: '#E7EED9',
+          300: '#C1D0A5',
+          500: '#9BAE7B',
+          700: '#6F8454'
+        },
+
+        // ══════ Legacy sketchbook tokens (kept so non-redesigned screens still render) ══════
+        paper: {
+          DEFAULT: '#FBEAD6',
+          light: '#FDF6EA',
+          dark: '#F6D9B6',
+          edge: '#EFC598',
+          shade: '#E6AE78'
+        },
+        // Ink — warm near-black, used for text and line art
+        ink: {
+          DEFAULT: '#1A1612',
+          soft: '#3B2F25',
+          faint: '#6B5A48',
+          hint: '#9B8870'
+        },
+        // Wine — Georgian ceramic red, primary accent
+        wine: {
+          DEFAULT: '#A03A2C',
+          deep: '#7A2A20',
+          light: '#C25747',
+          wash: '#E8C9C4'
+        },
+        // Moss — secondary accent
+        moss: {
+          DEFAULT: '#4A6B3A',
+          deep: '#35502A',
+          light: '#6B8E55',
+          wash: '#CFDAC2'
+        },
+        // Saffron — highlight gold
+        saffron: {
+          DEFAULT: '#C9923A',
+          deep: '#A37626',
+          light: '#E0B055',
+          wash: '#F0E1BD'
+        },
+        // Sky — Tbilisi sky, tertiary
+        sky: {
+          DEFAULT: '#7A9CB8',
+          deep: '#5B7A94',
+          light: '#A3BDD1',
+          wash: '#D3E0EB'
         }
       },
       fontFamily: {
-        display: ['Nunito', 'system-ui', 'sans-serif']
+        sans: ['Manrope', 'Noto Sans Georgian', '-apple-system', 'BlinkMacSystemFont', 'system-ui', 'sans-serif'],
+        display: ['Manrope', 'Noto Sans Georgian', 'system-ui', 'sans-serif'],
+        body: ['Manrope', 'Noto Sans Georgian', '-apple-system', 'system-ui', 'sans-serif'],
+        hand: ['Fraunces', 'cursive'],
+        geo: ['Noto Sans Georgian', 'Noto Serif Georgian', 'Manrope', 'sans-serif']
       },
       boxShadow: {
-        card: '0 4px 0 #E5D5B0',
-        btn: '0 4px 0 #C87A2A',
-        btngreen: '0 4px 0 #46A300',
-        btnblue: '0 4px 0 #2A8FCC'
+        paper: '0 1px 0 rgba(26,22,18,0.08), 0 2px 10px rgba(26,22,18,0.04)',
+        card: '2px 3px 0 rgba(26,22,18,0.08), 0 4px 16px rgba(26,22,18,0.05)',
+        deep: '4px 6px 0 rgba(26,22,18,0.1), 0 8px 28px rgba(26,22,18,0.08)',
+        stamp: 'inset 0 0 0 2px currentColor',
+        inset: 'inset 0 1px 2px rgba(26,22,18,0.12)'
+      },
+      borderRadius: {
+        sketch: '1px',
+        card: '4px',
+        pill: '999px'
+      },
+      letterSpacing: {
+        grand: '0.12em'
       }
     }
   },


### PR DESCRIPTION
## Summary

Ports the Minankari design system across all screens, adds a 4-round vocabulary quiz matching the original bot flow, moves mini-app access from chat menu button to /menu inline keyboard, and makes the Dashboard hero dynamic.

## Design — Minankari (Georgian enamel)

- **Palette**: cream `#FBF6EC`, navy `#1B5FB0`, ruby `#E01A3C`, gold `#F5B820`, ink `#15100A`
- **Font**: Manrope (variable, 400-800) + Noto Sans Georgian fallback
- **Components**: `jewel-tile` (ink border + offset shadow + gold hairline), `jewel-btn` (pressable), `KilimProgress` (zigzag triangle progress bar), `LoaderLetter` (breathing Georgian letter ქ)
- **Kilim strip** at top/bottom of every screen as product signature
- All 9 screens redesigned: Dashboard, ModuleMap, LessonTheory, Practice, VocabularyPractice, Result, Profile, VocabularyList, LandingScreen

## Vocabulary quiz — 4 rounds

Like the original bot: multi-choice both directions, then type-in both directions.
1. Multi-choice GE→RU (show Georgian, pick Russian meaning)
2. Multi-choice RU→GE (show Russian, pick Georgian word)
3. Type-in GE→RU (show Georgian, type Russian)
4. Type-in RU→GE (show Russian, type Georgian)

Backend returns `wordPairs` + `allGeorgian` + `allRussian` distractor pools. Frontend builds all 4 exercise types from one response. 5 words × 4 rounds = 20 questions per session.

## Menu integration

- `SetChatMenuButton` now resets to `MenuButtonCommands` (standard command list)
- Mini-app button `InlineKeyboardButton.WithWebApp("🐶 Бомбора — учить грузинский")` added to `/menu` inline keyboard
- Only shown when `MiniAppEnabled=true`
- Both old menu and mini-app accessible without conflict

## Dynamic Dashboard

Hero section now computes personalized greeting based on:
- Progress (0 lessons → "Давай начнём", some → "Хорошо идёшь", all done → "Все пройдены")
- Streak (3+ days → praise)
- Days since last visit (>2 days → "Давно не виделись")
- Tappable "lesson of the day" card navigating to next incomplete lesson

## Other fixes

- Correct answer highlights navy (blue), wrong → ruby (red). Was reversed.
- Loader centered via `min-height: 100dvh` instead of `min-h-full`

## Test plan

- [ ] `/menu` shows "🐶 Бомбора" WebApp button when MiniAppEnabled=true
- [ ] Tapping it opens the mini-app in WebApp overlay
- [ ] Chat menu button shows standard command list (not WebApp)
- [ ] Dashboard shows dynamic greeting based on progress
- [ ] "Lesson of the day" card navigates to correct lesson
- [ ] Vocab quiz has 4 rounds (multi-choice both dirs + type-in both dirs)
- [ ] Type-in accepts correct answer case-insensitively
- [ ] Correct answer = navy, wrong = ruby in quiz feedback
- [ ] KilimProgress renders correctly for all module sizes
- [ ] All screens render in Minankari palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)