### PR TITLE
Menu: replace broken Премиум button with WebApp paywall deep-link

### DIFF
--- a/src/Infrastructure/Telegram/CommonComponents/MenuKeyboard.cs
+++ b/src/Infrastructure/Telegram/CommonComponents/MenuKeyboard.cs
@@ -49,11 +49,24 @@ public static class MenuKeyboard
             InlineKeyboardButton.WithCallbackData($"{CommandNames.HowToIcon} Как пользоваться", CommandNames.HowTo)
         });
         
-        buttons.Add(new[]
+        // "Buy subscription" — opens the mini-app directly to the paywall.
+        // Falls back to a callback if mini-app isn't available.
+        if (!string.IsNullOrEmpty(miniAppUrl))
         {
-            InlineKeyboardButton.WithCallbackData($"{CommandNames.PayIcon} Премиум"),
-            InlineKeyboardButton.WithCallbackData($"{CommandNames.HelpIcon} Поддержка")
-        });
+            buttons.Add(new[]
+            {
+                InlineKeyboardButton.WithWebApp("💳 Оплатить подписку",
+                    new WebAppInfo { Url = $"{miniAppUrl}?paywall=1" }),
+                InlineKeyboardButton.WithCallbackData($"{CommandNames.HelpIcon} Поддержка", CommandNames.Help)
+            });
+        }
+        else
+        {
+            buttons.Add(new[]
+            {
+                InlineKeyboardButton.WithCallbackData($"{CommandNames.HelpIcon} Поддержка", CommandNames.Help)
+            });
+        }
         
         var keyboard = new InlineKeyboardMarkup(buttons);
         return keyboard;

--- a/src/Trale/miniapp-src/src/screens/Dashboard.tsx
+++ b/src/Trale/miniapp-src/src/screens/Dashboard.tsx
@@ -71,6 +71,20 @@ export default function Dashboard({ catalog, progress, todayLessons, userLevel, 
   const hasAccess = isPro || isTrialActive
   const [paywall, setPaywall] = useState<{ trigger: PaywallTrigger } | null>(null)
 
+  // Auto-open paywall when arrived via deep link "?paywall=1" — used by the
+  // bot's "💳 Оплатить подписку" button so users land straight on the sheet.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('paywall') === '1' && !isPro) {
+      setPaywall({ trigger: 'module' })
+      // Strip the query so a manual reload doesn't keep popping the paywall
+      const url = new URL(window.location.href)
+      url.searchParams.delete('paywall')
+      window.history.replaceState({}, '', url.toString())
+    }
+  }, [isPro])
+
   // Section data — defined early so unlock logic can reference them
   const basicsIds = ['alphabet-progressive', 'intro', 'numbers']
   const grammarIds = ['pronouns', 'present-tense', 'cases', 'postpositions', 'adjectives']

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,7 +46,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>Бомбора — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-C9XWIG5b.js"></script>
+    <script type="module" crossorigin src="/assets/index-CiXTIFIc.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-B9PQvol6.css">
   </head>
   <body>


### PR DESCRIPTION
## Summary

The "{PayIcon} Премиум" button in the bot's `/menu` had no callback data — tap did nothing. Replaced with a WebApp button "💳 Оплатить подписку" that opens the mini-app at `?paywall=1`.

Dashboard now intercepts that query parameter and auto-opens the ProPaywall sheet for non-Pro users (sheet shows the 5-tariff selector).

Also fixed: the "Поддержка" button in the same row also had no callback data — gave it `CommandNames.Help`.

When mini-app is disabled (no HostAddress), the Премиум row collapses to just Поддержка — no dead button.

## Test plan
- [x] Backend builds, mini-app builds
- [ ] Send /menu to the bot — see "💳 Оплатить подписку" + "Поддержка" row
- [ ] Tap "💳 Оплатить подписку" → mini-app opens, paywall slides up
- [ ] Tap "Поддержка" → support reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)