### PR TITLE
fix(agent): enable Testcontainers in bombora-agents container

### DIFF
--- a/deploy/agents/docker-compose.yml
+++ b/deploy/agents/docker-compose.yml
@@ -18,6 +18,14 @@ services:
       - TZ=Asia/Tbilisi
       # Limits
       - MAX_TURNS=${MAX_TURNS:-30}
+      # Testcontainers: run sibling containers on the host Docker daemon.
+      # RYUK_DISABLED — socket proxy can't look up ryuk by id after creation
+      # (returns 404), so disable the resource reaper.
+      # HOST_OVERRIDE=host.docker.internal — test client inside this container
+      # must connect to test Postgres via the host's docker-desktop bridge,
+      # not via `localhost` (which points back to bombora-agents itself).
+      - TESTCONTAINERS_RYUK_DISABLED=true
+      - TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal
     volumes:
       - agent-logs:/logs
       - agent-workspace:/workspace


### PR DESCRIPTION
## Проблема
Docker-сокет был примонтирован в #434, но Testcontainers всё равно не работал внутри `bombora-agents`, и QA-агент продолжал писать «IntegrationTests ⚠️ Docker/Testcontainers недоступен». Именно поэтому в ночных ПР-ах CI-проверка `LessonTheoryQuestionCoverageTests` падала уже на стороне GitHub Actions — QA ни разу её локально не прогонял.

## Корень
Две отдельные проблемы мешали Testcontainers:

1. **ResourceReaper (ryuk).** Docker Desktop socket-proxy на macOS возвращает 404 при попытке найти ryuk по container-id после его создания — вся инициализация Testcontainers падает. Лечится `TESTCONTAINERS_RYUK_DISABLED=true`.

2. **Host resolution.** Тест-клиент внутри агент-контейнера подключался к Postgres-контейнеру по `localhost:<порт>`, а `localhost` внутри агента — это он сам, а не хост. Лечится `TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal`.

## Проверка
С обоими флагами внутри агент-контейнера проходят **все 142 IntegrationTests**:

```
docker exec -e TESTCONTAINERS_RYUK_DISABLED=true -e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal \
  bombora-agents dotnet test tests/IntegrationTests/IntegrationTests.csproj
Passed! - Failed: 0, Passed: 142
```

## Применить
После мержа нужно один раз пересоздать контейнер агента:
```
cd deploy/agents && docker compose up -d --force-recreate
```