### PR TITLE
feat(agents): Piper TTS for local Georgian audio generation

### DIFF
--- a/deploy/agents/Dockerfile
+++ b/deploy/agents/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
     tzdata \
     ca-certificates \
     gpg \
+    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Default timezone (overridable via TZ env var)
@@ -56,6 +57,28 @@ RUN git clone --depth 1 --filter=blob:none --sparse https://github.com/anthropic
     && cd /opt/anthropic-plugins \
     && git sparse-checkout set plugins/frontend-design \
     && chown -R agent:agent /opt/anthropic-plugins
+
+# --- Piper TTS (local Georgian speech synthesis) -------------------------------
+# Local neural TTS so agents can generate lesson audio without an API key.
+# Binary is arch-specific — TARGETARCH comes from Docker buildx. Voice model
+# ka_GE-natia-medium is downloaded once at build time. The /scripts/tts-generate.sh
+# wrapper takes (text, output.ogg) and pipes through ffmpeg for opus encoding.
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        arm64) PIPER_ARCH=aarch64 ;; \
+        amd64) PIPER_ARCH=x86_64 ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+    esac; \
+    mkdir -p /opt/piper /opt/piper-voices; \
+    curl -fsSL "https://github.com/rhasspy/piper/releases/download/2023.11.14-2/piper_linux_${PIPER_ARCH}.tar.gz" \
+        | tar -xz -C /opt/piper --strip-components=1; \
+    curl -fsSL -o /opt/piper-voices/ka_GE-natia-medium.onnx \
+        "https://huggingface.co/rhasspy/piper-voices/resolve/main/ka/ka_GE/natia/medium/ka_GE-natia-medium.onnx"; \
+    curl -fsSL -o /opt/piper-voices/ka_GE-natia-medium.onnx.json \
+        "https://huggingface.co/rhasspy/piper-voices/resolve/main/ka/ka_GE/natia/medium/ka_GE-natia-medium.onnx.json"; \
+    chown -R agent:agent /opt/piper /opt/piper-voices; \
+    /opt/piper/piper --version
 
 # Pre-warm the Roslyn language server nuget cache as the `agent` user so the
 # first agent run doesn't stall on a first-time download. Falls back to a

--- a/deploy/agents/scripts/run-pipeline.sh
+++ b/deploy/agents/scripts/run-pipeline.sh
@@ -207,7 +207,11 @@ BREAKDOWN (creating the execution backlog with acceptance criteria):
 At the very end output '=== SUMMARY ===' with 3-7 bullets: issues created, backlog state."
 
     # 6. DEVELOPER
-    "${CONTEXT_PREFIX}Read .claude/agents/developer.md AND ARCHITECTURE.md. You have the official Microsoft .NET Agent Skills loaded (dotnet, dotnet-aspnet, dotnet-data, dotnet-test, dotnet-nuget) plus the Roslyn language server via lsp.json, AND the Anthropic 'frontend-design' skill for mini-app React/CSS work — check '/skills' to list all. When writing C#/ASP.NET/EF code, invoke the relevant .NET skill (e.g. for new endpoints, EF migrations, test scaffolding). When touching miniapp-src (React, Tailwind, CSS), invoke frontend-design so the implementation matches the designer's aesthetic intent instead of generic defaults. LSP diagnostics are available for reading symbols/references in the sln. Your role this hour:
+    "${CONTEXT_PREFIX}Read .claude/agents/developer.md AND ARCHITECTURE.md. You have the official Microsoft .NET Agent Skills loaded (dotnet, dotnet-aspnet, dotnet-data, dotnet-test, dotnet-nuget) plus the Roslyn language server via lsp.json, AND the Anthropic 'frontend-design' skill for mini-app React/CSS work — check '/skills' to list all. When writing C#/ASP.NET/EF code, invoke the relevant .NET skill (e.g. for new endpoints, EF migrations, test scaffolding). When touching miniapp-src (React, Tailwind, CSS), invoke frontend-design so the implementation matches the designer's aesthetic intent instead of generic defaults. LSP diagnostics are available for reading symbols/references in the sln.
+
+TTS for Georgian audio content: when an issue asks for audio files (e.g. Listen & Choose content, pronunciation samples), use the Piper wrapper: /scripts/tts-generate.sh \"<Georgian text>\" <output.ogg>. Voice is ka_GE-natia-medium (neural, female). Output audio goes under src/Trale/miniapp-src/public/audio/<module>/<slug>.ogg — Vite's public/ folder is copied into wwwroot during build, so these files DO get shipped with the app. Commit the generated .ogg files with the code that references them. Do NOT write audio into wwwroot/ directly (it's gitignored).
+
+Your role this hour:
 - Pick ONE task to work on, in this priority order:
     1) any open issue labelled 'needs-fix' (tech-lead sent back for rework) assigned to you or unassigned,
     2) else any open issue labelled 'bug' with no assignee (CONTENT BUGS from methodist are HIGHEST product priority — users will see wrong grammar; prefer issues that also have 'methodist' label),

--- a/deploy/agents/scripts/tts-generate.sh
+++ b/deploy/agents/scripts/tts-generate.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# Generate Georgian TTS audio using Piper's ka_GE-natia-medium voice,
+# converted to opus/ogg for compact web delivery.
+#
+# Usage:
+#   /scripts/tts-generate.sh "<Georgian text>" <output.ogg>
+#
+# Example:
+#   /scripts/tts-generate.sh "გამარჯობა" /workspace/repo/src/Trale/wwwroot/audio/alphabet/hello.ogg
+#
+# Batch via JSON manifest (one object per line):
+#   {"text": "...", "output": "..."}
+# Pipe through: while read -r line; do
+#   t=$(jq -r .text <<<"$line"); o=$(jq -r .output <<<"$line")
+#   /scripts/tts-generate.sh "$t" "$o"
+# done < manifest.jsonl
+
+PIPER_BIN="/opt/piper/piper"
+VOICE_MODEL="/opt/piper-voices/ka_GE-natia-medium.onnx"
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 \"<text>\" <output.ogg>" >&2
+    exit 64
+fi
+
+TEXT="$1"
+OUT="$2"
+
+if [ ! -x "${PIPER_BIN}" ]; then
+    echo "Piper binary not found at ${PIPER_BIN}" >&2
+    exit 69
+fi
+if [ ! -f "${VOICE_MODEL}" ]; then
+    echo "Voice model not found at ${VOICE_MODEL}" >&2
+    exit 69
+fi
+
+mkdir -p "$(dirname "${OUT}")"
+
+# Piper writes WAV to stdout when --output_file is -; pipe into ffmpeg for opus.
+# LD_LIBRARY_PATH picks up the bundled .so files next to the piper binary.
+LD_LIBRARY_PATH="/opt/piper:${LD_LIBRARY_PATH:-}" \
+    printf '%s\n' "${TEXT}" \
+    | "${PIPER_BIN}" \
+        --model "${VOICE_MODEL}" \
+        --output_file - \
+        2>/dev/null \
+    | ffmpeg -hide_banner -loglevel error -y \
+        -i - \
+        -c:a libopus -b:a 48k -ac 1 \
+        "${OUT}"
+
+# Sanity: file must exist and be non-empty.
+if [ ! -s "${OUT}" ]; then
+    echo "TTS failed: ${OUT} not written or empty" >&2
+    exit 74
+fi
+
+echo "wrote ${OUT} ($(wc -c < "${OUT}") bytes) for: ${TEXT}"


### PR DESCRIPTION
## Что добавляется

Локальный нейронный TTS в контейнер bombora-agents — developer-агент сможет сам генерить грузинское аудио (Listen & Choose, произношение), без API-ключей и сетевой зависимости.

## Стек
- **Piper** 2023.11.14-2 — prebuilt binary для linux/aarch64 и linux/amd64 через `TARGETARCH`. Ни Python, ни компиляция ONNX runtime не нужны.
- **Voice**: rhasspy/ka_GE-natia-medium (60МБ, жен, нейронный), качается из официального Piper-Voices HF-mirror при билде образа.
- **ffmpeg** — добавлен в базовый apt-install, нужен для opus/ogg кодирования (мини-апп шипит компактное аудио).
- **/scripts/tts-generate.sh** `"<ge text>" <output.ogg>` — одноразовая обёртка: пайпит Piper WAV через `ffmpeg -c:a libopus -b:a 48k -ac 1`. Громко падает если бинарь/модель/output отсутствуют.

## Изменения в prompt'e

Developer-агент узнаёт: где обёртка, какой голос, куда класть аудио — `src/Trale/miniapp-src/public/audio/<module>/<slug>.ogg`, т.к. Vite при билде копирует `public/` в wwwroot (а сам wwwroot gitignored, напрямую туда нельзя).

## Тест-план
- [ ] `docker compose build` проходит (качает Piper + voice-модель)
- [ ] Внутри контейнера: `/scripts/tts-generate.sh "გამარჯობა" /tmp/test.ogg` создаёт валидный .ogg
- [ ] Файл проигрывается (отправлю в Telegram сэмпл)
- [ ] После recreate контейнера — токены (OAuth/GitHub) не теряются (стандартный приём: export через docker inspect перед recreate)

## Стоимость
Образ вырастет на ~65МБ (Piper bin ~3МБ + onnx voice ~60МБ + ffmpeg apt ~20МБ).