### PR TITLE
fix(user): handle lifetime subscription in IsActivePremium

### DIFF
--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -26,6 +26,9 @@ public class User
     
     public bool IsActivePremium()
     {
-        return AccountType == UserAccountType.Premium && SubscribedUntil!.Value.Date > DateTime.UtcNow;
+        if (AccountType != UserAccountType.Premium) return false;
+        // Lifetime subscription: SubscribedUntil is null (see GrantProService).
+        if (!SubscribedUntil.HasValue) return true;
+        return SubscribedUntil.Value.Date > DateTime.UtcNow;
     }
 }

--- a/tests/Domain.UnitTests/UserTests.cs
+++ b/tests/Domain.UnitTests/UserTests.cs
@@ -1,0 +1,60 @@
+using Domain.Entities;
+using Shouldly;
+
+namespace Domain.UnitTests;
+
+public class UserTests
+{
+    [Test]
+    public void IsActivePremium_NonPremiumAccount_ReturnsFalse()
+    {
+        var user = new User
+        {
+            InitialLanguageSet = true,
+            AccountType = UserAccountType.Free,
+            SubscribedUntil = null,
+        };
+
+        user.IsActivePremium().ShouldBeFalse();
+    }
+
+    [Test]
+    public void IsActivePremium_PremiumWithNullSubscribedUntil_ReturnsTrue()
+    {
+        // Lifetime subscription: GrantProService sets SubscribedUntil = null.
+        var user = new User
+        {
+            InitialLanguageSet = true,
+            AccountType = UserAccountType.Premium,
+            SubscribedUntil = null,
+        };
+
+        user.IsActivePremium().ShouldBeTrue();
+    }
+
+    [Test]
+    public void IsActivePremium_PremiumWithFutureDate_ReturnsTrue()
+    {
+        var user = new User
+        {
+            InitialLanguageSet = true,
+            AccountType = UserAccountType.Premium,
+            SubscribedUntil = DateTime.UtcNow.AddDays(30),
+        };
+
+        user.IsActivePremium().ShouldBeTrue();
+    }
+
+    [Test]
+    public void IsActivePremium_PremiumWithPastDate_ReturnsFalse()
+    {
+        var user = new User
+        {
+            InitialLanguageSet = true,
+            AccountType = UserAccountType.Premium,
+            SubscribedUntil = DateTime.UtcNow.AddDays(-1),
+        };
+
+        user.IsActivePremium().ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Проблема

Прод падает: `System.InvalidOperationException: Nullable object must have a value` в `User.IsActivePremium()` (Domain/Entities/User.cs:29).

Причина — у лайфтайм-подписок `SubscribedUntil = null` (так их выставляет `GrantProService` на строке 46). Старая реализация безусловно дёргала `SubscribedUntil!.Value.Date`, что бросает исключение на каждый вызов для таких пользователей.

## Фикс

```csharp
if (AccountType != UserAccountType.Premium) return false;
if (!SubscribedUntil.HasValue) return true; // lifetime
return SubscribedUntil.Value.Date > DateTime.UtcNow;
```

## Тесты

`tests/Domain.UnitTests/UserTests.cs` — четыре кейса:
- Free → false
- Premium + null (lifetime) → true
- Premium + будущая дата → true
- Premium + прошедшая дата → false

Локально `dotnet test tests/Domain.UnitTests` — 29/29 зелёных.