### PR TITLE
Owner-only admin panel: stats, signups chart, user detail, grant Pro

### DIFF
--- a/src/Application/Admin/GetAdminStatsQuery.cs
+++ b/src/Application/Admin/GetAdminStatsQuery.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Admin;
+
+/// <summary>
+/// Aggregated stats for the owner-only admin screen. Service (not MediatR) per ARCHITECTURE.md.
+/// </summary>
+public class GetAdminStatsQuery(ITraleDbContext db)
+{
+    public async Task<AdminStatsDto> ExecuteAsync(CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var d7 = now.AddDays(-7);
+        var d30 = now.AddDays(-30);
+
+        var users = db.Users;
+
+        var total = await users.CountAsync(ct);
+        var active = await users.CountAsync(u => u.IsActive, ct);
+        var pro = await users.CountAsync(u => u.IsPro, ct);
+
+        // Trial users = not Pro AND registered within trial window (30 days)
+        var trial = await users.CountAsync(u => !u.IsPro && u.RegisteredAtUtc >= d30, ct);
+
+        // Free (not pro, trial expired)
+        var free = await users.CountAsync(u => !u.IsPro && u.RegisteredAtUtc < d30, ct);
+
+        var newToday = await users.CountAsync(u => u.RegisteredAtUtc >= now.AddDays(-1), ct);
+        var newWeek = await users.CountAsync(u => u.RegisteredAtUtc >= d7, ct);
+        var newMonth = await users.CountAsync(u => u.RegisteredAtUtc >= d30, ct);
+
+        // Payments / revenue
+        var totalRevenue = await db.Payments
+            .Where(p => p.RefundedAtUtc == null)
+            .SumAsync(p => (long)p.Amount, ct);
+        var revenueWeek = await db.Payments
+            .Where(p => p.RefundedAtUtc == null && p.PurchasedAtUtc >= d7)
+            .SumAsync(p => (long)p.Amount, ct);
+        var purchases = await db.Payments.CountAsync(p => p.RefundedAtUtc == null, ct);
+        var refunds = await db.Payments.CountAsync(p => p.RefundedAtUtc != null, ct);
+
+        // Vocabulary
+        var totalVocab = await db.VocabularyEntries.CountAsync(ct);
+        var avgVocab = total > 0 ? Math.Round((double)totalVocab / total, 1) : 0;
+
+        // Conversion: how many users that exited trial bought Pro
+        var trialExited = await users.CountAsync(u => u.RegisteredAtUtc < d30, ct);
+        var trialExitedAndPaid = await users.CountAsync(u => u.RegisteredAtUtc < d30 && u.IsPro, ct);
+        var conversionPct = trialExited > 0
+            ? Math.Round((double)trialExitedAndPaid / trialExited * 100, 1)
+            : 0;
+
+        return new AdminStatsDto
+        {
+            TotalUsers = total,
+            ActiveUsers = active,
+            ProUsers = pro,
+            TrialUsers = trial,
+            FreeUsers = free,
+            NewUsersToday = newToday,
+            NewUsersWeek = newWeek,
+            NewUsersMonth = newMonth,
+            TotalRevenueStars = totalRevenue,
+            RevenueWeekStars = revenueWeek,
+            TotalPurchases = purchases,
+            TotalRefunds = refunds,
+            TotalVocabularyEntries = totalVocab,
+            AverageVocabularyPerUser = avgVocab,
+            ConversionPostTrialPct = conversionPct
+        };
+    }
+}
+
+public class AdminStatsDto
+{
+    public int TotalUsers { get; init; }
+    public int ActiveUsers { get; init; }
+    public int ProUsers { get; init; }
+    public int TrialUsers { get; init; }
+    public int FreeUsers { get; init; }
+
+    public int NewUsersToday { get; init; }
+    public int NewUsersWeek { get; init; }
+    public int NewUsersMonth { get; init; }
+
+    public long TotalRevenueStars { get; init; }
+    public long RevenueWeekStars { get; init; }
+    public int TotalPurchases { get; init; }
+    public int TotalRefunds { get; init; }
+
+    public int TotalVocabularyEntries { get; init; }
+    public double AverageVocabularyPerUser { get; init; }
+
+    public double ConversionPostTrialPct { get; init; }
+}

--- a/src/Application/Admin/GetRecentUsersQuery.cs
+++ b/src/Application/Admin/GetRecentUsersQuery.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Admin;
+
+/// <summary>
+/// Most-recent users for the admin overview table.
+/// </summary>
+public class GetRecentUsersQuery(ITraleDbContext db)
+{
+    public async Task<List<RecentUserDto>> ExecuteAsync(int limit, CancellationToken ct)
+    {
+        if (limit <= 0) limit = 20;
+        if (limit > 100) limit = 100;
+
+        var users = await db.Users
+            .OrderByDescending(u => u.RegisteredAtUtc)
+            .Take(limit)
+            .Select(u => new
+            {
+                u.Id,
+                u.TelegramId,
+                u.IsPro,
+                u.SubscriptionPlan,
+                u.SubscribedUntil,
+                u.RegisteredAtUtc,
+                u.ProPurchasedAtUtc,
+                VocabCount = db.VocabularyEntries.Count(v => v.UserId == u.Id)
+            })
+            .ToListAsync(ct);
+
+        return users.Select(u => new RecentUserDto
+        {
+            TelegramId = u.TelegramId,
+            IsPro = u.IsPro,
+            Plan = u.SubscriptionPlan?.ToString(),
+            SubscribedUntilUtc = u.SubscribedUntil,
+            RegisteredAtUtc = u.RegisteredAtUtc,
+            ProPurchasedAtUtc = u.ProPurchasedAtUtc,
+            VocabularyCount = u.VocabCount
+        }).ToList();
+    }
+}
+
+public class RecentUserDto
+{
+    public long TelegramId { get; init; }
+    public bool IsPro { get; init; }
+    public string? Plan { get; init; }
+    public DateTime? SubscribedUntilUtc { get; init; }
+    public DateTime RegisteredAtUtc { get; init; }
+    public DateTime? ProPurchasedAtUtc { get; init; }
+    public int VocabularyCount { get; init; }
+}

--- a/src/Application/Admin/GetUserDetailQuery.cs
+++ b/src/Application/Admin/GetUserDetailQuery.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Admin;
+
+public class GetUserDetailQuery(ITraleDbContext db)
+{
+    public async Task<UserDetailDto?> ExecuteAsync(long telegramId, CancellationToken ct)
+    {
+        var user = await db.Users
+            .Include(u => u.Settings)
+            .FirstOrDefaultAsync(u => u.TelegramId == telegramId, ct);
+
+        if (user == null) return null;
+
+        var vocabCount = await db.VocabularyEntries.CountAsync(v => v.UserId == user.Id, ct);
+
+        var payments = await db.Payments
+            .Where(p => p.UserId == user.Id)
+            .OrderByDescending(p => p.PurchasedAtUtc)
+            .Select(p => new PaymentDto
+            {
+                ChargeId = p.TelegramPaymentChargeId,
+                Plan = p.Plan.ToString(),
+                Amount = p.Amount,
+                Currency = p.Currency,
+                PurchasedAtUtc = p.PurchasedAtUtc,
+                RefundedAtUtc = p.RefundedAtUtc
+            })
+            .ToListAsync(ct);
+
+        var progress = await db.MiniAppUserProgresses
+            .FirstOrDefaultAsync(p => p.UserId == user.Id, ct);
+
+        // Last activity = max of progress.UpdatedAtUtc and latest vocab entry / quiz / payment
+        DateTime? lastActivity = null;
+        var lastVocab = await db.VocabularyEntries
+            .Where(v => v.UserId == user.Id)
+            .OrderByDescending(v => v.DateAddedUtc)
+            .Select(v => (DateTime?)v.DateAddedUtc)
+            .FirstOrDefaultAsync(ct);
+        if (lastVocab.HasValue) lastActivity = lastVocab.Value;
+        if (payments.Count > 0 && (!lastActivity.HasValue || payments[0].PurchasedAtUtc > lastActivity.Value))
+        {
+            lastActivity = payments[0].PurchasedAtUtc;
+        }
+
+        return new UserDetailDto
+        {
+            TelegramId = user.TelegramId,
+            UserId = user.Id,
+            IsPro = user.IsPro,
+            IsActive = user.IsActive,
+            SubscriptionPlan = user.SubscriptionPlan?.ToString(),
+            SubscribedUntilUtc = user.SubscribedUntil,
+            ProPurchasedAtUtc = user.ProPurchasedAtUtc,
+            RegisteredAtUtc = user.RegisteredAtUtc,
+            CurrentLanguage = user.Settings?.CurrentLanguage.ToString() ?? "Unknown",
+            VocabularyCount = vocabCount,
+            Xp = progress?.Xp ?? 0,
+            Streak = progress?.Streak ?? 0,
+            Level = progress?.Level ?? "n/a",
+            LastActivityUtc = lastActivity,
+            Payments = payments
+        };
+    }
+}
+
+public class UserDetailDto
+{
+    public long TelegramId { get; init; }
+    public Guid UserId { get; init; }
+    public bool IsPro { get; init; }
+    public bool IsActive { get; init; }
+    public string? SubscriptionPlan { get; init; }
+    public DateTime? SubscribedUntilUtc { get; init; }
+    public DateTime? ProPurchasedAtUtc { get; init; }
+    public DateTime RegisteredAtUtc { get; init; }
+    public string CurrentLanguage { get; init; } = "Unknown";
+    public int VocabularyCount { get; init; }
+    public int Xp { get; init; }
+    public int Streak { get; init; }
+    public string Level { get; init; } = "n/a";
+    public DateTime? LastActivityUtc { get; init; }
+    public List<PaymentDto> Payments { get; init; } = new();
+}
+
+public class PaymentDto
+{
+    public string ChargeId { get; init; } = string.Empty;
+    public string Plan { get; init; } = string.Empty;
+    public int Amount { get; init; }
+    public string Currency { get; init; } = string.Empty;
+    public DateTime PurchasedAtUtc { get; init; }
+    public DateTime? RefundedAtUtc { get; init; }
+}

--- a/src/Application/Admin/GetUserSignupsTimeseriesQuery.cs
+++ b/src/Application/Admin/GetUserSignupsTimeseriesQuery.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Admin;
+
+/// <summary>
+/// Daily new-user counts over a window (default 30 days). Used for the admin chart.
+/// </summary>
+public class GetUserSignupsTimeseriesQuery(ITraleDbContext db)
+{
+    public async Task<List<TimeseriesPointDto>> ExecuteAsync(int days, CancellationToken ct)
+    {
+        if (days <= 0) days = 30;
+        if (days > 365) days = 365;
+
+        var now = DateTime.UtcNow;
+        var since = now.Date.AddDays(-days + 1);
+
+        var rows = await db.Users
+            .Where(u => u.RegisteredAtUtc >= since)
+            .Select(u => u.RegisteredAtUtc)
+            .ToListAsync(ct);
+
+        // Bucket by date in C# to avoid Postgres date_trunc translation issues
+        var byDate = rows
+            .GroupBy(d => d.Date)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var points = new List<TimeseriesPointDto>(days);
+        for (var i = 0; i < days; i++)
+        {
+            var date = since.AddDays(i);
+            points.Add(new TimeseriesPointDto
+            {
+                Date = date.ToString("yyyy-MM-dd"),
+                Count = byDate.TryGetValue(date, out var c) ? c : 0
+            });
+        }
+        return points;
+    }
+}
+
+public class TimeseriesPointDto
+{
+    public string Date { get; init; } = string.Empty;
+    public int Count { get; init; }
+}

--- a/src/Application/Admin/GrantProService.cs
+++ b/src/Application/Admin/GrantProService.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common;
+using Application.MiniApp;
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Admin;
+
+/// <summary>
+/// Owner-only: grant Pro access to a user without payment (manual gift / promo / refund replacement).
+/// </summary>
+public class GrantProService(ITraleDbContext db, ILoggerFactory loggerFactory)
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<GrantProService>();
+
+    public async Task<GrantProResult> ExecuteAsync(long telegramId, string planName, CancellationToken ct)
+    {
+        if (!Enum.TryParse<SubscriptionPlan>(planName, true, out var plan))
+        {
+            return GrantProResult.InvalidPlan;
+        }
+
+        var planInfo = SubscriptionPlans.ByPlan(plan);
+        if (planInfo == null)
+        {
+            return GrantProResult.InvalidPlan;
+        }
+
+        var user = await db.Users.FirstOrDefaultAsync(u => u.TelegramId == telegramId, ct);
+        if (user == null)
+        {
+            return GrantProResult.UserNotFound;
+        }
+
+        var now = DateTime.UtcNow;
+        user.IsPro = true;
+        user.SubscriptionPlan = plan;
+        if (!user.ProPurchasedAtUtc.HasValue) user.ProPurchasedAtUtc = now;
+
+        if (plan == SubscriptionPlan.Lifetime)
+        {
+            user.SubscribedUntil = null;
+        }
+        else if (planInfo.DurationDays.HasValue)
+        {
+            var startFrom = user.SubscribedUntil.HasValue && user.SubscribedUntil.Value > now
+                ? user.SubscribedUntil.Value
+                : now;
+            user.SubscribedUntil = startFrom.AddDays(planInfo.DurationDays.Value);
+        }
+
+        await db.SaveChangesAsync(ct);
+
+        _logger.LogInformation("Admin granted Pro plan {Plan} to user {TelegramId} (until {Until})",
+            plan, telegramId, user.SubscribedUntil?.ToString("u") ?? "lifetime");
+
+        return GrantProResult.Success;
+    }
+}
+
+public enum GrantProResult
+{
+    Success,
+    UserNotFound,
+    InvalidPlan
+}
+
+public class RevokeProService(ITraleDbContext db, ILoggerFactory loggerFactory)
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<RevokeProService>();
+
+    public async Task<bool> ExecuteAsync(long telegramId, CancellationToken ct)
+    {
+        var user = await db.Users.FirstOrDefaultAsync(u => u.TelegramId == telegramId, ct);
+        if (user == null) return false;
+
+        user.IsPro = false;
+        user.SubscriptionPlan = null;
+        user.SubscribedUntil = null;
+        await db.SaveChangesAsync(ct);
+
+        _logger.LogInformation("Admin revoked Pro from user {TelegramId}", telegramId);
+        return true;
+    }
+}

--- a/src/Application/DependencyInjection.cs
+++ b/src/Application/DependencyInjection.cs
@@ -44,6 +44,9 @@ public static class DependencyInjection
         services.AddScoped<GetAdminStatsQuery>();
         services.AddScoped<GetUserSignupsTimeseriesQuery>();
         services.AddScoped<GetRecentUsersQuery>();
+        services.AddScoped<GetUserDetailQuery>();
+        services.AddScoped<GrantProService>();
+        services.AddScoped<RevokeProService>();
 
         return services;
     }

--- a/src/Application/DependencyInjection.cs
+++ b/src/Application/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Application.Achievements.Services;
+using Application.Admin;
 using Application.Achievements.Services.Checkers;
 using Application.Common.Interfaces.Achievements;
 using Application.Quizzes.Services;
@@ -38,6 +39,12 @@ public static class DependencyInjection
         services.AddScoped<IAchievementChecker<IAchievementTrigger>, EmeraldChecker>();
         services.AddScoped<IAchievementChecker<IAchievementTrigger>, MyselfVocabularyChecker>();
         services.AddTransient<IAchievementsService, AchievementsService>();
+
+        // Admin queries (services per ARCHITECTURE.md, no MediatR)
+        services.AddScoped<GetAdminStatsQuery>();
+        services.AddScoped<GetUserSignupsTimeseriesQuery>();
+        services.AddScoped<GetRecentUsersQuery>();
+
         return services;
     }
 }

--- a/src/Trale/Controllers/AdminController.cs
+++ b/src/Trale/Controllers/AdminController.cs
@@ -24,19 +24,28 @@ public class AdminController : Controller
     private readonly GetAdminStatsQuery _statsQuery;
     private readonly GetUserSignupsTimeseriesQuery _timeseriesQuery;
     private readonly GetRecentUsersQuery _recentUsersQuery;
+    private readonly GetUserDetailQuery _userDetailQuery;
+    private readonly GrantProService _grantPro;
+    private readonly RevokeProService _revokePro;
 
     public AdminController(
         ITraleDbContext dbContext,
         BotConfiguration botConfig,
         GetAdminStatsQuery statsQuery,
         GetUserSignupsTimeseriesQuery timeseriesQuery,
-        GetRecentUsersQuery recentUsersQuery)
+        GetRecentUsersQuery recentUsersQuery,
+        GetUserDetailQuery userDetailQuery,
+        GrantProService grantPro,
+        RevokeProService revokePro)
     {
         _dbContext = dbContext;
         _botConfig = botConfig;
         _statsQuery = statsQuery;
         _timeseriesQuery = timeseriesQuery;
         _recentUsersQuery = recentUsersQuery;
+        _userDetailQuery = userDetailQuery;
+        _grantPro = grantPro;
+        _revokePro = revokePro;
     }
 
     [HttpGet("stats")]
@@ -73,6 +82,42 @@ public class AdminController : Controller
 
         var users = await _recentUsersQuery.ExecuteAsync(limit, ct);
         return Ok(new { users });
+    }
+
+    [HttpGet("users/{telegramId:long}")]
+    public async Task<IActionResult> UserDetail(long telegramId, CancellationToken ct)
+    {
+        if (!await IsOwnerAsync(ct)) return NotFound();
+        var detail = await _userDetailQuery.ExecuteAsync(telegramId, ct);
+        if (detail == null) return NotFound();
+        return Ok(detail);
+    }
+
+    public class GrantProRequest
+    {
+        public string Plan { get; set; } = string.Empty;
+    }
+
+    [HttpPost("users/{telegramId:long}/grant-pro")]
+    public async Task<IActionResult> GrantPro(long telegramId, [FromBody] GrantProRequest req, CancellationToken ct)
+    {
+        if (!await IsOwnerAsync(ct)) return NotFound();
+        var result = await _grantPro.ExecuteAsync(telegramId, req.Plan, ct);
+        return result switch
+        {
+            GrantProResult.Success => Ok(new { ok = true }),
+            GrantProResult.UserNotFound => NotFound(new { error = "user_not_found" }),
+            GrantProResult.InvalidPlan => BadRequest(new { error = "invalid_plan" }),
+            _ => StatusCode(500)
+        };
+    }
+
+    [HttpPost("users/{telegramId:long}/revoke-pro")]
+    public async Task<IActionResult> RevokePro(long telegramId, CancellationToken ct)
+    {
+        if (!await IsOwnerAsync(ct)) return NotFound();
+        var ok = await _revokePro.ExecuteAsync(telegramId, ct);
+        return ok ? Ok(new { ok = true }) : NotFound(new { error = "user_not_found" });
     }
 
     /// <summary>

--- a/src/Trale/Controllers/AdminController.cs
+++ b/src/Trale/Controllers/AdminController.cs
@@ -1,0 +1,105 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Admin;
+using Application.Common;
+using Infrastructure.Telegram;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Trale.Services;
+
+namespace Trale.Controllers;
+
+[ApiController]
+[Route("api/admin")]
+public class AdminController : Controller
+{
+    private const string InitDataHeader = "X-Telegram-Init-Data";
+
+    // Hardcoded owner Telegram ID for now (matches GetMiniAppProfile.cs).
+    // BotConfiguration.OwnerTelegramId can override via env BOTCONFIGURATION__OWNERTELEGRAMID.
+    private const long DefaultOwnerTelegramId = 309149393;
+
+    private readonly ITraleDbContext _dbContext;
+    private readonly BotConfiguration _botConfig;
+    private readonly GetAdminStatsQuery _statsQuery;
+    private readonly GetUserSignupsTimeseriesQuery _timeseriesQuery;
+    private readonly GetRecentUsersQuery _recentUsersQuery;
+
+    public AdminController(
+        ITraleDbContext dbContext,
+        BotConfiguration botConfig,
+        GetAdminStatsQuery statsQuery,
+        GetUserSignupsTimeseriesQuery timeseriesQuery,
+        GetRecentUsersQuery recentUsersQuery)
+    {
+        _dbContext = dbContext;
+        _botConfig = botConfig;
+        _statsQuery = statsQuery;
+        _timeseriesQuery = timeseriesQuery;
+        _recentUsersQuery = recentUsersQuery;
+    }
+
+    [HttpGet("stats")]
+    public async Task<IActionResult> Stats(CancellationToken ct)
+    {
+        if (!await IsOwnerAsync(ct))
+        {
+            return NotFound(); // hide existence from non-owners
+        }
+
+        var stats = await _statsQuery.ExecuteAsync(ct);
+        return Ok(stats);
+    }
+
+    [HttpGet("signups")]
+    public async Task<IActionResult> Signups([FromQuery] int days = 30, CancellationToken ct = default)
+    {
+        if (!await IsOwnerAsync(ct))
+        {
+            return NotFound();
+        }
+
+        var points = await _timeseriesQuery.ExecuteAsync(days, ct);
+        return Ok(new { days, points });
+    }
+
+    [HttpGet("recent-users")]
+    public async Task<IActionResult> RecentUsers([FromQuery] int limit = 20, CancellationToken ct = default)
+    {
+        if (!await IsOwnerAsync(ct))
+        {
+            return NotFound();
+        }
+
+        var users = await _recentUsersQuery.ExecuteAsync(limit, ct);
+        return Ok(new { users });
+    }
+
+    /// <summary>
+    /// Returns true ONLY if the request is authenticated via X-Telegram-Init-Data
+    /// AND the verified Telegram ID matches the configured owner. Otherwise everything
+    /// returns 404 to avoid revealing the admin endpoints.
+    /// </summary>
+    private async Task<bool> IsOwnerAsync(CancellationToken ct)
+    {
+        var initData = Request.Headers.TryGetValue(InitDataHeader, out var values)
+            ? values.ToString()
+            : null;
+
+        var telegramId = TelegramInitDataValidator.ValidateAndGetUserId(initData, _botConfig.Token);
+        if (telegramId == null)
+        {
+            return false;
+        }
+
+        var ownerId = _botConfig.OwnerTelegramId != 0 ? _botConfig.OwnerTelegramId : DefaultOwnerTelegramId;
+        if (telegramId.Value != ownerId)
+        {
+            return false;
+        }
+
+        // Belt-and-suspenders: confirm the user exists in DB
+        var exists = await _dbContext.Users.AnyAsync(u => u.TelegramId == telegramId.Value, ct);
+        return exists;
+    }
+}

--- a/src/Trale/miniapp-src/src/App.tsx
+++ b/src/Trale/miniapp-src/src/App.tsx
@@ -11,6 +11,7 @@ import Result from './screens/Result'
 import MistakesResult from './screens/MistakesResult'
 import Profile from './screens/Profile'
 import AdminScreen from './screens/AdminScreen'
+import AdminUserScreen from './screens/AdminUserScreen'
 import VocabularyList from './screens/VocabularyList'
 import VocabularyPractice from './screens/VocabularyPractice'
 import LandingScreen from './screens/LandingScreen'
@@ -320,6 +321,8 @@ export default function App() {
       )
     case 'admin':
       return <AdminScreen progress={progress} navigate={navigate} />
+    case 'admin-user':
+      return <AdminUserScreen telegramId={screen.telegramId} progress={progress} navigate={navigate} />
     case 'vocabulary-list':
       return <VocabularyList progress={progress} navigate={navigate} />
     case 'vocabulary-quiz':

--- a/src/Trale/miniapp-src/src/App.tsx
+++ b/src/Trale/miniapp-src/src/App.tsx
@@ -10,6 +10,7 @@ import PracticeMistakes from './screens/PracticeMistakes'
 import Result from './screens/Result'
 import MistakesResult from './screens/MistakesResult'
 import Profile from './screens/Profile'
+import AdminScreen from './screens/AdminScreen'
 import VocabularyList from './screens/VocabularyList'
 import VocabularyPractice from './screens/VocabularyPractice'
 import LandingScreen from './screens/LandingScreen'
@@ -317,6 +318,8 @@ export default function App() {
           />
         </>
       )
+    case 'admin':
+      return <AdminScreen progress={progress} navigate={navigate} />
     case 'vocabulary-list':
       return <VocabularyList progress={progress} navigate={navigate} />
     case 'vocabulary-quiz':

--- a/src/Trale/miniapp-src/src/api.ts
+++ b/src/Trale/miniapp-src/src/api.ts
@@ -181,6 +181,17 @@ export const api = {
     ),
   adminRecentUsers: (limit = 20) =>
     request<{ users: AdminRecentUser[] }>(`/api/admin/recent-users?limit=${limit}`),
+  adminUserDetail: (telegramId: number) =>
+    request<AdminUserDetail>(`/api/admin/users/${telegramId}`),
+  adminGrantPro: (telegramId: number, plan: string) =>
+    request<{ ok: boolean }>(`/api/admin/users/${telegramId}/grant-pro`, {
+      method: 'POST',
+      body: JSON.stringify({ plan })
+    }),
+  adminRevokePro: (telegramId: number) =>
+    request<{ ok: boolean }>(`/api/admin/users/${telegramId}/revoke-pro`, {
+      method: 'POST'
+    }),
 
   lessonQuestions: (moduleId: string, lessonId: number) =>
     request<Array<{
@@ -230,4 +241,29 @@ export interface AdminRecentUser {
   registeredAtUtc: string
   proPurchasedAtUtc: string | null
   vocabularyCount: number
+}
+
+export interface AdminUserDetail {
+  telegramId: number
+  userId: string
+  isPro: boolean
+  isActive: boolean
+  subscriptionPlan: string | null
+  subscribedUntilUtc: string | null
+  proPurchasedAtUtc: string | null
+  registeredAtUtc: string
+  currentLanguage: string
+  vocabularyCount: number
+  xp: number
+  streak: number
+  level: string
+  lastActivityUtc: string | null
+  payments: Array<{
+    chargeId: string
+    plan: string
+    amount: number
+    currency: string
+    purchasedAtUtc: string
+    refundedAtUtc: string | null
+  }>
 }

--- a/src/Trale/miniapp-src/src/api.ts
+++ b/src/Trale/miniapp-src/src/api.ts
@@ -174,6 +174,14 @@ export const api = {
       body: JSON.stringify({ chargeId: chargeId ?? null })
     }),
 
+  adminStats: () => request<AdminStats>('/api/admin/stats'),
+  adminSignups: (days = 30) =>
+    request<{ days: number; points: Array<{ date: string; count: number }> }>(
+      `/api/admin/signups?days=${days}`
+    ),
+  adminRecentUsers: (limit = 20) =>
+    request<{ users: AdminRecentUser[] }>(`/api/admin/recent-users?limit=${limit}`),
+
   lessonQuestions: (moduleId: string, lessonId: number) =>
     request<Array<{
       id: string
@@ -194,4 +202,32 @@ export const api = {
       throw new ApiError(resp.status, await resp.text().catch(() => ''))
     }
   }
+}
+
+export interface AdminStats {
+  totalUsers: number
+  activeUsers: number
+  proUsers: number
+  trialUsers: number
+  freeUsers: number
+  newUsersToday: number
+  newUsersWeek: number
+  newUsersMonth: number
+  totalRevenueStars: number
+  revenueWeekStars: number
+  totalPurchases: number
+  totalRefunds: number
+  totalVocabularyEntries: number
+  averageVocabularyPerUser: number
+  conversionPostTrialPct: number
+}
+
+export interface AdminRecentUser {
+  telegramId: number
+  isPro: boolean
+  plan: string | null
+  subscribedUntilUtc: string | null
+  registeredAtUtc: string
+  proPurchasedAtUtc: string | null
+  vocabularyCount: number
 }

--- a/src/Trale/miniapp-src/src/screens/AdminScreen.tsx
+++ b/src/Trale/miniapp-src/src/screens/AdminScreen.tsx
@@ -1,0 +1,242 @@
+import React, { useEffect, useState } from 'react'
+import Header from '../components/Header'
+import LoaderLetter from '../components/LoaderLetter'
+import { ProgressState, Screen } from '../types'
+import { api, AdminStats, AdminRecentUser } from '../api'
+
+interface Props {
+  progress: ProgressState
+  navigate: (s: Screen) => void
+}
+
+type Phase = 'loading' | 'ready' | 'forbidden' | 'error'
+
+export default function AdminScreen({ progress, navigate }: Props) {
+  const [phase, setPhase] = useState<Phase>('loading')
+  const [stats, setStats] = useState<AdminStats | null>(null)
+  const [signups, setSignups] = useState<{ date: string; count: number }[]>([])
+  const [users, setUsers] = useState<AdminRecentUser[]>([])
+  const [days, setDays] = useState<7 | 30 | 90>(30)
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.all([api.adminStats(), api.adminSignups(days), api.adminRecentUsers(20)])
+      .then(([s, sig, rec]) => {
+        if (cancelled) return
+        setStats(s)
+        setSignups(sig.points)
+        setUsers(rec.users)
+        setPhase('ready')
+      })
+      .catch((e: any) => {
+        if (cancelled) return
+        if (e?.status === 404) setPhase('forbidden')
+        else setPhase('error')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [days])
+
+  return (
+    <div className="flex flex-col min-h-full bg-cream">
+      <Header
+        progress={progress}
+        onBack={() => navigate({ kind: 'profile' })}
+        eyebrow="owner"
+        title="Admin"
+      />
+
+      <div
+        className="flex-1 px-5 pt-4"
+        style={{ paddingBottom: 'calc(var(--safe-b) + 32px)' }}
+      >
+        {phase === 'loading' && (
+          <div className="flex flex-col items-center gap-2 py-12">
+            <LoaderLetter />
+            <div className="font-sans text-[13px] text-jewelInk-mid">Загружаем статистику…</div>
+          </div>
+        )}
+
+        {phase === 'forbidden' && (
+          <div className="jewel-tile px-5 py-6 text-center">
+            <div className="relative z-[1] font-sans text-[14px] text-jewelInk">
+              Эта страница доступна только владельцу.
+            </div>
+          </div>
+        )}
+
+        {phase === 'error' && (
+          <div className="jewel-tile px-5 py-6 text-center">
+            <div className="relative z-[1] font-sans text-[14px] text-jewelInk">
+              Не получилось загрузить. Попробуй обновить страницу.
+            </div>
+          </div>
+        )}
+
+        {phase === 'ready' && stats && (
+          <>
+            {/* KPIs row 1: users */}
+            <div className="mn-eyebrow mb-2">Пользователи</div>
+            <div className="grid grid-cols-2 gap-2 mb-5">
+              <Tile label="Всего" value={fmt(stats.totalUsers)} />
+              <Tile label="Активных" value={fmt(stats.activeUsers)} />
+              <Tile label="Pro" value={fmt(stats.proUsers)} accent="ruby" />
+              <Tile label="На триале" value={fmt(stats.trialUsers)} accent="navy" />
+              <Tile label="Free" value={fmt(stats.freeUsers)} />
+              <Tile label="Конверсия" value={`${stats.conversionPostTrialPct}%`} accent="gold" />
+            </div>
+
+            {/* KPIs row 2: revenue */}
+            <div className="mn-eyebrow mb-2">Выручка</div>
+            <div className="grid grid-cols-2 gap-2 mb-5">
+              <Tile label="Всего ⭐" value={fmt(stats.totalRevenueStars)} accent="gold" />
+              <Tile label="За неделю ⭐" value={fmt(stats.revenueWeekStars)} accent="gold" />
+              <Tile label="Покупок" value={fmt(stats.totalPurchases)} />
+              <Tile label="Возвратов" value={fmt(stats.totalRefunds)} />
+            </div>
+
+            {/* KPIs row 3: engagement */}
+            <div className="mn-eyebrow mb-2">Активность</div>
+            <div className="grid grid-cols-2 gap-2 mb-5">
+              <Tile label="Слов в словарях" value={fmt(stats.totalVocabularyEntries)} />
+              <Tile label="Слов на юзера" value={`${stats.averageVocabularyPerUser}`} />
+              <Tile label="Новых сегодня" value={fmt(stats.newUsersToday)} />
+              <Tile label="За неделю" value={fmt(stats.newUsersWeek)} />
+            </div>
+
+            {/* Signups chart */}
+            <div className="flex items-center justify-between mb-2">
+              <div className="mn-eyebrow">Новые юзеры</div>
+              <div className="flex gap-1">
+                {([7, 30, 90] as const).map((d) => (
+                  <button
+                    key={d}
+                    onClick={() => setDays(d)}
+                    className={`px-2 py-1 rounded font-sans text-[11px] font-bold border-[1.5px] ${
+                      days === d
+                        ? 'bg-jewelInk text-cream border-jewelInk'
+                        : 'bg-cream text-jewelInk-mid border-jewelInk/25'
+                    }`}
+                  >
+                    {d}д
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="jewel-tile px-3 py-3 mb-5">
+              <div className="relative z-[1]">
+                <SignupsChart points={signups} />
+              </div>
+            </div>
+
+            {/* Recent users */}
+            <div className="mn-eyebrow mb-2">Последние юзеры ({users.length})</div>
+            <div className="flex flex-col gap-2">
+              {users.map((u) => (
+                <UserRow key={u.telegramId} u={u} />
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function fmt(n: number): string {
+  return n.toLocaleString('ru-RU')
+}
+
+function Tile({
+  label,
+  value,
+  accent,
+}: {
+  label: string
+  value: string
+  accent?: 'navy' | 'ruby' | 'gold'
+}) {
+  const accentText =
+    accent === 'navy'
+      ? 'text-navy'
+      : accent === 'ruby'
+        ? 'text-ruby'
+        : accent === 'gold'
+          ? 'text-gold-deep'
+          : 'text-jewelInk'
+  return (
+    <div className="jewel-tile px-3 py-3">
+      <div className="relative z-[1]">
+        <div className="mn-eyebrow text-jewelInk-mid mb-1">{label}</div>
+        <div className={`font-sans text-[20px] font-extrabold tabular-nums leading-none ${accentText}`}>
+          {value}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SignupsChart({ points }: { points: { date: string; count: number }[] }) {
+  if (points.length === 0) return <div className="text-center text-jewelInk-mid font-sans text-[12px]">нет данных</div>
+  const w = 320
+  const h = 120
+  const max = Math.max(1, ...points.map((p) => p.count))
+  const barW = w / points.length
+  const total = points.reduce((sum, p) => sum + p.count, 0)
+  return (
+    <div>
+      <svg viewBox={`0 0 ${w} ${h}`} width="100%" height={h} preserveAspectRatio="none">
+        {points.map((p, i) => {
+          const barH = (p.count / max) * (h - 16)
+          const x = i * barW + barW * 0.15
+          const bw = barW * 0.7
+          return (
+            <rect
+              key={p.date}
+              x={x}
+              y={h - barH}
+              width={bw}
+              height={barH}
+              fill="#0d4a6e"
+              rx="1.5"
+            />
+          )
+        })}
+      </svg>
+      <div className="mt-1 flex justify-between font-sans text-[10px] text-jewelInk-mid">
+        <span>{points[0]?.date}</span>
+        <span className="font-bold">всего: {fmt(total)}</span>
+        <span>{points[points.length - 1]?.date}</span>
+      </div>
+    </div>
+  )
+}
+
+function UserRow({ u }: { u: AdminRecentUser }) {
+  const reg = new Date(u.registeredAtUtc)
+  const regStr = reg.toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: '2-digit' })
+  return (
+    <div className="jewel-tile px-3 py-2 flex items-center gap-3">
+      <div className="relative z-[1] flex-1 min-w-0">
+        <div className="font-sans text-[12px] font-extrabold text-jewelInk tabular-nums">
+          {u.telegramId}
+        </div>
+        <div className="font-sans text-[10px] text-jewelInk-mid">
+          рег: {regStr} · 📖 {u.vocabularyCount}
+        </div>
+      </div>
+      {u.isPro ? (
+        <span
+          className="relative z-[1] shrink-0 px-2 py-0.5 rounded font-sans text-[10px] font-extrabold bg-gold text-jewelInk border border-jewelInk"
+        >
+          ⭐ {u.plan ?? 'Pro'}
+        </span>
+      ) : (
+        <span className="relative z-[1] shrink-0 px-2 py-0.5 rounded font-sans text-[10px] font-bold text-jewelInk-mid border border-jewelInk/25">
+          free
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/Trale/miniapp-src/src/screens/AdminScreen.tsx
+++ b/src/Trale/miniapp-src/src/screens/AdminScreen.tsx
@@ -134,7 +134,11 @@ export default function AdminScreen({ progress, navigate }: Props) {
             <div className="mn-eyebrow mb-2">Последние юзеры ({users.length})</div>
             <div className="flex flex-col gap-2">
               {users.map((u) => (
-                <UserRow key={u.telegramId} u={u} />
+                <UserRow
+                  key={u.telegramId}
+                  u={u}
+                  onClick={() => navigate({ kind: 'admin-user', telegramId: u.telegramId })}
+                />
               ))}
             </div>
           </>
@@ -213,11 +217,14 @@ function SignupsChart({ points }: { points: { date: string; count: number }[] })
   )
 }
 
-function UserRow({ u }: { u: AdminRecentUser }) {
+function UserRow({ u, onClick }: { u: AdminRecentUser; onClick: () => void }) {
   const reg = new Date(u.registeredAtUtc)
   const regStr = reg.toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: '2-digit' })
   return (
-    <div className="jewel-tile px-3 py-2 flex items-center gap-3">
+    <button
+      onClick={onClick}
+      className="jewel-tile jewel-pressable text-left px-3 py-2 flex items-center gap-3 w-full"
+    >
       <div className="relative z-[1] flex-1 min-w-0">
         <div className="font-sans text-[12px] font-extrabold text-jewelInk tabular-nums">
           {u.telegramId}
@@ -237,6 +244,7 @@ function UserRow({ u }: { u: AdminRecentUser }) {
           free
         </span>
       )}
-    </div>
+      <span className="relative z-[1] text-jewelInk-hint text-[12px] shrink-0">→</span>
+    </button>
   )
 }

--- a/src/Trale/miniapp-src/src/screens/AdminUserScreen.tsx
+++ b/src/Trale/miniapp-src/src/screens/AdminUserScreen.tsx
@@ -1,0 +1,265 @@
+import React, { useEffect, useState } from 'react'
+import Header from '../components/Header'
+import LoaderLetter from '../components/LoaderLetter'
+import { ProgressState, Screen } from '../types'
+import { api, AdminUserDetail } from '../api'
+
+interface Props {
+  telegramId: number
+  progress: ProgressState
+  navigate: (s: Screen) => void
+}
+
+const PLANS = [
+  { id: 'Month', label: '1 мес' },
+  { id: 'Quarter', label: '3 мес' },
+  { id: 'HalfYear', label: '6 мес' },
+  { id: 'Year', label: '1 год' },
+  { id: 'Lifetime', label: 'Навсегда' }
+]
+
+export default function AdminUserScreen({ telegramId, progress, navigate }: Props) {
+  const [phase, setPhase] = useState<'loading' | 'ready' | 'error' | 'forbidden'>('loading')
+  const [user, setUser] = useState<AdminUserDetail | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [toast, setToast] = useState<string | null>(null)
+
+  function load() {
+    setPhase('loading')
+    api
+      .adminUserDetail(telegramId)
+      .then((u) => {
+        setUser(u)
+        setPhase('ready')
+      })
+      .catch((e: any) => {
+        if (e?.status === 404) setPhase('forbidden')
+        else setPhase('error')
+      })
+  }
+
+  useEffect(() => {
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [telegramId])
+
+  function showToast(msg: string) {
+    setToast(msg)
+    setTimeout(() => setToast(null), 1800)
+  }
+
+  async function grant(plan: string) {
+    if (!confirm(`Выдать ${plan}?`)) return
+    setBusy(true)
+    try {
+      await api.adminGrantPro(telegramId, plan)
+      showToast(`✓ Выдано: ${plan}`)
+      load()
+    } catch {
+      showToast('✗ Ошибка')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function revoke() {
+    if (!confirm('Отозвать Pro?')) return
+    setBusy(true)
+    try {
+      await api.adminRevokePro(telegramId)
+      showToast('✓ Pro отозван')
+      load()
+    } catch {
+      showToast('✗ Ошибка')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col min-h-full bg-cream">
+      <Header
+        progress={progress}
+        onBack={() => navigate({ kind: 'admin' })}
+        eyebrow="admin · user"
+        title={`#${telegramId}`}
+      />
+
+      <div
+        className="flex-1 px-5 pt-4"
+        style={{ paddingBottom: 'calc(var(--safe-b) + 32px)' }}
+      >
+        {phase === 'loading' && (
+          <div className="flex flex-col items-center gap-2 py-12">
+            <LoaderLetter />
+            <div className="font-sans text-[13px] text-jewelInk-mid">Загружаем…</div>
+          </div>
+        )}
+
+        {phase === 'forbidden' && (
+          <div className="jewel-tile px-5 py-6 text-center">
+            <div className="relative z-[1] font-sans text-[14px] text-jewelInk">
+              Доступ только владельцу.
+            </div>
+          </div>
+        )}
+
+        {phase === 'error' && (
+          <div className="jewel-tile px-5 py-6 text-center">
+            <div className="relative z-[1] font-sans text-[14px] text-jewelInk">
+              Не получилось загрузить.
+            </div>
+          </div>
+        )}
+
+        {phase === 'ready' && user && (
+          <>
+            {/* Status card */}
+            <div className="jewel-tile px-4 py-4 mb-5">
+              <div className="relative z-[1]">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="font-sans text-[14px] font-bold text-jewelInk">
+                    Статус: {user.isActive ? 'активен' : 'неактивен'}
+                  </div>
+                  {user.isPro ? (
+                    <span className="px-2 py-0.5 rounded font-sans text-[11px] font-extrabold bg-gold text-jewelInk border border-jewelInk">
+                      ⭐ {user.subscriptionPlan ?? 'Pro'}
+                    </span>
+                  ) : (
+                    <span className="px-2 py-0.5 rounded font-sans text-[11px] font-bold text-jewelInk-mid border border-jewelInk/25">
+                      free
+                    </span>
+                  )}
+                </div>
+                <div className="font-sans text-[12px] text-jewelInk-mid leading-relaxed">
+                  Регистрация: {fmtDate(user.registeredAtUtc)}
+                  {user.proPurchasedAtUtc && <><br />Pro куплен: {fmtDate(user.proPurchasedAtUtc)}</>}
+                  {user.subscribedUntilUtc && <><br />Действует до: {fmtDate(user.subscribedUntilUtc)}</>}
+                  {user.subscriptionPlan === 'Lifetime' && <><br />Lifetime — без срока</>}
+                  <br />Язык: {user.currentLanguage}
+                  <br />Последняя активность: {user.lastActivityUtc ? fmtDate(user.lastActivityUtc) : '—'}
+                </div>
+              </div>
+            </div>
+
+            {/* Activity tiles */}
+            <div className="grid grid-cols-2 gap-2 mb-5">
+              <Tile label="XP" value={fmt(user.xp)} accent="navy" />
+              <Tile label="Стрик" value={`${user.streak}`} accent="ruby" />
+              <Tile label="Слов" value={fmt(user.vocabularyCount)} accent="gold" />
+              <Tile label="Уровень" value={user.level} />
+            </div>
+
+            {/* Grant Pro */}
+            <div className="mn-eyebrow mb-2">Выдать Pro</div>
+            <div className="grid grid-cols-3 gap-2 mb-3">
+              {PLANS.map((p) => (
+                <button
+                  key={p.id}
+                  onClick={() => grant(p.id)}
+                  disabled={busy}
+                  className="font-sans text-[12px] font-extrabold py-2 rounded border-[1.5px] border-jewelInk bg-cream active:opacity-70"
+                  style={{ boxShadow: '0 2px 0 #15100A' }}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+
+            {/* Revoke */}
+            {user.isPro && (
+              <button
+                onClick={revoke}
+                disabled={busy}
+                className="w-full font-sans text-[12px] font-bold text-ruby py-2 underline opacity-70 active:opacity-100 mb-5"
+              >
+                Отозвать Pro
+              </button>
+            )}
+
+            {/* Payments */}
+            {user.payments.length > 0 && (
+              <>
+                <div className="mn-eyebrow mb-2">Платежи ({user.payments.length})</div>
+                <div className="flex flex-col gap-2">
+                  {user.payments.map((p) => (
+                    <div
+                      key={p.chargeId}
+                      className={`jewel-tile px-3 py-2 ${p.refundedAtUtc ? 'opacity-50' : ''}`}
+                    >
+                      <div className="relative z-[1] flex items-center justify-between gap-3">
+                        <div className="flex-1 min-w-0">
+                          <div className="font-sans text-[12px] font-bold text-jewelInk">
+                            {p.plan} · {p.amount} {p.currency === 'XTR' ? '⭐' : p.currency}
+                          </div>
+                          <div className="font-sans text-[10px] text-jewelInk-mid">
+                            {fmtDate(p.purchasedAtUtc)}
+                            {p.refundedAtUtc && ` · возвращён ${fmtDate(p.refundedAtUtc)}`}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </>
+        )}
+
+        {toast && (
+          <div
+            className="fixed left-1/2 bottom-[80px] -translate-x-1/2 z-50 bg-jewelInk text-cream font-sans text-[13px] font-bold px-4 py-2 rounded-lg border-[1.5px] border-jewelInk"
+            style={{ boxShadow: '2px 2px 0 #15100A' }}
+          >
+            {toast}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function fmt(n: number): string {
+  return n.toLocaleString('ru-RU')
+}
+
+function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+}
+
+function Tile({
+  label,
+  value,
+  accent
+}: {
+  label: string
+  value: string
+  accent?: 'navy' | 'ruby' | 'gold'
+}) {
+  const accentText =
+    accent === 'navy'
+      ? 'text-navy'
+      : accent === 'ruby'
+        ? 'text-ruby'
+        : accent === 'gold'
+          ? 'text-gold-deep'
+          : 'text-jewelInk'
+  return (
+    <div className="jewel-tile px-3 py-3">
+      <div className="relative z-[1]">
+        <div className="mn-eyebrow text-jewelInk-mid mb-1">{label}</div>
+        <div
+          className={`font-sans text-[20px] font-extrabold tabular-nums leading-none ${accentText}`}
+        >
+          {value}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/Trale/miniapp-src/src/screens/Profile.tsx
+++ b/src/Trale/miniapp-src/src/screens/Profile.tsx
@@ -201,6 +201,24 @@ export default function Profile({ catalog, progress, isPro, isOwner = false, onP
           <a href="/terms.html" target="_blank" rel="noopener" className="underline">Условия</a>
         </div>
 
+        {/* Admin entry (owner only) */}
+        {isOwner && (
+          <button
+            onClick={() => navigate({ kind: 'admin' })}
+            className="mt-6 jewel-tile jewel-pressable w-full text-left px-4 py-4"
+          >
+            <div className="relative z-[1] flex items-center justify-between gap-3">
+              <div>
+                <div className="font-sans text-[15px] font-bold text-jewelInk">📊 Админка</div>
+                <div className="font-sans text-[12px] text-jewelInk-mid mt-0.5">
+                  Аналитика по пользователям и выручке
+                </div>
+              </div>
+              <span className="text-jewelInk-hint text-[14px] shrink-0">→</span>
+            </div>
+          </button>
+        )}
+
         {/* Debug tools (owner only) */}
         {isOwner && <OwnerDebugPanel />}
 

--- a/src/Trale/miniapp-src/src/types.ts
+++ b/src/Trale/miniapp-src/src/types.ts
@@ -24,6 +24,7 @@ export type Screen =
       remainingWrong: QuizQuestion[]
     }
   | { kind: 'profile' }
+  | { kind: 'admin' }
   | { kind: 'vocabulary-list' }
   | { kind: 'vocabulary-quiz'; mode: 'all' | 'new' | 'weak' | 'custom' | 'starter'; wordIds?: string[] }
 

--- a/src/Trale/miniapp-src/src/types.ts
+++ b/src/Trale/miniapp-src/src/types.ts
@@ -25,6 +25,7 @@ export type Screen =
     }
   | { kind: 'profile' }
   | { kind: 'admin' }
+  | { kind: 'admin-user'; telegramId: number }
   | { kind: 'vocabulary-list' }
   | { kind: 'vocabulary-quiz'; mode: 'all' | 'new' | 'weak' | 'custom' | 'starter'; wordIds?: string[] }
 

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,8 +46,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>Бомбора — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-B-UQUYsq.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DPqHSsIM.css">
+    <script type="module" crossorigin src="/assets/index-qeQnKa9R.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BhHY12sy.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,7 +46,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>Бомбора — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-BN15vUMZ.js"></script>
+    <script type="module" crossorigin src="/assets/index-B-UQUYsq.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DPqHSsIM.css">
   </head>
   <body>


### PR DESCRIPTION
## Summary

Owner-only admin screen accessible from Profile (visible only when `isOwner`). All `/api/admin/*` endpoints return 404 for non-owners.

## Backend
- `GET /api/admin/stats` — KPIs (users by tier, revenue stars, conversion %, vocab stats)
- `GET /api/admin/signups?days=7|30|90` — daily new-user counts for chart
- `GET /api/admin/recent-users?limit=N` — newest users with subscription status
- `GET /api/admin/users/{telegramId}` — full user detail (status, XP, streak, vocab, last activity, payment history)
- `POST /api/admin/users/{telegramId}/grant-pro` — gift Pro on any plan
- `POST /api/admin/users/{telegramId}/revoke-pro` — remove Pro

Owner check: validates `X-Telegram-Init-Data` header against `BotConfiguration.OwnerTelegramId` (defaults to `309149393`). Belt-and-suspenders: confirms user exists in DB.

All queries are services per ARCHITECTURE.md (no MediatR):
- `GetAdminStatsQuery`, `GetUserSignupsTimeseriesQuery`, `GetRecentUsersQuery`, `GetUserDetailQuery`, `GrantProService`, `RevokeProService`.

## Frontend
- `AdminScreen` — KPI tiles, SVG bar chart for signups (7/30/90d switchable), recent users list (clickable rows)
- `AdminUserScreen` — status card, XP/streak/vocab/level tiles, plan grant grid (1m/3m/6m/1y/Lifetime), revoke button, payment history
- Entry button on Profile, visible only when `isOwner`
- New routes: `{ kind: 'admin' }`, `{ kind: 'admin-user'; telegramId }`

## Test plan
- [x] Backend builds, all 66 tests pass
- [x] Frontend builds clean
- [x] /api/admin/stats and /api/admin/users/* return 404 without valid Telegram initData
- [ ] Open Profile → 📊 Админка as owner → see stats
- [ ] Click on a user → see detail → grant/revoke Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)