### PR TITLE
feat(agents): hard-gate QA on full tests + draft morning PR until CI green

### DIFF
--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -15,13 +15,17 @@
 
 ## Что ты делаешь
 
-### 1. Сборка и тесты
+### 1. Сборка и тесты — жёсткий гейт
+
 ```bash
-dotnet build
-dotnet test
+dotnet build TraleBot.sln
+dotnet test TraleBot.sln                  # ВСЕ проекты: Domain, Application, Infrastructure, IntegrationTests
 cd src/Trale/miniapp-src && npm run build
 ```
-Если что-то не собирается или тесты падают — это баг #1. Почини и зафиксируй.
+
+**IntegrationTests обязательны.** В этом контейнере Testcontainers работает — в `deploy/agents/docker-compose.yml` выставлены `TESTCONTAINERS_RYUK_DISABLED=true` и `TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal`. Если IntegrationTests не запускаются — это проблема инфры, немедленно отметь в отчёте и файли issue, НЕ пропускай их молча.
+
+Если любая из команд падает — это баг #1. Либо почини сам (мелкие вещи: stale snapshot, missing lemma в theory, wwwroot rebuild), либо откати последний developer-коммит, либо повесь `needs-fix` на issue, который developer только что тронул. **Час не закрывается, пока `dotnet test TraleBot.sln` локально не зелёный.**
 
 ### 2. Проверка миграций
 - Есть ли новые файлы в `src/Persistence/Migrations/`?
@@ -85,4 +89,6 @@ cd src/Trale/miniapp-src && npm run build
 - НЕ пушь в main
 - НЕ удаляй чужой код без причины
 - Если не уверен — отметь как «⚠️ требует проверки» вместо того чтобы чинить наугад
-- ВСЕГДА запускай `dotnet test` после любых исправлений — тесты должны быть зелёными
+- ВСЕГДА запускай `dotnet test TraleBot.sln` после любых исправлений — ВСЕ тесты (включая IntegrationTests) должны быть зелёными
+- Никогда не пиши в отчёте «IntegrationTests skipped/unavailable» как нормальный исход — это всегда ошибка среды и должна быть расследована
+- Час считается закрытым только если последний локальный прогон `dotnet test TraleBot.sln` зелёный. Если не удалось довести до зелёного — явно об этом напиши в отчёте и в `=== SUMMARY ===`, чтобы следующий developer-слот увидел ишью как priority #1

--- a/deploy/agents/scripts/run-pipeline.sh
+++ b/deploy/agents/scripts/run-pipeline.sh
@@ -223,11 +223,11 @@ At the very end output '=== SUMMARY ===' with 3-7 bullets: issue picked, files c
 
     # 7. QA
     "${CONTEXT_PREFIX}Read .claude/agents/qa.md. You have the official Microsoft .NET Agent Skills loaded including dotnet-diag (performance/debugging/incident analysis) and dotnet-test (test execution, filtering, failure triage) — check '/skills' and use them to diagnose failing tests or flaky integration runs. Your role this hour (after developer):
-- Run the full integration pass on the current state of the shared branch: 'dotnet test' + 'cd src/Trale/miniapp-src && npm run build'. Check migrations if DB code changed.
-- If builds/tests fail: comment on the issue that developer just touched with the failure details, add label 'needs-fix'. Do NOT try to fix big regressions yourself — that is developer's job next hour.
-- Small build/config fixes (missing files, stale snapshots, wwwroot rebuild) — do fix those yourself.
-- Append integration findings to 'qa-report-${TODAY}.md' at repo root (create if absent). One dated section per hour.
-At the very end output '=== SUMMARY ===' with 3-7 bullets: what you ran, what passed, what failed, follow-ups filed."
+- Run the FULL test pass on the current state of the shared branch: 'dotnet test TraleBot.sln' (ALL projects, IntegrationTests included — Testcontainers works here, env vars TESTCONTAINERS_RYUK_DISABLED + TESTCONTAINERS_HOST_OVERRIDE are set in compose) + 'cd src/Trale/miniapp-src && npm run build'. Check migrations if DB code changed.
+- HARD GATE: the hour does NOT close until 'dotnet test TraleBot.sln' is green locally. If IntegrationTests fail — do NOT write 'skipped/unavailable' in the report, that is always an infra bug and must be filed as such.
+- If builds/tests fail: either fix small things yourself (stale snapshot, missing lemma in theory, wwwroot rebuild, missing migration .Designer.cs), or revert the last developer commit to return to green, or comment on the issue that developer just touched with the failure details and add label 'needs-fix'. Do NOT leave the branch red for the next hour.
+- Append integration findings to 'qa-report-${TODAY}.md' at repo root (create if absent). One dated section per hour. Explicitly record the result of 'dotnet test TraleBot.sln' (pass/fail + count).
+At the very end output '=== SUMMARY ===' with 3-7 bullets: what you ran, whether 'dotnet test TraleBot.sln' ended green, what passed, what failed, follow-ups filed."
 
     # 8. TECH-LEAD-REVIEW (architecture review — runs LAST, after QA)
     "${CONTEXT_PREFIX}Read .claude/agents/tech-lead.md AND ARCHITECTURE.md. You have the official Microsoft .NET Agent Skills loaded (dotnet, dotnet-aspnet, dotnet-data, dotnet-test, dotnet-nuget) — invoke them when reviewing C# code, tests, EF migrations, or package decisions so feedback matches Microsoft's own .NET team standards.

--- a/deploy/agents/scripts/run-qa.sh
+++ b/deploy/agents/scripts/run-qa.sh
@@ -205,23 +205,52 @@ ${FILES_CHANGED}
 PREOF
 )
 
-# --- Open or refresh PR ---------------------------------------------------------
+# --- Open or refresh PR (as DRAFT) ----------------------------------------------
 # Use the REST API directly for body updates. `gh pr edit` currently fails
 # (exit 1) on repos with classic Projects attached — it emits "GraphQL: Projects
 # (classic) is being deprecated" and aborts the update. REST PATCH avoids the
 # GraphQL projects enumeration entirely.
+#
+# Morning PR always opens as DRAFT. It is promoted to "ready for review" only
+# AFTER GitHub Actions CI returns green (see CI-gate below). This way the
+# owner's morning PR list only surfaces PRs that are actually mergeable —
+# red PRs stay visibly in draft state with the failure details commented.
 REPO_SLUG=$(git config --get remote.origin.url | sed -E 's#.*github\.com[:/]([^/]+/[^/.]+).*#\1#')
 EXISTING_PR=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number' 2>/dev/null || true)
 if [ -n "${EXISTING_PR}" ]; then
     echo ">>> PR #${EXISTING_PR} already exists for ${BRANCH}. Updating body via REST."
     gh api "repos/${REPO_SLUG}/pulls/${EXISTING_PR}" --method PATCH \
         -f body="${PR_BODY}" --jq .html_url || true
+    PR_NUMBER="${EXISTING_PR}"
 else
-    gh pr create \
+    PR_NUMBER=$(gh pr create \
         --title "Ночной прогон ${TODAY}" \
         --body "${PR_BODY}" \
         --base main \
-        --head "${BRANCH}"
+        --head "${BRANCH}" \
+        --draft \
+        | grep -oE '/pull/[0-9]+' | grep -oE '[0-9]+' || true)
+fi
+
+# --- CI gate: wait for green, promote draft → ready -----------------------------
+# Gives GitHub Actions up to 15 minutes to finish. If green → mark PR as ready
+# for review. If red or timeout → leave as draft and post a comment pointing at
+# the failed run, so the owner sees exactly why it isn't mergeable yet.
+if [ -n "${PR_NUMBER}" ]; then
+    echo ">>> Waiting for CI on PR #${PR_NUMBER}..."
+    if timeout 900 gh pr checks "${PR_NUMBER}" --watch --fail-fast >/dev/null 2>&1; then
+        echo ">>> CI green. Marking PR #${PR_NUMBER} as ready for review."
+        gh pr ready "${PR_NUMBER}" 2>/dev/null || true
+    else
+        echo ">>> CI failed or timed out. PR #${PR_NUMBER} stays in draft."
+        FAILED_RUN=$(gh pr checks "${PR_NUMBER}" --json name,state,link \
+            --jq '.[] | select(.state != "SUCCESS") | "- " + .name + " (" + .state + ") " + .link' 2>/dev/null || echo "- see Actions tab")
+        gh pr comment "${PR_NUMBER}" --body "🚧 Автоматически оставлен в draft — CI не зелёный.
+
+$FAILED_RUN
+
+Следующему developer-слоту стоит взять это как priority #1." 2>/dev/null || true
+    fi
 fi
 
 git checkout main


### PR DESCRIPTION
## Зачем

Решаем две корневые проблемы ночного пайплайна:

1. QA-агент писал «all unit tests green», но `IntegrationTests` у него помечались `⚠️ Docker/Testcontainers недоступен` и не запускались. Это и есть причина вчерашнего падения CI на `LessonTheoryQuestionCoverageTests` — фикс в adjectives theory не был проверен локально, красный CI всплыл уже на стороне GitHub Actions.
2. Ночной ПР утром открыт как ready-for-review даже если CI красный. Владелец вынужден вручную смотреть состояние каждого ПР-а.

## Что изменено

Три согласованные правки:

### `.claude/agents/qa.md`
- Явно требуется `dotnet test TraleBot.sln` (все проекты, включая IntegrationTests).
- Отмечено, что Testcontainers теперь работает благодаря env в `deploy/agents/docker-compose.yml` (#547 уже в main). «IntegrationTests skipped» больше не валидный исход — это инфра-баг.
- Час не закрывается, пока локальный прогон не зелёный.

### `deploy/agents/scripts/run-pipeline.sh`
- Hourly QA-инструкция приведена в соответствие с qa.md: обязательный `dotnet test TraleBot.sln`, либо фикс, либо откат developer-коммита, либо `needs-fix`. Никогда не оставлять ветку красной для следующего часа.
- В `=== SUMMARY ===` обязательно указывать, чем закончился `dotnet test TraleBot.sln`.

### `deploy/agents/scripts/run-qa.sh`
- Утренний ПР открывается как **draft**.
- Скрипт ждёт GitHub Actions до 15 минут (`gh pr checks --watch --fail-fast`).
  - Green → `gh pr ready` — ПР становится готов к мержу.
  - Red/timeout → остаётся draft, комментирует ПР со ссылкой на упавший run, чтобы следующий developer-слот взял это как priority #1.

## Эффект

Утром в списке ПР-ов **ready-for-review** оказываются только зелёные. Красные остаются в draft с явным маркером «почему не готов» — их видно сразу, но они не шумят.

## Что дальше

Чтобы это заработало, нужно чтобы агент-контейнер был пересоздан с compose из #547 (я это уже сделал локально). После мержа этого PR агент на следующем ночном прогоне будет гонять полный `dotnet test TraleBot.sln` и драфтовать ПР до CI-green.