### PR TITLE
Admin broadcast tool + sort users by vocabulary count

### DIFF
--- a/src/Application/Admin/BroadcastService.cs
+++ b/src/Application/Admin/BroadcastService.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common;
+using Application.MiniApp;
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Admin;
+
+/// <summary>
+/// Owner-only: send a message + optionally grant Pro to a segment of users.
+/// Segment can be filtered by activity recency, by minimum vocabulary size,
+/// or both. The vocabulary filter is the "wake up dormant users" knob —
+/// people who once collected lots of words but stopped using the bot.
+/// </summary>
+public class BroadcastService(
+    ITraleDbContext db,
+    ITelegramMessageSender telegramSender,
+    ILoggerFactory loggerFactory)
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<BroadcastService>();
+
+    public async Task<BroadcastPreview> PreviewAsync(BroadcastSegment segment, CancellationToken ct)
+    {
+        var ids = await ResolveTelegramIdsAsync(segment, ct);
+        return new BroadcastPreview
+        {
+            TotalRecipients = ids.Count,
+            SampleTelegramIds = ids.Take(10).ToList()
+        };
+    }
+
+    public async Task<BroadcastResult> ExecuteAsync(
+        BroadcastSegment segment,
+        string message,
+        string? grantPlanName,
+        bool dryRun,
+        bool includeMiniAppButton,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return new BroadcastResult { Error = "Empty message" };
+        }
+        if (message.Length > 4000)
+        {
+            return new BroadcastResult { Error = "Message too long (max 4000 chars)" };
+        }
+
+        var telegramIds = await ResolveTelegramIdsAsync(segment, ct);
+
+        SubscriptionPlan? plan = null;
+        if (!string.IsNullOrEmpty(grantPlanName))
+        {
+            if (!Enum.TryParse<SubscriptionPlan>(grantPlanName, true, out var parsed))
+            {
+                return new BroadcastResult { Error = $"Unknown plan: {grantPlanName}" };
+            }
+            plan = parsed;
+        }
+
+        if (dryRun)
+        {
+            return new BroadcastResult { Sent = 0, Granted = 0, Failed = 0, TotalRecipients = telegramIds.Count };
+        }
+
+        var users = await db.Users
+            .Where(u => telegramIds.Contains(u.TelegramId))
+            .ToListAsync(ct);
+
+        var sent = 0;
+        var failed = 0;
+        var granted = 0;
+        var now = DateTime.UtcNow;
+
+        foreach (var user in users)
+        {
+            if (plan.HasValue && !user.IsPro)
+            {
+                user.IsPro = true;
+                user.SubscriptionPlan = plan.Value;
+                user.ProPurchasedAtUtc ??= now;
+                if (plan.Value == SubscriptionPlan.Lifetime)
+                {
+                    user.SubscribedUntil = null;
+                }
+                else
+                {
+                    var planInfo = SubscriptionPlans.ByPlan(plan.Value);
+                    if (planInfo?.DurationDays != null)
+                    {
+                        user.SubscribedUntil = now.AddDays(planInfo.DurationDays.Value);
+                    }
+                }
+                granted++;
+            }
+
+            var ok = await telegramSender.SendTextAsync(
+                user.TelegramId, message, includeMiniAppButton, ct);
+            if (ok) sent++;
+            else
+            {
+                failed++;
+                _logger.LogWarning("Broadcast failed for {TelegramId}", user.TelegramId);
+            }
+        }
+
+        if (granted > 0)
+        {
+            await db.SaveChangesAsync(ct);
+        }
+
+        _logger.LogInformation("Broadcast done: sent={Sent} failed={Failed} granted={Granted} of {Total}",
+            sent, failed, granted, telegramIds.Count);
+
+        return new BroadcastResult
+        {
+            TotalRecipients = telegramIds.Count,
+            Sent = sent,
+            Failed = failed,
+            Granted = granted
+        };
+    }
+
+    private async Task<List<long>> ResolveTelegramIdsAsync(BroadcastSegment segment, CancellationToken ct)
+    {
+        // Start with all active users, then layer filters.
+        var users = db.Users.Where(u => u.IsActive);
+
+        // Filter by minimum vocabulary count
+        if (segment.MinVocabularyCount > 0)
+        {
+            var minVocab = segment.MinVocabularyCount;
+            users = users.Where(u =>
+                db.VocabularyEntries.Count(v => v.UserId == u.Id) >= minVocab);
+        }
+
+        // Filter by activity recency (only when explicitly requested)
+        if (segment.ActiveWithinDays.HasValue && segment.ActiveWithinDays.Value > 0)
+        {
+            var since = DateTime.UtcNow.AddDays(-segment.ActiveWithinDays.Value);
+            var fromVocab = db.VocabularyEntries
+                .Where(v => v.DateAddedUtc >= since)
+                .Select(v => v.UserId);
+            var fromQuiz = db.Quizzes
+                .Where(q => q.DateStarted >= since)
+                .Select(q => q.UserId);
+            var fromMiniApp = db.MiniAppUserProgresses
+                .Where(p => p.LastPlayedAtUtc != null && p.LastPlayedAtUtc >= since)
+                .Select(p => p.UserId);
+
+            var activeUserIds = await fromVocab.Union(fromQuiz).Union(fromMiniApp).Distinct().ToListAsync(ct);
+            users = users.Where(u => activeUserIds.Contains(u.Id));
+        }
+
+        return await users.Select(u => u.TelegramId).ToListAsync(ct);
+    }
+}
+
+public class BroadcastSegment
+{
+    /// <summary>Minimum vocabulary entries required (0 = no filter).</summary>
+    public int MinVocabularyCount { get; set; }
+
+    /// <summary>Optional recency filter — null/0 means no recency filter (waking dormant users).</summary>
+    public int? ActiveWithinDays { get; set; }
+}
+
+public interface ITelegramMessageSender
+{
+    Task<bool> SendTextAsync(long telegramId, string text, bool includeMiniAppButton, CancellationToken ct);
+}
+
+public class BroadcastPreview
+{
+    public int TotalRecipients { get; init; }
+    public List<long> SampleTelegramIds { get; init; } = new();
+}
+
+public class BroadcastResult
+{
+    public int TotalRecipients { get; init; }
+    public int Sent { get; init; }
+    public int Failed { get; init; }
+    public int Granted { get; init; }
+    public string? Error { get; init; }
+}

--- a/src/Application/Admin/GetRecentUsersQuery.cs
+++ b/src/Application/Admin/GetRecentUsersQuery.cs
@@ -11,7 +11,8 @@ namespace Application.Admin;
 public enum RecentUsersSort
 {
     RecentSignup,
-    RecentActivity
+    RecentActivity,
+    VocabularyCount
 }
 
 /// <summary>
@@ -37,13 +38,17 @@ public class GetRecentUsersQuery(ITraleDbContext db)
             q = q.Where(u => u.TelegramId.ToString().Contains(search));
         }
 
-        // Pull a candidate set, then either order by signup OR enrich with activity
-        // and order by that. To keep it simple, fetch up to limit*5 candidates for
-        // activity sort, then trim after enrichment.
-        var fetchLimit = sort == RecentUsersSort.RecentActivity ? Math.Min(limit * 5, 500) : limit;
+        // For sorts that depend on enriched columns (activity / vocab count) we need
+        // a wider candidate window before trimming to `limit` after computing them.
+        var fetchLimit = sort == RecentUsersSort.RecentSignup ? limit : Math.Min(limit * 5, 500);
 
-        var candidates = await q
-            .OrderByDescending(u => u.RegisteredAtUtc)
+        // For VocabularyCount sort, prime the candidate window by vocab count
+        // straight from the DB so we don't accidentally trim the heaviest users.
+        var primedQuery = sort == RecentUsersSort.VocabularyCount
+            ? q.OrderByDescending(u => db.VocabularyEntries.Count(v => v.UserId == u.Id))
+            : q.OrderByDescending(u => u.RegisteredAtUtc);
+
+        var candidates = await primedQuery
             .Take(fetchLimit)
             .Select(u => new
             {
@@ -82,6 +87,10 @@ public class GetRecentUsersQuery(ITraleDbContext db)
         if (sort == RecentUsersSort.RecentActivity)
         {
             enriched = enriched.OrderByDescending(u => u.LastActivityUtc ?? DateTime.MinValue);
+        }
+        else if (sort == RecentUsersSort.VocabularyCount)
+        {
+            enriched = enriched.OrderByDescending(u => u.VocabularyCount);
         }
 
         return enriched.Take(limit).ToList();

--- a/src/Application/DependencyInjection.cs
+++ b/src/Application/DependencyInjection.cs
@@ -51,6 +51,7 @@ public static class DependencyInjection
         services.AddScoped<GetUserDetailQuery>();
         services.AddScoped<GrantProService>();
         services.AddScoped<RevokeProService>();
+        services.AddScoped<BroadcastService>();
 
         return services;
     }

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -73,6 +73,7 @@ public static class DependencyInjection
         services.AddScoped<IUserNotificationService, TelegramNotificationService>();
         services.AddScoped<IIdempotencyService, IdempotencyService>();
         services.AddScoped<ITelegramRefundClient, TelegramRefundClient>();
+        services.AddScoped<Application.Admin.ITelegramMessageSender, Infrastructure.Telegram.Services.TelegramMessageSender>();
         
         // Georgian quiz services
         services.AddScoped<IGeorgianQuizSessionService, GeorgianQuizSessionService>();

--- a/src/Infrastructure/Telegram/Services/TelegramMessageSender.cs
+++ b/src/Infrastructure/Telegram/Services/TelegramMessageSender.cs
@@ -1,0 +1,44 @@
+using Application.Admin;
+using Infrastructure.Telegram;
+using Microsoft.Extensions.Logging;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Infrastructure.Telegram.Services;
+
+public class TelegramMessageSender(
+    ITelegramBotClient bot,
+    BotConfiguration config,
+    ILoggerFactory loggerFactory) : ITelegramMessageSender
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<TelegramMessageSender>();
+
+    public async Task<bool> SendTextAsync(long telegramId, string text, bool includeMiniAppButton, CancellationToken ct)
+    {
+        try
+        {
+            InlineKeyboardMarkup? keyboard = null;
+            if (includeMiniAppButton
+                && config.MiniAppEnabled
+                && !string.IsNullOrEmpty(config.HostAddress))
+            {
+                keyboard = new InlineKeyboardMarkup(new[]
+                {
+                    InlineKeyboardButton.WithWebApp(
+                        "🚀 Открыть TraleBot",
+                        new WebAppInfo { Url = $"{config.HostAddress}/" })
+                });
+            }
+
+            await bot.SendTextMessageAsync(
+                telegramId, text, replyMarkup: keyboard, cancellationToken: ct);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to send broadcast to {TelegramId}", telegramId);
+            return false;
+        }
+    }
+}

--- a/src/Trale/Controllers/AdminController.cs
+++ b/src/Trale/Controllers/AdminController.cs
@@ -27,6 +27,7 @@ public class AdminController : Controller
     private readonly GetUserDetailQuery _userDetailQuery;
     private readonly GrantProService _grantPro;
     private readonly RevokeProService _revokePro;
+    private readonly BroadcastService _broadcast;
 
     public AdminController(
         ITraleDbContext dbContext,
@@ -36,7 +37,8 @@ public class AdminController : Controller
         GetRecentUsersQuery recentUsersQuery,
         GetUserDetailQuery userDetailQuery,
         GrantProService grantPro,
-        RevokeProService revokePro)
+        RevokeProService revokePro,
+        BroadcastService broadcast)
     {
         _dbContext = dbContext;
         _botConfig = botConfig;
@@ -46,6 +48,7 @@ public class AdminController : Controller
         _userDetailQuery = userDetailQuery;
         _grantPro = grantPro;
         _revokePro = revokePro;
+        _broadcast = broadcast;
     }
 
     [HttpGet("stats")]
@@ -84,9 +87,12 @@ public class AdminController : Controller
             return NotFound();
         }
 
-        var sortEnum = sort == "recent_activity"
-            ? RecentUsersSort.RecentActivity
-            : RecentUsersSort.RecentSignup;
+        var sortEnum = sort switch
+        {
+            "recent_activity" => RecentUsersSort.RecentActivity,
+            "vocab_count" => RecentUsersSort.VocabularyCount,
+            _ => RecentUsersSort.RecentSignup
+        };
 
         var users = await _recentUsersQuery.ExecuteAsync(limit, search, sortEnum, ct);
         return Ok(new { users });
@@ -126,6 +132,47 @@ public class AdminController : Controller
         if (!await IsOwnerAsync(ct)) return NotFound();
         var ok = await _revokePro.ExecuteAsync(telegramId, ct);
         return ok ? Ok(new { ok = true }) : NotFound(new { error = "user_not_found" });
+    }
+
+    [HttpGet("broadcast/preview")]
+    public async Task<IActionResult> BroadcastPreview(
+        [FromQuery] int? activeWithinDays,
+        [FromQuery] int minVocab = 0,
+        CancellationToken ct = default)
+    {
+        if (!await IsOwnerAsync(ct)) return NotFound();
+        var segment = new BroadcastSegment
+        {
+            ActiveWithinDays = activeWithinDays,
+            MinVocabularyCount = minVocab
+        };
+        var preview = await _broadcast.PreviewAsync(segment, ct);
+        return Ok(preview);
+    }
+
+    public class BroadcastRequest
+    {
+        public int? ActiveWithinDays { get; set; }
+        public int MinVocabularyCount { get; set; }
+        public string Message { get; set; } = string.Empty;
+        public string? GrantPlan { get; set; }
+        public bool DryRun { get; set; } = true;
+        public bool IncludeMiniAppButton { get; set; } = true;
+    }
+
+    [HttpPost("broadcast")]
+    public async Task<IActionResult> Broadcast([FromBody] BroadcastRequest req, CancellationToken ct)
+    {
+        if (!await IsOwnerAsync(ct)) return NotFound();
+        var segment = new BroadcastSegment
+        {
+            ActiveWithinDays = req.ActiveWithinDays,
+            MinVocabularyCount = req.MinVocabularyCount
+        };
+        var result = await _broadcast.ExecuteAsync(
+            segment, req.Message, req.GrantPlan, req.DryRun, req.IncludeMiniAppButton, ct);
+        if (result.Error != null) return BadRequest(result);
+        return Ok(result);
     }
 
     /// <summary>

--- a/src/Trale/miniapp-src/src/api.ts
+++ b/src/Trale/miniapp-src/src/api.ts
@@ -203,6 +203,30 @@ export const api = {
       method: 'POST'
     }),
 
+  adminBroadcastPreview: (opts: { activeWithinDays?: number | null; minVocab?: number }) => {
+    const params = new URLSearchParams()
+    if (opts.activeWithinDays != null) params.set('activeWithinDays', String(opts.activeWithinDays))
+    if (opts.minVocab) params.set('minVocab', String(opts.minVocab))
+    return request<{ totalRecipients: number; sampleTelegramIds: number[] }>(
+      `/api/admin/broadcast/preview?${params}`
+    )
+  },
+  adminBroadcast: (body: {
+    activeWithinDays?: number | null
+    minVocabularyCount?: number
+    message: string
+    grantPlan: string | null
+    dryRun: boolean
+    includeMiniAppButton: boolean
+  }) =>
+    request<{ totalRecipients: number; sent: number; failed: number; granted: number; error?: string }>(
+      `/api/admin/broadcast`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body)
+      }
+    ),
+
   lessonQuestions: (moduleId: string, lessonId: number) =>
     request<Array<{
       id: string

--- a/src/Trale/miniapp-src/src/screens/AdminScreen.tsx
+++ b/src/Trale/miniapp-src/src/screens/AdminScreen.tsx
@@ -18,7 +18,7 @@ export default function AdminScreen({ progress, navigate }: Props) {
   const [users, setUsers] = useState<AdminRecentUser[]>([])
   const [days, setDays] = useState<7 | 30 | 90>(30)
   const [search, setSearch] = useState('')
-  const [sort, setSort] = useState<'recent_signup' | 'recent_activity'>('recent_activity')
+  const [sort, setSort] = useState<'recent_signup' | 'recent_activity' | 'vocab_count'>('recent_activity')
   const [usersLoading, setUsersLoading] = useState(false)
 
   // Initial load: stats + chart + first batch of users
@@ -155,6 +155,9 @@ export default function AdminScreen({ progress, navigate }: Props) {
               </div>
             </div>
 
+            {/* Broadcast & Grant — owner only one-off campaign tool */}
+            <BroadcastPanel />
+
             {/* Users with search + sort */}
             <div className="flex items-center justify-between mb-2">
               <div className="mn-eyebrow">Юзеры ({users.length})</div>
@@ -178,6 +181,16 @@ export default function AdminScreen({ progress, navigate }: Props) {
                   }`}
                 >
                   регистрация
+                </button>
+                <button
+                  onClick={() => setSort('vocab_count')}
+                  className={`px-2 py-1 rounded font-sans text-[10px] font-bold border-[1.5px] ${
+                    sort === 'vocab_count'
+                      ? 'bg-jewelInk text-cream border-jewelInk'
+                      : 'bg-cream text-jewelInk-mid border-jewelInk/25'
+                  }`}
+                >
+                  слова
                 </button>
               </div>
             </div>
@@ -217,6 +230,226 @@ export default function AdminScreen({ progress, navigate }: Props) {
 
 function fmt(n: number): string {
   return n.toLocaleString('ru-RU')
+}
+
+function BroadcastPanel() {
+  const [minVocab, setMinVocab] = useState(10)
+  const [useActivity, setUseActivity] = useState(false)
+  const [days, setDays] = useState(365)
+  const [grantPlan, setGrantPlan] = useState<string>('Lifetime')
+  const [includeMiniAppButton, setIncludeMiniAppButton] = useState(true)
+  const [message, setMessage] = useState('')
+  const [preview, setPreview] = useState<{ totalRecipients: number; sampleTelegramIds: number[] } | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState<string | null>(null)
+
+  function segmentSummary() {
+    const parts: string[] = []
+    if (minVocab > 0) parts.push(`словарь ≥ ${minVocab}`)
+    if (useActivity) parts.push(`активные за ${days}д`)
+    if (parts.length === 0) parts.push('все юзеры')
+    return parts.join(' + ')
+  }
+
+  function buildBody(dryRun: boolean) {
+    return {
+      activeWithinDays: useActivity ? days : null,
+      minVocabularyCount: minVocab,
+      message,
+      grantPlan: grantPlan || null,
+      dryRun,
+      includeMiniAppButton
+    }
+  }
+
+  async function doPreview() {
+    setBusy(true)
+    setResult(null)
+    try {
+      const p = await api.adminBroadcastPreview({
+        activeWithinDays: useActivity ? days : null,
+        minVocab
+      })
+      setPreview(p)
+    } catch {
+      setResult('preview failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function doDryRun() {
+    if (!message.trim()) {
+      setResult('пустое сообщение')
+      return
+    }
+    setBusy(true)
+    setResult(null)
+    try {
+      const r = await api.adminBroadcast(buildBody(true))
+      setResult(`dry-run: получателей ${r.totalRecipients} (никому не отправлено)`)
+    } catch (e: any) {
+      setResult(`ошибка: ${e?.message ?? 'unknown'}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function doSend() {
+    if (!message.trim()) {
+      setResult('пустое сообщение')
+      return
+    }
+    if (!confirm(
+      `ОТПРАВИТЬ?\nСегмент: ${segmentSummary()}\n` +
+      (grantPlan ? `+ выдать Pro план: ${grantPlan}\n` : '') +
+      (includeMiniAppButton ? '+ кнопка «Открыть TraleBot» в сообщении\n' : '') +
+      `Сообщение длиной ${message.length} символов.\n\n` +
+      'Это РЕАЛЬНАЯ отправка через бота.'
+    )) return
+
+    setBusy(true)
+    setResult(null)
+    try {
+      const r = await api.adminBroadcast(buildBody(false))
+      setResult(`✓ отправлено ${r.sent}/${r.totalRecipients}, выдано Pro: ${r.granted}, ошибок: ${r.failed}`)
+    } catch (e: any) {
+      setResult(`ошибка: ${e?.message ?? 'unknown'}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="mb-5">
+      <div className="mn-eyebrow mb-2">📢 Broadcast (one-off)</div>
+      <div className="jewel-tile px-4 py-4">
+        <div className="relative z-[1] flex flex-col gap-3">
+          {/* Min vocabulary filter — primary "wake dormant users" knob */}
+          <div className="flex gap-2 items-center">
+            <label className="font-sans text-[12px] text-jewelInk-mid">слов в словаре ≥</label>
+            <input
+              type="number"
+              min={0}
+              max={1000}
+              value={minVocab}
+              onChange={(e) => setMinVocab(parseInt(e.target.value) || 0)}
+              className="w-20 px-2 py-1 rounded border-[1.5px] border-jewelInk/40 font-sans text-[13px] tabular-nums"
+            />
+          </div>
+
+          {/* Optional activity filter */}
+          <label className="flex gap-2 items-center">
+            <input
+              type="checkbox"
+              checked={useActivity}
+              onChange={(e) => setUseActivity(e.target.checked)}
+            />
+            <span className="font-sans text-[12px] text-jewelInk-mid">+ активные за</span>
+            <input
+              type="number"
+              min={1}
+              max={365}
+              value={days}
+              disabled={!useActivity}
+              onChange={(e) => setDays(parseInt(e.target.value) || 30)}
+              className="w-16 px-2 py-1 rounded border-[1.5px] border-jewelInk/40 font-sans text-[13px] tabular-nums disabled:opacity-50"
+            />
+            <span className="font-sans text-[12px] text-jewelInk-mid">дней</span>
+          </label>
+
+          <div className="flex justify-between items-center">
+            <span className="font-sans text-[11px] text-jewelInk-mid">
+              сегмент: <strong className="text-jewelInk">{segmentSummary()}</strong>
+            </span>
+            <button
+              onClick={doPreview}
+              disabled={busy}
+              className="px-3 py-1 rounded font-sans text-[11px] font-bold border-[1.5px] border-jewelInk/40 active:opacity-70"
+            >
+              preview
+            </button>
+          </div>
+
+          {preview && (
+            <div className="font-sans text-[11px] text-jewelInk-mid">
+              получателей: <strong className="text-jewelInk">{preview.totalRecipients}</strong>
+              {preview.sampleTelegramIds.length > 0 && (
+                <div className="mt-1 truncate">
+                  пример: {preview.sampleTelegramIds.slice(0, 5).join(', ')}
+                  {preview.totalRecipients > 5 && ' …'}
+                </div>
+              )}
+            </div>
+          )}
+
+          <div>
+            <label className="font-sans text-[12px] text-jewelInk-mid">выдать Pro план (опц.)</label>
+            <select
+              value={grantPlan}
+              onChange={(e) => setGrantPlan(e.target.value)}
+              className="w-full mt-1 px-2 py-1.5 rounded border-[1.5px] border-jewelInk/40 font-sans text-[13px] bg-cream"
+            >
+              <option value="">— без granta —</option>
+              <option value="Month">1 месяц</option>
+              <option value="Quarter">3 месяца</option>
+              <option value="HalfYear">6 месяцев</option>
+              <option value="Year">1 год</option>
+              <option value="Lifetime">Навсегда</option>
+            </select>
+          </div>
+
+          <label className="flex gap-2 items-center">
+            <input
+              type="checkbox"
+              checked={includeMiniAppButton}
+              onChange={(e) => setIncludeMiniAppButton(e.target.checked)}
+            />
+            <span className="font-sans text-[12px] text-jewelInk-mid">кнопка «🚀 Открыть TraleBot» в сообщении</span>
+          </label>
+
+          <div>
+            <label className="font-sans text-[12px] text-jewelInk-mid">сообщение</label>
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              rows={6}
+              maxLength={4000}
+              placeholder="Текст сообщения для рассылки…"
+              className="w-full mt-1 px-2 py-2 rounded border-[1.5px] border-jewelInk/40 font-sans text-[13px] bg-cream text-jewelInk"
+            />
+            <div className="font-sans text-[10px] text-jewelInk-hint text-right mt-0.5">
+              {message.length} / 4000
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              onClick={doDryRun}
+              disabled={busy}
+              className="flex-1 font-sans text-[13px] font-bold py-2 rounded border-[1.5px] border-jewelInk/40 active:opacity-70"
+            >
+              dry-run
+            </button>
+            <button
+              onClick={doSend}
+              disabled={busy}
+              className="flex-1 font-sans text-[13px] font-extrabold text-cream py-2 rounded border-[1.5px] border-jewelInk active:opacity-70"
+              style={{ background: '#b54e5e', boxShadow: '0 2px 0 #15100A' }}
+            >
+              {busy ? '…' : 'РЕАЛЬНО ОТПРАВИТЬ'}
+            </button>
+          </div>
+
+          {result && (
+            <div className="font-sans text-[11px] text-jewelInk text-center">
+              {result}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 function relativeTime(iso: string): string {

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,8 +46,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>Бомбора — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-CiXTIFIc.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-B9PQvol6.css">
+    <script type="module" crossorigin src="/assets/index-Boru3Ojx.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-Bd771tgR.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

One-off campaign tool in admin to message a segment of users (and optionally grant Pro). Designed to wake up dormant users and reward early adopters.

## Backend
- **`BroadcastService`** — segments by vocabulary size (≥N words) and/or recent activity (`activeWithinDays`). Either filter alone, or both together.
- **`POST /api/admin/broadcast`** — body: `{ activeWithinDays?, minVocabularyCount, message, grantPlan?, dryRun, includeMiniAppButton }`. `dryRun: true` is the safety default.
- **`GET /api/admin/broadcast/preview`** — recipient count + sample of 10 IDs, no sending.
- **`TelegramMessageSender`** — wraps `ITelegramBotClient`. When `includeMiniAppButton=true` and the mini-app is enabled, the message gets an inline WebApp button "🚀 Открыть TraleBot" so users open the app one-tap from the message.
- **`GetRecentUsersQuery`** — new sort `VocabularyCount`, primes the candidate window via vocab count so heavy users aren't trimmed by the pre-sort fetch limit.

## Frontend
- **`BroadcastPanel`** in Admin: min-vocab input (the "wake dormant users" knob), optional activity-recency checkbox, plan selector, button-include checkbox, message textarea (max 4000), preview / dry-run / send with confirm dialog.
- **Sort tab "слова"** in user list — sort by vocabulary count for finding power users.

## Test plan
- [x] Backend builds, frontend builds
- [x] All endpoints 404 for non-owners
- [x] Local check: `min vocab >= 10` → 35 users (vs 26 by activity-only) — confirms it surfaces dormant power users
- [ ] Admin UI: preview / dry-run / sort-by-words tested manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)