### PR TITLE
Hotfix: normalize HostAddress to https + 2 replicas, readiness probes

### DIFF
--- a/deploy/tralebot.yml
+++ b/deploy/tralebot.yml
@@ -47,7 +47,15 @@ kind: Deployment
 metadata:
   name: tralebot-deployment
 spec:
-  replicas: 1
+  replicas: 2
+  # Rolling update keeps the old pod running until the new one passes
+  # readiness checks. If the new build crashes on startup (e.g. bad config),
+  # K8s will fail the rollout and leave the old pod serving traffic — no outage.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: tralebot
@@ -56,9 +64,6 @@ spec:
       labels:
         app: tralebot
       annotations:
-        # Force a rolling restart on every deploy so env-only changes take effect.
-        # Without this, kubectl apply may keep the old pod running if only env values
-        # changed and the image tag happens to match an already-pulled image.
         kubectl.kubernetes.io/restartedAt: "$RUN_NUMBER"
     spec:
       containers:
@@ -66,6 +71,27 @@ spec:
           image: undermove/tralebot:$RUN_NUMBER
           ports:
             - containerPort: 1402
+          # Readiness probe gates traffic on /healthz — until it returns 200
+          # the pod isn't added to the Service. Combined with maxUnavailable: 0
+          # this means a crash-looping new pod can never replace a healthy old one.
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 1402
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          # Liveness probe restarts the pod if it stops responding (deadlock etc).
+          # More forgiving than readiness — only kicks in for already-running pods.
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 1402
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
           env:
             - name: ConnectionStrings__TraleBotDb
               valueFrom:

--- a/src/Infrastructure/Telegram/BotCommands/MenuCommand.cs
+++ b/src/Infrastructure/Telegram/BotCommands/MenuCommand.cs
@@ -30,7 +30,7 @@ public class MenuCommand : IBotCommand
     public async Task Execute(TelegramRequest request, CancellationToken token)
     {
         var miniAppUrl = _botConfig.MiniAppEnabled && !string.IsNullOrEmpty(_botConfig.HostAddress)
-            ? $"{_botConfig.HostAddress}/"
+            ? $"{_botConfig.NormalizedHost()}/"
             : null;
         var isOwner = _botConfig.OwnerTelegramId != 0 && request.UserTelegramId == _botConfig.OwnerTelegramId;
         var keyboard = MenuKeyboard.GetMenuKeyboard(request.User!.Settings.CurrentLanguage, miniAppUrl, isOwner);

--- a/src/Infrastructure/Telegram/BotCommands/StartCommand.cs
+++ b/src/Infrastructure/Telegram/BotCommands/StartCommand.cs
@@ -52,7 +52,7 @@ public class StartCommand(ITelegramBotClient client, IMediator mediator, BotConf
         }
 
         var miniAppUrl = botConfig.MiniAppEnabled && !string.IsNullOrEmpty(botConfig.HostAddress)
-            ? $"{botConfig.HostAddress}/"
+            ? $"{botConfig.NormalizedHost()}/"
             : null;
 
         // Build keyboard: WebApp button (primary CTA) when mini-app is enabled, plus text menu fallback.

--- a/src/Infrastructure/Telegram/BotConfiguration.cs
+++ b/src/Infrastructure/Telegram/BotConfiguration.cs
@@ -1,5 +1,25 @@
 ﻿namespace Infrastructure.Telegram;
 
+public static class BotConfigurationExtensions
+{
+    /// <summary>
+    /// Returns HostAddress with explicit https:// scheme and no trailing slash.
+    /// Telegram's setChatMenuButton + WebApp inline buttons enforce https,
+    /// so we sanitize here regardless of how the env var was configured.
+    /// </summary>
+    public static string NormalizedHost(this BotConfiguration config)
+    {
+        var raw = config.HostAddress;
+        if (string.IsNullOrWhiteSpace(raw)) return "";
+        var trimmed = raw.Trim().TrimEnd('/');
+        if (trimmed.StartsWith("https://", System.StringComparison.OrdinalIgnoreCase))
+            return trimmed;
+        if (trimmed.StartsWith("http://", System.StringComparison.OrdinalIgnoreCase))
+            return "https://" + trimmed.Substring("http://".Length);
+        return "https://" + trimmed;
+    }
+}
+
 public class BotConfiguration
 {
     public const string Configuration = "BotConfiguration";

--- a/src/Infrastructure/Telegram/Services/TelegramMessageSender.cs
+++ b/src/Infrastructure/Telegram/Services/TelegramMessageSender.cs
@@ -27,7 +27,7 @@ public class TelegramMessageSender(
                 {
                     InlineKeyboardButton.WithWebApp(
                         "🚀 Открыть TraleBot",
-                        new WebAppInfo { Url = $"{config.HostAddress}/" })
+                        new WebAppInfo { Url = $"{config.NormalizedHost()}/" })
                 });
             }
 

--- a/src/Trale/HostedServices/CreateWebhook.cs
+++ b/src/Trale/HostedServices/CreateWebhook.cs
@@ -26,20 +26,24 @@ public class CreateWebhook : IHostedService
             return;
         }
 
-        await _telegramBotClient.SetWebhookAsync($"{_config.HostAddress}/telegram/{_config.WebhookToken}",
+        // Normalize HostAddress via the shared extension so all WebApp URLs
+        // get explicit https:// (Telegram requires it for setChatMenuButton).
+        var hostAddress = _config.NormalizedHost();
+
+        await _telegramBotClient.SetWebhookAsync($"{hostAddress}/telegram/{_config.WebhookToken}",
             dropPendingUpdates: false,
             cancellationToken: cancellationToken);
 
         // Chat menu button (next to the text input) opens the TraleBot mini-app directly
         // when the feature is enabled — so users always have one-tap access to the app.
         // Falls back to standard commands menu when mini-app is disabled.
-        if (_config.MiniAppEnabled && !string.IsNullOrEmpty(_config.HostAddress))
+        if (_config.MiniAppEnabled)
         {
             await _telegramBotClient.SetChatMenuButtonAsync(
                 menuButton: new MenuButtonWebApp
                 {
                     Text = "🚀 TraleBot",
-                    WebApp = new WebAppInfo { Url = $"{_config.HostAddress}/" }
+                    WebApp = new WebAppInfo { Url = $"{hostAddress}/" }
                 },
                 cancellationToken: cancellationToken);
         }


### PR DESCRIPTION
## Critical fix

Production pod is crash-looping because the K8s secret \`TRALEBOT_SERVER_HOST\` stores \`tralebot.com/\` without \`https://\`. Telegram's \`setChatMenuButton\` rejects WebApp URLs without explicit https scheme, the hosted service throws on startup.

(PR #155 only added the \`restartedAt\` annotation; the actual URL fix and replicas changes live in this PR.)

## What this PR does

### Fix the URL
- New \`BotConfigurationExtensions.NormalizedHost()\` — strips trailing slash, prepends \`https://\` if missing
- Used everywhere a WebApp URL is built: \`CreateWebhook\`, \`MenuCommand\`, \`StartCommand\`, \`TelegramMessageSender\`

### Make sure this can't take prod down again
- **\`replicas: 2\`** — two pods at all times
- **\`strategy: RollingUpdate\`** with \`maxSurge: 1, maxUnavailable: 0\` — new pod must come up healthy before old one is killed
- **\`readinessProbe\`** on \`/healthz\` — pod isn't added to Service until /healthz returns 200
- **\`livenessProbe\`** on \`/healthz\` — restarts pod if it deadlocks later
- A crash-looping new build can never replace a healthy old one

## Long-term cleanup
The K8s secret \`TRALEBOT_SERVER_HOST\` should be updated to \`https://tralebot.com\` for cleanliness. The code now tolerates either format.

## Test plan
- [ ] Merge → CI builds → kubectl apply rolls out
- [ ] \`kubectl get pods -n tralebot-prod -w\` — new pod comes up before old is killed
- [ ] /menu in @trale_bot shows WebApp buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)