### PR TITLE
Hotfix: don't delete webhook on pod shutdown

### DIFF
--- a/src/Trale/HostedServices/CreateWebhook.cs
+++ b/src/Trale/HostedServices/CreateWebhook.cs
@@ -85,12 +85,14 @@ public class CreateWebhook : IHostedService
         }
     }
 
-    public async Task StopAsync(CancellationToken cancellationToken)
+    public Task StopAsync(CancellationToken cancellationToken)
     {
-        if (!string.IsNullOrEmpty(_config.HostAddress))
-        {
-            // set first parameter to true in critical situations
-            await _telegramBotClient.DeleteWebhookAsync(false, cancellationToken);
-        }
+        // Intentionally NOT calling DeleteWebhookAsync here. With multi-replica
+        // deployments and rolling updates, the shutdown of one pod would otherwise
+        // wipe the webhook URL while the other pod stays running but never re-runs
+        // its StartAsync — leaving Telegram with no delivery target and silently
+        // queueing updates. The next pod startup re-sets the webhook to the correct
+        // URL anyway, so deletion on shutdown serves no purpose in production.
+        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
- Removed the `DeleteWebhookAsync` call from `CreateWebhook.StopAsync` — kept it as `Task.CompletedTask`.
- Root cause for prod outage where slash commands stopped working after the 2-replica rollout: when one pod terminated during a rolling update, its `StopAsync` wiped Telegram's webhook URL. The other pod stayed up but its `StartAsync` had already executed, so the webhook never got re-set. Mini-app kept working because it talks to `/api` directly via ingress, masking the failure.
- Verified in prod: `getWebhookInfo` returned `url=""` with `pending_update_count=5` while both pods were `Running 0`. Manually re-set the webhook to unblock — pending count dropped to 0.
- Webhook lifecycle should outlive individual pods. Next pod startup re-sets the URL idempotently, so the delete-on-shutdown served no production purpose.

## Test plan
- [ ] After merge + deploy, confirm `getWebhookInfo` URL stays set across rolling restart
- [ ] `/start` and `/menu` slash commands respond from prod
- [ ] Trigger a manual rollout (`kubectl rollout restart deployment/tralebot-deployment -n tralebot-prod`) and verify webhook stays intact during pod recycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)