### PR TITLE
Two-sided referral program with activation triggers

### DIFF
--- a/src/Application/Common/ITraleDbContext.cs
+++ b/src/Application/Common/ITraleDbContext.cs
@@ -19,6 +19,7 @@ public interface ITraleDbContext
     DbSet<GeorgianQuizSession> GeorgianQuizSessions { get; }
     DbSet<MiniAppUserProgress> MiniAppUserProgresses { get; }
     DbSet<Payment> Payments { get; }
+    DbSet<Referral> Referrals { get; }
     
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
     EntityEntry Entry(object entity);

--- a/src/Application/DependencyInjection.cs
+++ b/src/Application/DependencyInjection.cs
@@ -3,6 +3,7 @@ using Application.Achievements.Services;
 using Application.Admin;
 using Application.Achievements.Services.Checkers;
 using Application.Common.Interfaces.Achievements;
+using Application.MiniApp.Commands;
 using Application.MiniApp.Queries;
 using Application.Quizzes.Services;
 using Application.Translation;
@@ -52,6 +53,11 @@ public static class DependencyInjection
         services.AddScoped<GrantProService>();
         services.AddScoped<RevokeProService>();
         services.AddScoped<BroadcastService>();
+
+        // Referral services (per ARCHITECTURE.md, no MediatR)
+        services.AddScoped<RecordReferralLinkService>();
+        services.AddScoped<TryActivateReferralService>();
+        services.AddScoped<GetReferralInfoQuery>();
 
         return services;
     }

--- a/src/Application/MiniApp/Commands/ActivateProStars.cs
+++ b/src/Application/MiniApp/Commands/ActivateProStars.cs
@@ -18,7 +18,10 @@ public class ActivateProStars : IRequest<ActivateProStarsResult>
     public int? Amount { get; init; }
     public string? Currency { get; init; }
 
-    public class Handler(ITraleDbContext dbContext, ILoggerFactory loggerFactory)
+    public class Handler(
+        ITraleDbContext dbContext,
+        ILoggerFactory loggerFactory,
+        TryActivateReferralService referralActivator)
         : IRequestHandler<ActivateProStars, ActivateProStarsResult>
     {
         private readonly ILogger _logger = loggerFactory.CreateLogger<Handler>();
@@ -91,6 +94,14 @@ public class ActivateProStars : IRequest<ActivateProStarsResult>
 
             _logger.LogInformation("Pro Stars activated for user {UserId} plan {Plan}",
                 request.UserId, planInfo?.Plan.ToString() ?? "legacy");
+
+            // Strongest activation signal: a paid purchase. Idempotent — no-op if no pending
+            // referral or already activated by lesson/vocab. Bypasses the cooldown check is fine
+            // because we still apply the per-referrer daily/yearly caps.
+            if (!string.IsNullOrEmpty(request.ChargeId))
+            {
+                await referralActivator.ExecuteAsync(request.UserId, "purchase", ct);
+            }
 
             // AlreadyPro only when user was already Pro AND no new payment payload arrived
             // (extension payments still report Success).

--- a/src/Application/MiniApp/Commands/CompleteLessonProgress.cs
+++ b/src/Application/MiniApp/Commands/CompleteLessonProgress.cs
@@ -17,7 +17,8 @@ public class CompleteLessonProgress : IRequest<CompleteLessonProgressResult>
 
     public class Handler(
         ITraleDbContext dbContext,
-        IProgressCalculator progressCalculator)
+        IProgressCalculator progressCalculator,
+        TryActivateReferralService referralActivator)
         : IRequestHandler<CompleteLessonProgress, CompleteLessonProgressResult>
     {
         public async Task<CompleteLessonProgressResult> Handle(CompleteLessonProgress request, CancellationToken ct)
@@ -31,6 +32,12 @@ public class CompleteLessonProgress : IRequest<CompleteLessonProgressResult>
             var update = progressCalculator.CalculateLessonCompletion(
                 progress, request.ModuleId, request.LessonId, request.Correct, request.Total);
             await dbContext.SaveChangesAsync(ct);
+
+            // Try to activate referral after a meaningful lesson completion (not vocab pseudo-module)
+            if (update.LessonCompleted && request.ModuleId != "vocabulary")
+            {
+                await referralActivator.ExecuteAsync(request.UserId, "first_lesson", ct);
+            }
 
             return new CompleteLessonProgressResult.Success(
                 update.XpEarned,

--- a/src/Application/MiniApp/Commands/RecordReferralLinkService.cs
+++ b/src/Application/MiniApp/Commands/RecordReferralLinkService.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common;
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Application.MiniApp.Commands;
+
+/// <summary>
+/// Records a "user A invited user B" link at the moment user B registers via the
+/// /start ref_X deep-link. Does NOT grant any bonus to the referrer — that happens
+/// later via TryActivateReferralService when B does something meaningful.
+///
+/// User B (referee) is rewarded immediately with extended trial — that's the
+/// hook that makes them click in the first place.
+/// </summary>
+public class RecordReferralLinkService(ITraleDbContext db, ILoggerFactory loggerFactory)
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<RecordReferralLinkService>();
+
+    public const int RefereeTrialBonusDays = 30;
+
+    public async Task<RecordReferralLinkResult> ExecuteAsync(
+        Guid newUserId, long referrerTelegramId, CancellationToken ct)
+    {
+        var newUser = await db.Users.FirstOrDefaultAsync(u => u.Id == newUserId, ct);
+        if (newUser == null) return RecordReferralLinkResult.NewUserNotFound;
+
+        // One referee — one referrer, ever.
+        if (newUser.ReferredByUserId.HasValue) return RecordReferralLinkResult.AlreadyReferred;
+
+        var referrer = await db.Users.FirstOrDefaultAsync(u => u.TelegramId == referrerTelegramId, ct);
+        if (referrer == null) return RecordReferralLinkResult.ReferrerNotFound;
+        if (referrer.Id == newUser.Id) return RecordReferralLinkResult.SelfReferral;
+
+        var now = DateTime.UtcNow;
+
+        // Referee bonus: extended trial. We shift RegisteredAtUtc earlier so trialDaysLeft
+        // calculation in GetMiniAppProfile gives more days.
+        newUser.RegisteredAtUtc = newUser.RegisteredAtUtc.AddDays(-RefereeTrialBonusDays);
+        newUser.ReferredByUserId = referrer.Id;
+
+        db.Referrals.Add(new Referral
+        {
+            Id = Guid.NewGuid(),
+            ReferrerUserId = referrer.Id,
+            RefereeUserId = newUser.Id,
+            CreatedAtUtc = now,
+            ActivatedAtUtc = null,
+            ActivationTrigger = null,
+            BonusReferrerDays = 0,
+            BonusRefereeDays = RefereeTrialBonusDays
+        });
+
+        await db.SaveChangesAsync(ct);
+        _logger.LogInformation("Referral link recorded: {Referee} <- {Referrer}",
+            newUser.Id, referrer.Id);
+        return RecordReferralLinkResult.Recorded;
+    }
+}
+
+public enum RecordReferralLinkResult
+{
+    Recorded,
+    AlreadyReferred,
+    NewUserNotFound,
+    ReferrerNotFound,
+    SelfReferral
+}

--- a/src/Application/MiniApp/Commands/TryActivateReferralService.cs
+++ b/src/Application/MiniApp/Commands/TryActivateReferralService.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common;
+using Application.MiniApp;
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Application.MiniApp.Commands;
+
+/// <summary>
+/// Idempotent: call this whenever a user does something that should count as
+/// "real engagement" — completing a lesson, adding their N-th vocab entry,
+/// purchasing Pro. If the user has a pending referral and passes anti-fraud
+/// checks, the referrer gets their bonus. Otherwise no-op.
+/// </summary>
+public class TryActivateReferralService(ITraleDbContext db, ILoggerFactory loggerFactory)
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<TryActivateReferralService>();
+
+    public const int ReferrerProBonusDays = 30;
+    public const int ReferrerTrialBonusDays = 7;
+    private const int MinSecondsBetweenRegistrationAndActivation = 3600; // 1 hour
+    private const int DailyActivationCapPerReferrer = 5;
+    private const int YearlyActivationCapPerReferrer = 12;
+
+    public async Task<TryActivateReferralResult> ExecuteAsync(
+        Guid refereeUserId, string trigger, CancellationToken ct)
+    {
+        var referral = await db.Referrals
+            .FirstOrDefaultAsync(r => r.RefereeUserId == refereeUserId && r.ActivatedAtUtc == null, ct);
+        if (referral == null) return TryActivateReferralResult.NoPendingReferral;
+
+        var now = DateTime.UtcNow;
+
+        // Anti-fraud: require minimum lifetime between registration and activation
+        // to defeat batch-fake "register then immediately activate" scripts.
+        if ((now - referral.CreatedAtUtc).TotalSeconds < MinSecondsBetweenRegistrationAndActivation)
+        {
+            return TryActivateReferralResult.TooEarly;
+        }
+
+        // Anti-fraud: cap daily activations per referrer
+        var startOfDay = now.Date;
+        var todayActivations = await db.Referrals
+            .CountAsync(r => r.ReferrerUserId == referral.ReferrerUserId
+                          && r.ActivatedAtUtc != null
+                          && r.ActivatedAtUtc >= startOfDay, ct);
+        if (todayActivations >= DailyActivationCapPerReferrer)
+        {
+            // Mark the referral as "saturated" — keep referee's trial bonus, just
+            // skip the referrer reward. Don't activate so it can be reviewed.
+            return TryActivateReferralResult.DailyCapReached;
+        }
+
+        // Anti-fraud: cap yearly activations per referrer
+        var yearAgo = now.AddDays(-365);
+        var yearActivations = await db.Referrals
+            .CountAsync(r => r.ReferrerUserId == referral.ReferrerUserId
+                          && r.ActivatedAtUtc != null
+                          && r.ActivatedAtUtc >= yearAgo, ct);
+        if (yearActivations >= YearlyActivationCapPerReferrer)
+        {
+            return TryActivateReferralResult.YearlyCapReached;
+        }
+
+        var referrer = await db.Users.FirstOrDefaultAsync(u => u.Id == referral.ReferrerUserId, ct);
+        if (referrer == null) return TryActivateReferralResult.ReferrerGone;
+
+        // Apply the referrer reward
+        int days;
+        if (referrer.IsPro && referrer.SubscriptionPlan == SubscriptionPlan.Lifetime)
+        {
+            // Lifetime gets nothing extra — counter only
+            days = 0;
+        }
+        else if (referrer.IsPro && referrer.SubscribedUntil.HasValue)
+        {
+            days = ReferrerProBonusDays;
+            referrer.SubscribedUntil = referrer.SubscribedUntil.Value.AddDays(days);
+        }
+        else
+        {
+            // Trial / free user — extend trial by shifting registration earlier
+            days = ReferrerTrialBonusDays;
+            referrer.RegisteredAtUtc = referrer.RegisteredAtUtc.AddDays(-days);
+        }
+
+        referral.ActivatedAtUtc = now;
+        referral.ActivationTrigger = trigger;
+        referral.BonusReferrerDays = days;
+
+        await db.SaveChangesAsync(ct);
+
+        _logger.LogInformation("Referral activated: {Referee} → {Referrer} +{Days}d via {Trigger}",
+            refereeUserId, referrer.Id, days, trigger);
+        return TryActivateReferralResult.Activated;
+    }
+}
+
+public enum TryActivateReferralResult
+{
+    Activated,
+    NoPendingReferral,
+    TooEarly,
+    DailyCapReached,
+    YearlyCapReached,
+    ReferrerGone
+}

--- a/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
+++ b/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.MiniApp.Queries;
+
+/// <summary>
+/// Data for the Profile screen "Invite a friend" card. Returns the user's
+/// referral telegram-id (used to build the deep-link), counts of pending
+/// vs activated referrals, and the bonus the referrer would currently earn
+/// (varies: lifetime owner = nothing, Pro = +30 days, free = +7 trial days).
+/// The deep-link URL itself is built by the controller because it needs
+/// BotConfiguration.BotName from Infrastructure.
+/// </summary>
+public class GetReferralInfoQuery(ITraleDbContext db)
+{
+    public async Task<GetReferralInfoResult?> ExecuteAsync(Guid userId, CancellationToken ct)
+    {
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Id == userId, ct);
+        if (user == null) return null;
+
+        var invited = await db.Referrals
+            .Where(r => r.ReferrerUserId == userId)
+            .CountAsync(ct);
+        var activated = await db.Referrals
+            .Where(r => r.ReferrerUserId == userId && r.ActivatedAtUtc != null)
+            .CountAsync(ct);
+
+        // What the user gets per successful activation, given their current state.
+        // Mirrors the branching in TryActivateReferralService.
+        string bonusLabel;
+        if (user.IsPro && user.SubscriptionPlan == Domain.Entities.SubscriptionPlan.Lifetime)
+        {
+            bonusLabel = "счётчик друзей (Lifetime — без бонуса)";
+        }
+        else if (user.IsPro)
+        {
+            bonusLabel = $"+{Commands.TryActivateReferralService.ReferrerProBonusDays} дней Pro за каждого активного друга";
+        }
+        else
+        {
+            bonusLabel = $"+{Commands.TryActivateReferralService.ReferrerTrialBonusDays} дней триала за каждого активного друга";
+        }
+
+        return new GetReferralInfoResult
+        {
+            ReferrerTelegramId = user.TelegramId,
+            InvitedCount = invited,
+            ActivatedCount = activated,
+            BonusLabel = bonusLabel
+        };
+    }
+}
+
+public class GetReferralInfoResult
+{
+    public long ReferrerTelegramId { get; init; }
+    public int InvitedCount { get; init; }
+    public int ActivatedCount { get; init; }
+    public string BonusLabel { get; init; } = "";
+}

--- a/src/Application/VocabularyEntries/Commands/TranslateAndCreateVocabularyEntry/TranslateAndCreateVocabularyEntry.cs
+++ b/src/Application/VocabularyEntries/Commands/TranslateAndCreateVocabularyEntry/TranslateAndCreateVocabularyEntry.cs
@@ -4,6 +4,7 @@ using Application.Common;
 using Application.Common.Extensions;
 using Application.Common.Interfaces.Achievements;
 using Application.Common.Interfaces.TranslationService;
+using Application.MiniApp.Commands;
 using Application.Translation;
 using Domain.Entities;
 using MediatR;
@@ -13,13 +14,19 @@ namespace Application.VocabularyEntries.Commands.TranslateAndCreateVocabularyEnt
 
 public class TranslateAndCreateVocabularyEntry : IRequest<CreateVocabularyEntryResult>
 {
+    /// <summary>Threshold for the "vocab" referral activation trigger — referee must add at least
+    /// this many words before the referrer gets credit. Higher than 1 to defeat trivial fraud
+    /// (one-word "real engagement" was too easy to fake).</summary>
+    public const int VocabActivationThreshold = 5;
+
     public required Guid UserId { get; init; }
     public required string Word { get; init; }
 
     public class Handler(
         ILanguageTranslator languageTranslator,
         ITraleDbContext context,
-        IAchievementsService achievementService)
+        IAchievementsService achievementService,
+        TryActivateReferralService referralActivator)
         : IRequestHandler<TranslateAndCreateVocabularyEntry, CreateVocabularyEntryResult>
     {
         public async Task<CreateVocabularyEntryResult> Handle(TranslateAndCreateVocabularyEntry request, CancellationToken ct)
@@ -95,8 +102,18 @@ public class TranslateAndCreateVocabularyEntry : IRequest<CreateVocabularyEntryR
 
             await context.SaveChangesAsync(ct);
 
-            var vocabularyCountTrigger = new VocabularyCountTrigger { VocabularyEntriesCount = user.VocabularyEntries.Count };
+            var newVocabCount = user.VocabularyEntries.Count + 1; // +1 for the entry just saved
+            var vocabularyCountTrigger = new VocabularyCountTrigger { VocabularyEntriesCount = newVocabCount };
             await achievementService.AssignAchievements(vocabularyCountTrigger, user.Id, ct);
+
+            // Activate referral on N-th vocab entry. We fire on every add past the threshold rather
+            // than only at exactly N — TryActivateReferralService is idempotent (no-ops if already
+            // activated), so duplicate calls are cheap and we don't lose activation if the first
+            // attempt fails (e.g., still inside the 1-hour cooldown).
+            if (newVocabCount >= VocabActivationThreshold)
+            {
+                await referralActivator.ExecuteAsync(request.UserId, "vocab_5", ct);
+            }
 
             return new CreateVocabularyEntryResult.TranslationSuccess(
                 definition,

--- a/src/Domain/Entities/Referral.cs
+++ b/src/Domain/Entities/Referral.cs
@@ -1,0 +1,36 @@
+#pragma warning disable CS8618
+namespace Domain.Entities;
+
+/// <summary>
+/// One row per "user A invited user B" event. Allows funnel analytics
+/// (clicks → registered → activated) and per-pair audit when investigating fraud.
+/// User.ReferredByUserId mirrors RefereeUserId → ReferrerUserId of the latest row
+/// for fast lookups, but this table is the source of truth.
+/// </summary>
+public class Referral
+{
+    public Guid Id { get; set; }
+
+    public Guid ReferrerUserId { get; set; }
+    public virtual User Referrer { get; set; }
+
+    public Guid RefereeUserId { get; set; }
+    public virtual User Referee { get; set; }
+
+    /// <summary>When the referee registered via the deep-link.</summary>
+    public DateTime CreatedAtUtc { get; set; }
+
+    /// <summary>When the activation trigger fired. Null until the referee
+    /// actually does something meaningful in the app.</summary>
+    public DateTime? ActivatedAtUtc { get; set; }
+
+    /// <summary>What triggered activation: "first_lesson" / "vocab_5" / "purchase".
+    /// Null while ActivatedAtUtc is null.</summary>
+    public string? ActivationTrigger { get; set; }
+
+    /// <summary>Days of Pro/trial added to referrer at activation. Zero if capped.</summary>
+    public int BonusReferrerDays { get; set; }
+
+    /// <summary>Days of trial added to referee at registration.</summary>
+    public int BonusRefereeDays { get; set; }
+}

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -16,6 +16,10 @@ public class User
     public bool IsPro { get; set; }
     public DateTime? ProPurchasedAtUtc { get; set; }
     public SubscriptionPlan? SubscriptionPlan { get; set; }
+    /// <summary>Mirrors the referrer from the latest Referral row for fast lookups.
+    /// Source of truth is the Referrals table (see Referral entity).</summary>
+    public Guid? ReferredByUserId { get; set; }
+    public virtual User? ReferredBy { get; set; }
     public virtual UserSettings Settings { get; set; }
     public virtual ICollection<VocabularyEntry> VocabularyEntries { get; set; }
     public virtual ICollection<Quiz> Quizzes { get; set; }
@@ -23,6 +27,7 @@ public class User
     public virtual ICollection<Achievement> Achievements { get; set; }
     public virtual ICollection<ShareableQuiz> ShareableQuizzes { get; set; }
     public virtual ICollection<Payment> Payments { get; set; }
+    public virtual ICollection<Referral> ReferralsMade { get; set; }
     
     public bool IsActivePremium()
     {

--- a/src/Infrastructure/Telegram/BotCommands/StartCommand.cs
+++ b/src/Infrastructure/Telegram/BotCommands/StartCommand.cs
@@ -1,16 +1,26 @@
+using Application.MiniApp.Commands;
 using Application.Quizzes.Commands.CreateSharedQuiz;
 using Application.Users.Commands.CreateUser;
 using Infrastructure.Telegram.BotCommands.Quiz;
 using Infrastructure.Telegram.Models;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using Telegram.Bot;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.ReplyMarkups;
 
 namespace Infrastructure.Telegram.BotCommands;
 
-public class StartCommand(ITelegramBotClient client, IMediator mediator, BotConfiguration botConfig) : IBotCommand
+public class StartCommand(
+    ITelegramBotClient client,
+    IMediator mediator,
+    BotConfiguration botConfig,
+    RecordReferralLinkService referralRecorder,
+    ILoggerFactory loggerFactory) : IBotCommand
 {
+    private const string ReferralPrefix = "ref_";
+    private readonly ILogger _logger = loggerFactory.CreateLogger<StartCommand>();
+
     public Task<bool> IsApplicable(TelegramRequest request, CancellationToken ct)
     {
         var commandPayload = request.Text;
@@ -33,22 +43,39 @@ public class StartCommand(ITelegramBotClient client, IMediator mediator, BotConf
         }
 
         var commandWithArgs = request.Text.Split(' ');
+        var hasReferralArg = false;
         if (ContainsArguments(commandWithArgs))
         {
-            var result = await mediator.Send(new CreateQuizFromShareableCommand
+            var arg = commandWithArgs[1];
+            if (arg.StartsWith(ReferralPrefix, StringComparison.OrdinalIgnoreCase))
             {
-                UserId = request.User?.Id ?? user!.Id,
-                ShareableQuizId = Guid.Parse(commandWithArgs[1])
-            }, token);
-
-            await (result switch
+                // /start ref_<TelegramId> — record referral link, fall through to normal welcome.
+                hasReferralArg = true;
+                if (long.TryParse(arg.AsSpan(ReferralPrefix.Length), out var referrerTelegramId))
+                {
+                    var refResult = await referralRecorder.ExecuteAsync(user!.Id, referrerTelegramId, token);
+                    _logger.LogInformation(
+                        "Referral attempt from /start: user {User} referrer-tg {Referrer} → {Result}",
+                        user.Id, referrerTelegramId, refResult);
+                }
+            }
+            else
             {
-                CreateQuizFromShareableResult.SharedQuizCreated created => SendFirstQuestion(request, token, created),
-                CreateQuizFromShareableResult.NotEnoughQuestionsForSharedQuiz _ => Task.CompletedTask,
-                _ => throw new ArgumentOutOfRangeException(nameof(result))
-            });
+                var result = await mediator.Send(new CreateQuizFromShareableCommand
+                {
+                    UserId = request.User?.Id ?? user!.Id,
+                    ShareableQuizId = Guid.Parse(arg)
+                }, token);
 
-            return;
+                await (result switch
+                {
+                    CreateQuizFromShareableResult.SharedQuizCreated created => SendFirstQuestion(request, token, created),
+                    CreateQuizFromShareableResult.NotEnoughQuestionsForSharedQuiz _ => Task.CompletedTask,
+                    _ => throw new ArgumentOutOfRangeException(nameof(result))
+                });
+
+                return;
+            }
         }
 
         var miniAppUrl = botConfig.MiniAppEnabled && !string.IsNullOrEmpty(botConfig.HostAddress)
@@ -79,6 +106,13 @@ public class StartCommand(ITelegramBotClient client, IMediator mediator, BotConf
                 ? "Жми «🚀 Открыть TraleBot» — попадёшь в приложение, где есть алфавит, грамматика, словарь и квизы. Тебя там встретит щенок Бомбора 🐶 — твой гид и маскот.\n\n"
                 : "";
 
+            // If they came in via a referral link, show the bonus trial — that's the hook
+            // that justified clicking. RecordReferralLinkService only credits valid links,
+            // but showing the bonus on any ref_X arg is fine: bad links just look like 60 days.
+            var trialLine = hasReferralArg
+                ? "Тебе ещё и бонус: 60 дней бесплатно вместо 30 — за то, что пришёл по приглашению. 🎁"
+                : "Первые 30 дней — всё бесплатно.";
+
             await client.SendTextMessageAsync(
                 request.UserTelegramId,
 $@"გამარჯობა, {request.UserName}! 👋
@@ -90,7 +124,7 @@ $@"გამარჯობა, {request.UserName}! 👋
 
 {miniAppLine}А ещё в чате со мной можно переводить слова — я добавлю их в твой словарь и сделаю по ним квизы. Просто напиши любое слово или фразу.
 
-Первые 30 дней — всё бесплатно.",
+{trialLine}",
                 replyMarkup: keyboard,
                 cancellationToken: token);
         }

--- a/src/Persistence/Configurations/ReferralConfiguration.cs
+++ b/src/Persistence/Configurations/ReferralConfiguration.cs
@@ -1,0 +1,30 @@
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Persistence.Configurations;
+
+public class ReferralConfiguration : IEntityTypeConfiguration<Referral>
+{
+    public void Configure(EntityTypeBuilder<Referral> builder)
+    {
+        builder.HasKey(r => r.Id);
+
+        builder.HasOne(r => r.Referrer)
+            .WithMany(u => u.ReferralsMade)
+            .HasForeignKey(r => r.ReferrerUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(r => r.Referee)
+            .WithOne()
+            .HasForeignKey<Referral>(r => r.RefereeUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.Property(r => r.ActivationTrigger).HasMaxLength(64);
+
+        // One row per (referrer, referee) — stops double-credit
+        builder.HasIndex(r => new { r.ReferrerUserId, r.RefereeUserId }).IsUnique();
+        // One referee can be referred by only one person
+        builder.HasIndex(r => r.RefereeUserId).IsUnique();
+    }
+}

--- a/src/Persistence/Configurations/UserConfiguration.cs
+++ b/src/Persistence/Configurations/UserConfiguration.cs
@@ -21,5 +21,10 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
             .WithOne(ve => ve.User)
             .HasForeignKey(ve => ve.UserId);
         builder.Property(u => u.SubscriptionPlan).HasConversion<int?>();
+
+        builder.HasOne(u => u.ReferredBy)
+            .WithMany()
+            .HasForeignKey(u => u.ReferredByUserId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/src/Persistence/Migrations/20260416171143_AddReferralsTable.Designer.cs
+++ b/src/Persistence/Migrations/20260416171143_AddReferralsTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Persistence;
@@ -11,9 +12,11 @@ using Persistence;
 namespace Persistence.Migrations
 {
     [DbContext(typeof(TraleDbContext))]
-    partial class TraleDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260416171143_AddReferralsTable")]
+    partial class AddReferralsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/Migrations/20260416171143_AddReferralsTable.cs
+++ b/src/Persistence/Migrations/20260416171143_AddReferralsTable.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReferralsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ReferredByUserId",
+                table: "Users",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Referrals",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ReferrerUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RefereeUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ActivatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ActivationTrigger = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    BonusReferrerDays = table.Column<int>(type: "integer", nullable: false),
+                    BonusRefereeDays = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Referrals", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Referrals_Users_RefereeUserId",
+                        column: x => x.RefereeUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Referrals_Users_ReferrerUserId",
+                        column: x => x.ReferrerUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_ReferredByUserId",
+                table: "Users",
+                column: "ReferredByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Referrals_RefereeUserId",
+                table: "Referrals",
+                column: "RefereeUserId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Referrals_ReferrerUserId_RefereeUserId",
+                table: "Referrals",
+                columns: new[] { "ReferrerUserId", "RefereeUserId" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Users_Users_ReferredByUserId",
+                table: "Users",
+                column: "ReferredByUserId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Users_Users_ReferredByUserId",
+                table: "Users");
+
+            migrationBuilder.DropTable(
+                name: "Referrals");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Users_ReferredByUserId",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "ReferredByUserId",
+                table: "Users");
+        }
+    }
+}

--- a/src/Persistence/TraleDbContext.cs
+++ b/src/Persistence/TraleDbContext.cs
@@ -28,6 +28,7 @@ public class TraleDbContext : DbContext, ITraleDbContext
     public DbSet<GeorgianQuizSession> GeorgianQuizSessions { get; set; } = null!;
     public DbSet<MiniAppUserProgress> MiniAppUserProgresses { get; set; } = null!;
     public DbSet<Payment> Payments { get; set; } = null!;
+    public DbSet<Referral> Referrals { get; set; } = null!;
 
     public async Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
     {
@@ -47,6 +48,7 @@ public class TraleDbContext : DbContext, ITraleDbContext
         modelBuilder.ApplyConfiguration(new GeorgianQuizSessionConfiguration());
         modelBuilder.ApplyConfiguration(new MiniAppUserProgressConfiguration());
         modelBuilder.ApplyConfiguration(new PaymentConfiguration());
+        modelBuilder.ApplyConfiguration(new ReferralConfiguration());
     }
     
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/src/Trale/Controllers/MiniAppController.cs
+++ b/src/Trale/Controllers/MiniAppController.cs
@@ -353,6 +353,37 @@ public class MiniAppController : Controller
         return Ok(new { dates });
     }
 
+    [HttpGet("referral")]
+    public async Task<IActionResult> Referral(
+        [FromServices] Application.MiniApp.Queries.GetReferralInfoQuery query,
+        CancellationToken ct)
+    {
+        var user = await ResolveUserAsync(ct);
+        if (user == null)
+        {
+            return Unauthorized(new { error = "not_authenticated" });
+        }
+
+        var info = await query.ExecuteAsync(user.Id, ct);
+        if (info == null)
+        {
+            return NotFound();
+        }
+
+        // Build the t.me deep-link here because BotName lives in Infrastructure.
+        var link = $"https://t.me/{_botConfig.BotName}?start=ref_{info.ReferrerTelegramId}";
+        var shareText = "Учу грузинский в TraleBot 🇬🇪 — приходи, тебе дадут 60 дней триала вместо 30.";
+
+        return Ok(new
+        {
+            link,
+            shareText,
+            invitedCount = info.InvitedCount,
+            activatedCount = info.ActivatedCount,
+            bonusLabel = info.BonusLabel
+        });
+    }
+
     [HttpGet("vocabulary")]
     public async Task<IActionResult> GetVocabulary(CancellationToken ct)
     {

--- a/src/Trale/miniapp-src/src/api.ts
+++ b/src/Trale/miniapp-src/src/api.ts
@@ -177,6 +177,15 @@ export const api = {
   activityDays: (days = 35) =>
     request<{ dates: string[] }>(`/api/miniapp/activity-days?days=${days}`),
 
+  referral: () =>
+    request<{
+      link: string
+      shareText: string
+      invitedCount: number
+      activatedCount: number
+      bonusLabel: string
+    }>('/api/miniapp/referral'),
+
   adminStats: () => request<AdminStats>('/api/admin/stats'),
   adminSignups: (days = 30) =>
     request<{ days: number; points: Array<{ date: string; count: number }> }>(

--- a/src/Trale/miniapp-src/src/screens/Profile.tsx
+++ b/src/Trale/miniapp-src/src/screens/Profile.tsx
@@ -236,6 +236,9 @@ export default function Profile({ catalog, progress, isPro, isOwner = false, tel
           </div>
         </button>
 
+        {/* Referral — invite friends, get bonus */}
+        <ReferralCard />
+
         {/* Telegram ID for support — copyable */}
         {telegramId != null && <TelegramIdCard telegramId={telegramId} />}
 
@@ -287,6 +290,114 @@ export default function Profile({ catalog, progress, isPro, isOwner = false, tel
           }}
         />
       )}
+    </div>
+  )
+}
+
+function ReferralCard() {
+  const [data, setData] = useState<{
+    link: string
+    shareText: string
+    invitedCount: number
+    activatedCount: number
+    bonusLabel: string
+  } | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    api
+      .referral()
+      .then((r) => {
+        if (!cancelled) setData(r)
+      })
+      .catch(() => {
+        if (!cancelled) setError(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (error || !data) return null
+
+  async function copy() {
+    if (!data) return
+    try {
+      const tg = (window as any).Telegram?.WebApp
+      if (tg?.HapticFeedback?.impactOccurred) tg.HapticFeedback.impactOccurred('light')
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(data.link)
+      } else {
+        const ta = document.createElement('textarea')
+        ta.value = data.link
+        ta.style.position = 'fixed'
+        ta.style.left = '-9999px'
+        document.body.appendChild(ta)
+        ta.select()
+        document.execCommand('copy')
+        document.body.removeChild(ta)
+      }
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // best effort
+    }
+  }
+
+  function share() {
+    const tg = (window as any).Telegram?.WebApp
+    // Use Telegram's native share dialog when available — picks a chat to forward to.
+    const shareUrl = `https://t.me/share/url?url=${encodeURIComponent(
+      data!.link
+    )}&text=${encodeURIComponent(data!.shareText)}`
+    if (tg?.openTelegramLink) {
+      tg.openTelegramLink(shareUrl)
+    } else {
+      window.open(shareUrl, '_blank', 'noopener')
+    }
+  }
+
+  return (
+    <div className="mt-6">
+      <div className="mn-eyebrow mb-2">пригласи друга</div>
+      <div className="jewel-tile px-4 py-4">
+        <div className="relative z-[1]">
+          <div className="font-sans text-[13px] text-jewelInk-mid mb-3 leading-snug">
+            Друг получит 60 дней триала вместо 30. Ты — {data.bonusLabel}, когда он
+            пройдёт первый урок или добавит 5 слов.
+          </div>
+
+          <div className="flex items-center gap-2 mb-3 jewel-tile px-3 py-2">
+            <div className="relative z-[1] flex-1 min-w-0 font-sans text-[12px] text-jewelInk truncate">
+              {data.link}
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              onClick={share}
+              className="flex-1 font-sans text-[13px] font-extrabold text-jewelInk min-h-[40px] rounded border-[1.5px] border-jewelInk"
+              style={{ background: '#F5B820', boxShadow: '0 2px 0 #15100A' }}
+            >
+              Поделиться
+            </button>
+            <button
+              onClick={copy}
+              className="flex-1 font-sans text-[13px] font-bold text-jewelInk min-h-[40px] rounded border-[1.5px] border-jewelInk/40"
+            >
+              {copied ? '✓ скопировано' : '📋 копировать'}
+            </button>
+          </div>
+
+          {data.invitedCount > 0 && (
+            <div className="mt-3 font-sans text-[11px] text-jewelInk-mid">
+              Пригласил: {data.invitedCount} · активных: {data.activatedCount}
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,7 +46,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>Бомбора — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-CBFYka6q.js"></script>
+    <script type="module" crossorigin src="/assets/index-DzBHtuUB.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Bd771tgR.css">
   </head>
   <body>

--- a/tests/Application.UnitTests/Tests/ActivateProStarsCommandTests.cs
+++ b/tests/Application.UnitTests/Tests/ActivateProStarsCommandTests.cs
@@ -13,7 +13,10 @@ public class ActivateProStarsCommandTests : CommandTestsBase
     [SetUp]
     public void SetUp()
     {
-        _sut = new ActivateProStars.Handler(Context, NullLoggerFactory.Instance);
+        _sut = new ActivateProStars.Handler(
+            Context,
+            NullLoggerFactory.Instance,
+            new TryActivateReferralService(Context, NullLoggerFactory.Instance));
     }
 
     [Test]

--- a/tests/Application.UnitTests/Tests/TranslateAndCreateVocabularyEntryCommandTests.cs
+++ b/tests/Application.UnitTests/Tests/TranslateAndCreateVocabularyEntryCommandTests.cs
@@ -1,12 +1,14 @@
 using Application.Achievements.Services.Triggers;
 using Application.Common.Interfaces.Achievements;
 using Application.Common.Interfaces.TranslationService;
+using Application.MiniApp.Commands;
 using Application.Translation;
 using Application.UnitTests.Common;
 using Application.UnitTests.DSL;
 using Application.VocabularyEntries.Commands.TranslateAndCreateVocabularyEntry;
 using Domain.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Shouldly;
 
@@ -39,7 +41,8 @@ public class TranslateAndCreateVocabularyEntryCommandTests : CommandTestsBase
         _createVocabularyEntryCommandHandler = new TranslateAndCreateVocabularyEntry.Handler(
             _languageTranslatorMock.Object,
             Context,
-            _achievementsService.Object);
+            _achievementsService.Object,
+            new TryActivateReferralService(Context, NullLoggerFactory.Instance));
     }
     
     [Test]


### PR DESCRIPTION
## Summary
- Referee gets +30 trial days at `/start ref_<TgId>`. Referrer earns bonus only after activation: complete a lesson, add 5+ vocab words, or buy Pro.
- Anti-fraud: 1hr min between registration and activation, 5/day and 12/year per referrer cap, one referee ever per user, self-referral blocked, unique indexes against double-credit.
- Referrer reward: Lifetime owners get a counter only; Pro users get +30 days; trial/free users get +7 trial days. Referee reward: +30 trial days at /start.
- New `Referral` entity + EF migration. New services `RecordReferralLinkService` and `TryActivateReferralService`. New `GET /api/miniapp/referral` endpoint. New `ReferralCard` on Profile screen with copy/share buttons.

## Test plan
- [ ] User A opens Profile in mini-app → sees ReferralCard with link `t.me/<bot>?start=ref_<A.TgId>`
- [ ] Tap "Поделиться" → opens Telegram share sheet with link
- [ ] Tap "Копировать" → clipboard contains link, button shows "✓ скопировано"
- [ ] User B opens A's link → /start fires → B sees welcome with "60 дней триала вместо 30" badge
- [ ] B's RegisteredAtUtc is shifted back by 30 days; B's ReferredByUserId = A.Id
- [ ] Same B clicks A's link again → AlreadyReferred (no double-credit)
- [ ] B tries A's own link with own TG id → SelfReferral (no record)
- [ ] B completes a lesson → Referral.ActivatedAtUtc set, A gets bonus per state (Pro: +30d to SubscribedUntil, free: -7d to RegisteredAtUtc)
- [ ] B adds 5 vocab words → activation fires (idempotent if lesson already activated)
- [ ] B buys Pro → activation fires with trigger="purchase"
- [ ] If B activates within 1hr of registration → TooEarly result, no bonus to A yet
- [ ] If A already had 5 successful activations today → DailyCapReached, no bonus, status remains pending for review
- [ ] A's ReferralCard shows updated invitedCount/activatedCount

🤖 Generated with [Claude Code](https://claude.com/claude-code)