### PR TITLE
fix(alphabet): hide L11 audio-choice — bad TTS quality on isolated letters

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -267,7 +267,7 @@ Registered in `ModuleRegistry` (mini-app catalog) or exposed via Telegram comman
 ### Launch modules (owner-approved)
 | ID | Folder | Lessons | Theory |
 |---|---|---|---|
-| `alphabet-progressive` | `GeorgianAlphabetProgressive` | 11 (lesson 11 = audio-choice) | ✅ |
+| `alphabet-progressive` | `GeorgianAlphabetProgressive` | 10 (L11 audio-choice temporarily disabled, see ModuleRegistry.cs) | ✅ |
 | `numbers` | `GeorgianNumbers` | 5 (lesson 5 = audio-choice) | ✅ |
 | `intro` | `GeorgianVocabIntro` | 6 (lesson 6 = audio-choice) | ✅ |
 | `pronouns` | `GeorgianPronouns` | 6 (lesson 6 = audio-choice) | ✅ |

--- a/src/Trale/MiniApp/MiniAppContentProvider.cs
+++ b/src/Trale/MiniApp/MiniAppContentProvider.cs
@@ -263,9 +263,10 @@ public class MiniAppContentProvider : IMiniAppContentProvider, ITraleMiniAppCont
                         Example("ყავა — кофе", "ღამე — ночь")
                     }),
                 Lesson(10, "Экзамен: все 33!", "სახლი, ძაღლი, ხაჭაპური", "Финальный экзамен", "Прочитай любое слово!",
-                    new List<TheoryBlockDto> { Paragraph("Все 33 буквы — ты готов!"), List("სახლი — дом", "ძაღლი — собака", "წიგნი — книга", "ხაჭაპური — хачапური", "ღვინო — вино", "ყავა — кофе"), Example("საქართველო", "Грузия") }),
-                Lesson(11, "Слушай и выбери", "ა, ბ, გ, ე...", "Аудио: узнай букву на слух", "Услышать звук и выбрать правильную грузинскую букву.",
-                    new List<TheoryBlockDto> { Paragraph("Нажми ▶ и выбери услышанную букву. Тренируй различие похожих звуков."), List("Гласные: ა ე ი ო უ", "Простые согласные: ბ გ დ მ ნ ს ლ კ ტ რ", "Сложные: შ ხ ქ თ ჩ — придыхательные и абруптивные") })
+                    new List<TheoryBlockDto> { Paragraph("Все 33 буквы — ты готов!"), List("სახლი — дом", "ძაღლი — собака", "წიგნი — книга", "ხაჭაპური — хачапური", "ღვინო — вино", "ყავა — кофе"), Example("საქართველო", "Грузия") })
+                // L11 (Слушай и выбери) temporarily disabled — Piper TTS quality on
+                // isolated letters is too poor to disambiguate ejective vs aspirated
+                // pairs. Re-enable once letter audio is re-recorded.
             }
         };
     }

--- a/src/Trale/MiniApp/ModuleRegistry.cs
+++ b/src/Trale/MiniApp/ModuleRegistry.cs
@@ -13,7 +13,10 @@ public static class ModuleRegistry
 {
     private static readonly FrozenDictionary<string, ModuleDefinition> Modules = new Dictionary<string, ModuleDefinition>
     {
-        ["alphabet-progressive"] = new("alphabet-progressive", "Lessons/GeorgianAlphabetProgressive", 11),
+        // L11 (audio-choice) temporarily disabled — Piper TTS quality on isolated letters
+// is too poor to disambiguate ejective vs aspirated pairs (კ/ქ, ტ/თ, წ/ც, ჭ/ჩ).
+// Re-enable once letter audio is re-recorded or replaced with better TTS.
+["alphabet-progressive"] = new("alphabet-progressive", "Lessons/GeorgianAlphabetProgressive", 10),
         ["numbers"] = new("numbers", "Lessons/GeorgianNumbers", 5),
         ["verb-classes"] = new("verb-classes", "Lessons/GeorgianVerbClasses", 7),
         ["version-vowels"] = new("version-vowels", "Lessons/GeorgianVersionVowels", 5),


### PR DESCRIPTION
## Summary
- Piper ka_GE-natia-medium TTS for isolated Georgian letters can't disambiguate ejective/aspirated pairs (კ/ქ, ტ/თ, წ/ც, ჭ/ჩ, პ/ფ) — owner reported the lesson is unfair.
- Drop `MaxLessons` from 11 to 10 for `alphabet-progressive` and remove `Lesson(11)` from `BuildAlphabetProgressiveModule`.
- Keep `questions11.json` and the `.m4a` files in the repo so we can re-enable after re-recording letter audio.

Follow-up: file issue to re-record audio as letter NAMES (ანი, ბანი, განი…) with theory clarifying letter-name vs letter-sound — agents tonight.

## Test plan
- [x] `L11` returns 404 locally
- [x] `L10` (Экзамен) still returns 200
- [x] FEATURES.md updated to reflect the temporary disabled state

🤖 Generated with [Claude Code](https://claude.com/claude-code)