### PR TITLE
Enable mini-app on production (MiniAppEnabled=true)

### DIFF
--- a/deploy/tralebot.yml
+++ b/deploy/tralebot.yml
@@ -97,12 +97,14 @@ spec:
                 secretKeyRef:
                   name: tralebot-secrets
                   key: TRALEBOT_SERVER_HOST
-            # Mini-app feature flag. Set to "true" to light up the Kutya mini-app
-            # chat menu button for Telegram users. While false, the SPA still builds
-            # and is served at the host root (landing page for public visitors),
-            # but the bot doesn't set any chat menu button — prod users see no change.
+            # Mini-app feature flag. When true, the bot:
+            # - sets the chat menu button to a WebApp button (one-tap mini-app launch)
+            # - shows the WebApp button in the /menu inline keyboard
+            # - exposes the "💳 Оплатить подписку" deep link
+            # When false, the SPA is still served at the host root (landing page),
+            # but no menu buttons are set in Telegram for users.
             - name: BotConfiguration__MiniAppEnabled
-              value: "false"
+              value: "true"
 
 ---
 


### PR DESCRIPTION
## Summary

Flip `BotConfiguration__MiniAppEnabled` from `"false"` to `"true"` in the K8s deployment so production users get the full mini-app experience.

After merge & deploy, prod users will see:
- 🚀 Chat menu button (rather than the standard /commands menu)
- 🚀 "Открыть TraleBot" + 💳 "Оплатить подписку" in /menu
- 🚀 WebApp launch button on /start

Bot description, short description, and command list are already set via API on every startup (in `CreateWebhookHostedService`).

## Pre-launch checklist (all done in earlier PRs)

- [x] Refund flow (`/api/miniapp/refund` → Telegram `refundStarPayment`)
- [x] Privacy + Terms with real IE info (PR #146 + later updates)
- [x] Georgian-only as default language
- [x] 30-day free trial + 5 subscription tiers (100/249/449/849/1399 ⭐)
- [x] In-mini-app paywall via `openInvoice` (no chat-context-switch)
- [x] Bot profile metadata via API
- [x] Owner-only admin (stats / users / grant / refund / broadcast)
- [x] Profile rework (heatmap, phrase of day, copyable Telegram ID)
- [x] CI workflow runs tests on every PR

## Optional next step (not blocking)

Configure **Direct Link Mini App** in BotFather → `/mybots → @trale_bot → Configure Mini App → URL https://tralebot.com`. Gives the "Open" button on the bot's preview tile in users' chat lists, plus a shareable `t.me/trale_bot/app` link. Cannot be set via API.

## Test plan
- [ ] Deploy to k8s
- [ ] Send /start to @trale_bot — see WebApp button
- [ ] Verify chat menu button is "🚀 TraleBot"
- [ ] Open mini-app, see paywall, try Stars purchase

🤖 Generated with [Claude Code](https://claude.com/claude-code)