### PR TITLE
Profile rework: streak heatmap, phrase of day, no Dashboard duplication

### DIFF
--- a/src/Application/DependencyInjection.cs
+++ b/src/Application/DependencyInjection.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Application.Achievements.Services;
 using Application.Achievements.Services.Checkers;
 using Application.Common.Interfaces.Achievements;
+using Application.MiniApp.Queries;
 using Application.Quizzes.Services;
 using Application.Translation;
 using Application.Translation.Languages;
@@ -38,6 +39,10 @@ public static class DependencyInjection
         services.AddScoped<IAchievementChecker<IAchievementTrigger>, EmeraldChecker>();
         services.AddScoped<IAchievementChecker<IAchievementTrigger>, MyselfVocabularyChecker>();
         services.AddTransient<IAchievementsService, AchievementsService>();
+
+        // MiniApp queries (services per ARCHITECTURE.md)
+        services.AddScoped<GetActivityDaysQuery>();
+
         return services;
     }
 }

--- a/src/Application/MiniApp/Queries/GetActivityDaysQuery.cs
+++ b/src/Application/MiniApp/Queries/GetActivityDaysQuery.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.MiniApp.Queries;
+
+/// <summary>
+/// Activity days for the user's profile streak heatmap.
+/// "Active" = added at least one vocabulary entry that day. Service per ARCHITECTURE.md.
+/// </summary>
+public class GetActivityDaysQuery(ITraleDbContext db)
+{
+    public async Task<List<string>> ExecuteAsync(Guid userId, int days, CancellationToken ct)
+    {
+        if (days <= 0) days = 30;
+        if (days > 365) days = 365;
+
+        var since = DateTime.UtcNow.Date.AddDays(-days + 1);
+
+        var dates = await db.VocabularyEntries
+            .Where(v => v.UserId == userId && v.DateAddedUtc >= since)
+            .Select(v => v.DateAddedUtc)
+            .ToListAsync(ct);
+
+        return dates
+            .Select(d => d.Date)
+            .Distinct()
+            .OrderBy(d => d)
+            .Select(d => d.ToString("yyyy-MM-dd"))
+            .ToList();
+    }
+}

--- a/src/Trale/Controllers/MiniAppController.cs
+++ b/src/Trale/Controllers/MiniAppController.cs
@@ -336,6 +336,22 @@ public class MiniAppController : Controller
         });
     }
 
+    [HttpGet("activity-days")]
+    public async Task<IActionResult> ActivityDays(
+        [FromQuery] int days,
+        [FromServices] Application.MiniApp.Queries.GetActivityDaysQuery query,
+        CancellationToken ct)
+    {
+        var user = await ResolveUserAsync(ct);
+        if (user == null)
+        {
+            return Unauthorized(new { error = "not_authenticated" });
+        }
+
+        var dates = await query.ExecuteAsync(user.Id, days <= 0 ? 35 : days, ct);
+        return Ok(new { dates });
+    }
+
     [HttpGet("vocabulary")]
     public async Task<IActionResult> GetVocabulary(CancellationToken ct)
     {

--- a/src/Trale/miniapp-src/src/api.ts
+++ b/src/Trale/miniapp-src/src/api.ts
@@ -174,6 +174,9 @@ export const api = {
       body: JSON.stringify({ chargeId: chargeId ?? null })
     }),
 
+  activityDays: (days = 35) =>
+    request<{ dates: string[] }>(`/api/miniapp/activity-days?days=${days}`),
+
   lessonQuestions: (moduleId: string, lessonId: number) =>
     request<Array<{
       id: string

--- a/src/Trale/miniapp-src/src/screens/Profile.tsx
+++ b/src/Trale/miniapp-src/src/screens/Profile.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import Header from '../components/Header'
 import Mascot from '../components/Mascot'
-import KilimProgress from '../components/KilimProgress'
 import ProPaywall from '../components/ProPaywall'
 import { CatalogDto, ProgressState, Screen } from '../types'
 import { api } from '../api'
@@ -16,14 +15,73 @@ interface Props {
   navigate: (s: Screen) => void
 }
 
+// Phrase of the day — small daily learning hit on the Profile screen.
+const DAILY_PHRASES: { ge: string; ru: string; hint: string }[] = [
+  { ge: 'როგორ ხარ?', ru: 'Как дела?', hint: 'Самый частый вопрос на улице' },
+  { ge: 'მადლობა', ru: 'Спасибо', hint: 'Можно сократить до მადლი' },
+  { ge: 'არაფერი', ru: 'Не за что', hint: 'Дословно — «ничего»' },
+  { ge: 'ყავა, თუ შეიძლება', ru: 'Кофе, если можно', hint: 'Вежливая просьба' },
+  { ge: 'ნახვამდის', ru: 'До свидания', hint: 'Дословно — «до встречи»' },
+  { ge: 'ბოდიში', ru: 'Извини / простите', hint: 'Универсальное' },
+  { ge: 'რამდენი ღირს?', ru: 'Сколько стоит?', hint: 'На рынке и в такси' },
+  { ge: 'მე მიყვარს', ru: 'Я люблю', hint: 'Дательный: «мне любится»' },
+  { ge: 'სუპერ!', ru: 'Супер!', hint: 'Заимствование, но звучит по-грузински' },
+  { ge: 'წადი', ru: 'Иди / поехали', hint: 'Императив от წავიდე' },
+  { ge: 'რა გქვია?', ru: 'Как тебя зовут?', hint: 'Дословно — «как тебе называется»' },
+  { ge: 'აქ', ru: 'Здесь', hint: 'Минимум — два звука' },
+  { ge: 'იქ', ru: 'Там', hint: 'И тоже два звука' },
+  { ge: 'კარგია', ru: 'Хорошо', hint: 'Дословно — «есть хорошее»' },
+]
+
+function pickDailyPhrase(): { ge: string; ru: string; hint: string } {
+  const day = Math.floor(Date.now() / (1000 * 60 * 60 * 24))
+  return DAILY_PHRASES[day % DAILY_PHRASES.length]
+}
+
+function pickEncouragement(streak: number, totalLessons: number): string {
+  if (streak >= 7) return `🔥 Стрик ${streak} дн — ты уже привычка!`
+  if (streak >= 3) return `Третий день подряд — продолжай.`
+  if (totalLessons === 0) return `Открой первый урок — алфавит ждёт.`
+  if (totalLessons < 5) return `Уже несколько уроков. Ещё чуть-чуть — и почувствуешь язык.`
+  if (totalLessons < 20) return `Половина пути. Грамматика начинает складываться.`
+  return `Ты уже знаешь много. Бомбора гордится.`
+}
+
 export default function Profile({ catalog, progress, isPro, isOwner = false, onPurchaseSuccess, navigate }: Props) {
   const [showPaywall, setShowPaywall] = useState(false)
+  const [activityDates, setActivityDates] = useState<Set<string>>(new Set())
+
   const modules = catalog.modules
   const totalDone = Object.values(progress.completedLessons).reduce(
     (s, arr) => s + arr.length,
     0
   )
-  const totalAvailable = modules.reduce((s, m) => s + m.lessons.length, 0)
+  const phrase = pickDailyPhrase()
+  const encouragement = pickEncouragement(progress.streak, totalDone)
+
+  // Favorite module = module with the highest absolute completion progress
+  const favorite = modules
+    .filter((m) => m.lessons.length > 0)
+    .map((m) => ({
+      module: m,
+      done: (progress.completedLessons[m.id] ?? []).length,
+      total: m.lessons.length
+    }))
+    .sort((a, b) => b.done - a.done)[0]
+
+  useEffect(() => {
+    let cancelled = false
+    api
+      .activityDays(35)
+      .then((r) => {
+        if (cancelled) return
+        setActivityDates(new Set(r.dates))
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   return (
     <div className="flex flex-col min-h-full bg-cream">
@@ -38,9 +96,8 @@ export default function Profile({ catalog, progress, isPro, isOwner = false, onP
         className="flex-1 px-5 pt-6 pb-in"
         style={{ paddingBottom: 'calc(var(--safe-b) + 40px)' }}
       >
-        {/* Passport card */}
-        <div className="jewel-tile px-5 py-5 mb-6 relative overflow-hidden">
-          {/* Pro corner badge for Pro users */}
+        {/* Hero — mascot + greeting + encouragement */}
+        <div className="jewel-tile px-5 py-5 mb-5 relative overflow-hidden">
           {isPro && (
             <div
               className="absolute top-0 right-0 z-[2] bg-gold text-jewelInk text-[11px] font-extrabold px-2 py-1 border-l-[1.5px] border-b-[1.5px] border-jewelInk rounded-bl-md"
@@ -53,60 +110,99 @@ export default function Profile({ catalog, progress, isPro, isOwner = false, onP
 
           <div className="relative z-[1] flex items-center gap-4">
             <div className="shrink-0">
-              <Mascot mood="happy" size={96} />
+              <Mascot mood={progress.streak >= 3 ? 'cheer' : 'happy'} size={88} />
             </div>
             <div className="flex-1">
-              <div className="mn-eyebrow mb-1">владелец</div>
-              <div className="font-sans text-[20px] font-extrabold text-jewelInk leading-none">
-                ученик
-              </div>
-              <div className="font-geo text-[13px] font-bold text-jewelInk-mid mt-1.5">
-                ქართული
+              <div className="mn-eyebrow mb-1">გამარჯობა</div>
+              <div className="font-sans text-[18px] font-extrabold text-jewelInk leading-tight">
+                {encouragement}
               </div>
             </div>
           </div>
+        </div>
 
-          <div className="relative z-[1] mt-5 pt-4 border-t border-jewelInk/15 grid grid-cols-3 gap-3">
-            <PassportField
-              label="стрик"
-              value={`${progress.streak}`}
-              unit="дн"
-              accent="ruby"
-            />
-            <PassportField
-              label="опыт"
-              value={`${progress.xp}`}
-              unit="xp"
-              accent="navy"
-            />
-            <PassportField
-              label="уроков"
-              value={`${totalDone}`}
-              unit={`/ ${totalAvailable}`}
-              accent="gold"
-            />
+        {/* Phrase of the day — daily learning hit */}
+        <div className="mn-eyebrow mb-2">фраза дня</div>
+        <div className="jewel-tile px-5 py-4 mb-5">
+          <div className="relative z-[1] text-center">
+            <div className="font-geo text-[26px] font-extrabold text-jewelInk leading-tight">
+              {phrase.ge}
+            </div>
+            <div className="font-sans text-[14px] text-jewelInk-mid mt-1">
+              {phrase.ru}
+            </div>
+            <div className="mn-eyebrow text-jewelInk-hint mt-3">
+              {phrase.hint}
+            </div>
           </div>
+        </div>
 
-          {/* Upgrade CTA for free users */}
-          {!isPro && (
-            <div className="relative z-[1] mt-4 pt-4 border-t border-jewelInk/15">
+        {/* Streak heatmap — last 35 days (5 weeks × 7) */}
+        <div className="mn-eyebrow mb-2">активность · 35 дней</div>
+        <div className="jewel-tile px-4 py-4 mb-5">
+          <div className="relative z-[1]">
+            <StreakHeatmap activityDates={activityDates} days={35} />
+            <div className="font-sans text-[11px] text-jewelInk-mid text-center mt-2">
+              {activityDates.size > 0
+                ? `${activityDates.size} ${plural(activityDates.size, 'день', 'дня', 'дней')} с активностью`
+                : 'Сделай первый шаг — добавь слово или пройди урок'}
+            </div>
+          </div>
+        </div>
+
+        {/* Quick stats row */}
+        <div className="grid grid-cols-3 gap-2 mb-5">
+          <StatCard label="стрик" value={`${progress.streak}`} unit="дн" accent="ruby" />
+          <StatCard label="опыт" value={`${progress.xp}`} unit="xp" accent="navy" />
+          <StatCard label="всего" value={`${totalDone}`} unit="ур" accent="gold" />
+        </div>
+
+        {/* Favorite module */}
+        {favorite && favorite.done > 0 && (
+          <>
+            <div className="mn-eyebrow mb-2">любимый раздел</div>
+            <button
+              onClick={() => navigate({ kind: 'module', moduleId: favorite.module.id })}
+              className="jewel-tile jewel-pressable text-left w-full px-4 py-3 mb-5"
+            >
+              <div className="relative z-[1] flex items-center justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="font-sans text-[15px] font-extrabold text-jewelInk">
+                    {favorite.module.title}
+                  </div>
+                  <div className="font-sans text-[11px] text-jewelInk-mid mt-0.5">
+                    Пройдено: {favorite.done} / {favorite.total} уроков
+                  </div>
+                </div>
+                <span className="text-jewelInk-hint text-[14px] shrink-0">→</span>
+              </div>
+            </button>
+          </>
+        )}
+
+        {/* Pro CTA / refund */}
+        {!isPro ? (
+          <div className="jewel-tile px-5 py-4 mb-5">
+            <div className="relative z-[1]">
               <div className="flex items-center gap-1 mb-0.5">
                 <span className="text-gold text-[13px] font-bold">★</span>
-                <span className="font-sans text-[13px] font-bold text-jewelInk">Про-доступ</span>
+                <span className="font-sans text-[14px] font-bold text-jewelInk">Открыть всё</span>
               </div>
               <div className="font-sans text-[11px] text-jewelInk-mid mb-3">
-                Открыть все модули
+                Все модули, словарь без лимита, новые уроки по мере выхода
               </div>
               <button
                 onClick={() => setShowPaywall(true)}
-                className="w-full font-sans text-[14px] font-extrabold text-jewelInk min-h-[40px] rounded border-[1.5px] border-jewelInk flex items-center justify-center"
+                className="w-full font-sans text-[14px] font-extrabold text-jewelInk min-h-[44px] rounded border-[1.5px] border-jewelInk flex items-center justify-center"
                 style={{ background: '#F5B820', boxShadow: '0 2px 0 #15100A' }}
               >
-                Купить за 150 ⭐
+                Выбрать тариф
               </button>
             </div>
-          )}
-        </div>
+          </div>
+        ) : (
+          <RefundButton onRefunded={onPurchaseSuccess} />
+        )}
 
         {showPaywall && (
           <ProPaywall
@@ -126,106 +222,50 @@ export default function Profile({ catalog, progress, isPro, isOwner = false, onP
           }
         `}</style>
 
-        {/* Module progress */}
-        <div className="mn-eyebrow mb-3">разделы блокнота</div>
-        <div className="flex flex-col gap-4">
-          {modules.map((m) => {
-            const total = m.lessons.length
-            const done = (progress.completedLessons[m.id] ?? []).length
-            const accent: 'navy' | 'ruby' | 'gold' =
-              m.id === 'alphabet'
-                ? 'navy'
-                : m.id === 'verbs-of-movement'
-                ? 'ruby'
-                : 'gold'
-            const accentText =
-              accent === 'navy'
-                ? 'text-navy'
-                : accent === 'ruby'
-                ? 'text-ruby'
-                : 'text-gold-deep'
+        {/* Settings: change level */}
+        <div className="mn-eyebrow mb-2 mt-2">настройки</div>
+        <button
+          onClick={() => navigate({ kind: 'onboarding' })}
+          className="jewel-tile jewel-pressable w-full text-left px-4 py-3"
+        >
+          <div className="relative z-[1]">
+            <div className="font-sans text-[14px] font-bold text-jewelInk">
+              Сменить уровень
+            </div>
+            <div className="font-sans text-[11px] text-jewelInk-mid mt-0.5">
+              Если хочешь начать заново или поменять стартовую точку
+            </div>
+          </div>
+        </button>
 
-            if (total === 0) {
-              return (
-                <div
-                  key={m.id}
-                  className="jewel-tile px-4 py-3 flex items-center justify-between"
-                >
-                  <div className="relative z-[1]">
-                    <div className="font-sans text-[15px] font-bold text-jewelInk">
-                      {m.title}
-                    </div>
-                    <div className="font-sans text-[11px] text-jewelInk-mid">
-                      живой словарь
-                    </div>
-                  </div>
-                </div>
-              )
-            }
-
-            const isDone = done === total
-            return (
-              <div key={m.id} className="jewel-tile px-4 py-4">
-                <div className="relative z-[1]">
-                  <div className="flex items-baseline justify-between mb-2 gap-2">
-                    <div className="font-sans text-[15px] font-bold text-jewelInk truncate">
-                      {m.title}
-                    </div>
-                    <div className="shrink-0 font-sans text-[12px] font-bold tabular-nums">
-                      {isDone ? (
-                        <span className="text-gold-deep">
-                          ✓ {done} / {total}
-                        </span>
-                      ) : (
-                        <>
-                          <span className={accentText}>{done}</span>
-                          <span className="text-jewelInk-hint"> / {total}</span>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                  <KilimProgress done={done} total={total} accent={accent} />
-                </div>
-              </div>
-            )
-          })}
-        </div>
-
-        {/* Refund button for Pro users */}
-        {isPro && <RefundButton onRefunded={onPurchaseSuccess} />}
-
-        {/* Legal links */}
+        {/* Legal */}
         <div className="mt-6 flex justify-center gap-4 font-sans text-[12px] text-jewelInk-mid">
           <a href="/privacy.html" target="_blank" rel="noopener" className="underline">Приватность</a>
           <span className="text-jewelInk-hint">·</span>
           <a href="/terms.html" target="_blank" rel="noopener" className="underline">Условия</a>
         </div>
 
-        {/* Debug tools (owner only) */}
-        {isOwner && <OwnerDebugPanel />}
-
-        {/* Change level */}
-        <div className="mt-8">
+        {/* Owner-only entries */}
+        {isOwner && (
           <button
-            onClick={() => navigate({ kind: 'onboarding' })}
-            className="jewel-tile jewel-pressable w-full text-left px-4 py-4"
+            onClick={() => navigate({ kind: 'admin' })}
+            className="mt-6 jewel-tile jewel-pressable w-full text-left px-4 py-3"
           >
-            <div className="relative z-[1]">
-              <div className="font-sans text-[15px] font-bold text-jewelInk">
-                Выбрать свой уровень
+            <div className="relative z-[1] flex items-center justify-between gap-3">
+              <div>
+                <div className="font-sans text-[14px] font-bold text-jewelInk">📊 Админка</div>
+                <div className="font-sans text-[11px] text-jewelInk-mid mt-0.5">
+                  Аналитика, пользователи, гранты
+                </div>
               </div>
-              <div className="font-sans text-[12px] text-jewelInk-mid mt-0.5">
-                Если пропустили этот шаг или хотите изменить
-              </div>
+              <span className="text-jewelInk-hint text-[14px] shrink-0">→</span>
             </div>
           </button>
-        </div>
+        )}
+        {isOwner && <OwnerDebugPanel />}
 
         <div className="mt-6 text-center">
-          <div className="mn-eyebrow text-jewelInk-mid">
-            учись в своём темпе — блокнот ждёт
-          </div>
-          <div className="mt-4 font-sans text-[10px] font-bold text-jewelInk-hint uppercase tracking-widest">
+          <div className="font-sans text-[10px] font-bold text-jewelInk-hint uppercase tracking-widest">
             TraleBot · ბომბორა · 2026
           </div>
         </div>
@@ -233,6 +273,87 @@ export default function Profile({ catalog, progress, isPro, isOwner = false, onP
 
       <div className="mn-kilim opacity-70" />
       <div style={{ height: 'calc(var(--safe-b) + 4px)' }} />
+    </div>
+  )
+}
+
+function plural(n: number, one: string, two: string, many: string): string {
+  const mod100 = n % 100
+  const mod10 = n % 10
+  if (mod100 >= 11 && mod100 <= 14) return many
+  if (mod10 === 1) return one
+  if (mod10 >= 2 && mod10 <= 4) return two
+  return many
+}
+
+function StreakHeatmap({ activityDates, days }: { activityDates: Set<string>; days: number }) {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const cells: { date: string; active: boolean; isToday: boolean }[] = []
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today)
+    d.setDate(today.getDate() - i)
+    const iso = d.toISOString().slice(0, 10)
+    cells.push({
+      date: iso,
+      active: activityDates.has(iso),
+      isToday: i === 0
+    })
+  }
+
+  // Render as 5 rows × 7 columns (oldest top-left, today bottom-right)
+  const rows: typeof cells[] = []
+  for (let i = 0; i < cells.length; i += 7) {
+    rows.push(cells.slice(i, i + 7))
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5 items-center">
+      {rows.map((row, ri) => (
+        <div key={ri} className="flex gap-1.5">
+          {row.map((c) => (
+            <div
+              key={c.date}
+              title={c.date}
+              className="w-6 h-6 rounded border-[1.5px] border-jewelInk"
+              style={{
+                background: c.active ? '#0d4a6e' : 'rgba(21,16,10,0.06)',
+                outline: c.isToday ? '2px solid #F5B820' : 'none',
+                outlineOffset: c.isToday ? '1px' : undefined
+              }}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function StatCard({
+  label,
+  value,
+  unit,
+  accent
+}: {
+  label: string
+  value: string
+  unit: string
+  accent: 'navy' | 'ruby' | 'gold'
+}) {
+  const accentText =
+    accent === 'navy' ? 'text-navy' : accent === 'ruby' ? 'text-ruby' : 'text-gold-deep'
+  return (
+    <div className="jewel-tile px-3 py-3 text-center">
+      <div className="relative z-[1]">
+        <div className="mn-eyebrow text-jewelInk-mid mb-1">{label}</div>
+        <div className={`font-sans text-[22px] font-extrabold tabular-nums leading-none ${accentText}`}>
+          {value}
+        </div>
+        <div className="font-sans text-[10px] font-bold text-jewelInk-hint uppercase tracking-wider mt-0.5">
+          {unit}
+        </div>
+      </div>
     </div>
   )
 }
@@ -256,7 +377,7 @@ function RefundButton({ onRefunded }: { onRefunded: () => void }) {
 
   if (state === 'done') {
     return (
-      <div className="mt-6 jewel-tile px-4 py-3 text-center">
+      <div className="mt-2 mb-5 jewel-tile px-4 py-3 text-center">
         <div className="relative z-[1] font-sans text-[13px] font-bold text-jewelInk">
           ✓ Возврат оформлен
         </div>
@@ -266,7 +387,7 @@ function RefundButton({ onRefunded }: { onRefunded: () => void }) {
 
   if (state === 'confirming') {
     return (
-      <div className="mt-6 jewel-tile px-4 py-4">
+      <div className="mt-2 mb-5 jewel-tile px-4 py-4">
         <div className="relative z-[1]">
           <div className="font-sans text-[14px] font-bold text-jewelInk mb-1">
             Вернуть звёзды?
@@ -295,7 +416,7 @@ function RefundButton({ onRefunded }: { onRefunded: () => void }) {
   }
 
   return (
-    <div className="mt-6">
+    <div className="mb-5">
       <button
         onClick={() => setState('confirming')}
         disabled={state === 'pending'}
@@ -334,26 +455,10 @@ function OwnerDebugPanel() {
   }
 
   const actions = [
-    {
-      label: 'Сбросить reveal ქ',
-      hint: 'Покажет оверлей буквы ქ снова',
-      fn: () => clearKeys(['bombora_kani_reveal_shown'], 'kani reveal'),
-    },
-    {
-      label: 'Сбросить unlock-анимации',
-      hint: 'Повторит анимацию открытия секций',
-      fn: () => clearKeys(['bombora_unlocked_once'], 'unlock'),
-    },
-    {
-      label: 'Очистить весь localStorage',
-      hint: 'Онбординг, прогресс UI, флаги',
-      fn: clearAllLocalStorage,
-    },
-    {
-      label: 'Reload мини-аппа',
-      hint: 'location.reload()',
-      fn: reload,
-    },
+    { label: 'Сбросить reveal ქ', hint: 'Покажет оверлей буквы ქ снова', fn: () => clearKeys(['bombora_kani_reveal_shown'], 'kani reveal') },
+    { label: 'Сбросить unlock-анимации', hint: 'Повторит анимацию открытия секций', fn: () => clearKeys(['bombora_unlocked_once'], 'unlock') },
+    { label: 'Очистить весь localStorage', hint: 'Онбординг, прогресс UI, флаги', fn: clearAllLocalStorage },
+    { label: 'Reload мини-аппа', hint: 'location.reload()', fn: reload },
   ]
 
   return (
@@ -368,12 +473,8 @@ function OwnerDebugPanel() {
           >
             <div className="relative z-[1] flex items-center justify-between gap-3">
               <div className="flex-1 min-w-0">
-                <div className="font-sans text-[13px] font-bold text-jewelInk">
-                  {a.label}
-                </div>
-                <div className="font-sans text-[11px] text-jewelInk-mid mt-0.5">
-                  {a.hint}
-                </div>
+                <div className="font-sans text-[13px] font-bold text-jewelInk">{a.label}</div>
+                <div className="font-sans text-[11px] text-jewelInk-mid mt-0.5">{a.hint}</div>
               </div>
               <span className="text-jewelInk-hint text-[12px] shrink-0">→</span>
             </div>
@@ -389,34 +490,6 @@ function OwnerDebugPanel() {
           {toast}
         </div>
       )}
-    </div>
-  )
-}
-
-function PassportField({
-  label,
-  value,
-  unit,
-  accent
-}: {
-  label: string
-  value: string
-  unit: string
-  accent: 'navy' | 'ruby' | 'gold'
-}) {
-  const accentText =
-    accent === 'navy' ? 'text-navy' : accent === 'ruby' ? 'text-ruby' : 'text-gold-deep'
-  return (
-    <div className="text-center">
-      <div className="mn-eyebrow text-jewelInk-mid mb-1">{label}</div>
-      <div
-        className={`font-sans text-[22px] font-extrabold tabular-nums leading-none ${accentText}`}
-      >
-        {value}
-      </div>
-      <div className="font-sans text-[10px] font-bold text-jewelInk-hint uppercase tracking-wider mt-0.5">
-        {unit}
-      </div>
     </div>
   )
 }

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,7 +46,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>Бомбора — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-BN15vUMZ.js"></script>
+    <script type="module" crossorigin src="/assets/index-Cn6ztL16.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DPqHSsIM.css">
   </head>
   <body>


### PR DESCRIPTION
## Why

The old Profile was just a duplicate Dashboard — it listed every module with progress bars that you already see on the home screen. So Profile felt useless. This makes it a personal-progress view with something interesting to look at every day.

## What's new
- **Hero card** — mascot mood reacts to streak (cheer at 3+ days), and a personalized one-liner based on streak / lessons done.
- **Phrase of the day** — one Georgian phrase + Russian + a tiny linguistic hint, rotates daily.
- **Streak heatmap** — 5×7 = 35 days. Filled cells for active days, current day outlined in gold. "Active" = added a vocabulary entry that day.
- **Quick stats** row: streak / xp / total lessons (one compact row, replaces the old fat passport block).
- **Favorite section** — your most-progressed module, tappable to open.
- Pro CTA / refund / Settings / Legal / Owner panels kept.

## What's gone
- The full per-module progress list with KilimProgress bars. Dashboard already shows that.

## Backend
- New `GET /api/miniapp/activity-days?days=35` returns ISO date strings where the user added vocabulary. Service per ARCHITECTURE.md (no MediatR).

## Test plan
- [x] Backend builds, all 66 tests pass
- [x] Frontend builds clean
- [x] /api/miniapp/activity-days returns 401 without auth
- [ ] Open Profile, see heatmap, phrase, encouragement

🤖 Generated with [Claude Code](https://claude.com/claude-code)