### PR TITLE
build: prevent stale Vite bundle from breaking the mini-app

### DIFF
--- a/src/Trale/Trale.csproj
+++ b/src/Trale/Trale.csproj
@@ -146,4 +146,31 @@
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Content>
     </ItemGroup>
+
+    <!-- Mini-app SPA build: run `vite build` automatically before .NET build whenever
+         source files in miniapp-src/ are newer than wwwroot/index.html. Without this
+         step, dotnet build can regenerate index.html with a fresh fingerprint while
+         wwwroot/assets/ keeps the old bundle, breaking the mini-app at runtime
+         (browser fetches a hash that doesn't exist → React never starts → blank
+         screen). Self-healing on every dotnet build.
+         Inputs/Outputs make MSBuild skip the target when nothing relevant changed,
+         so it adds zero overhead on incremental builds. -->
+    <ItemGroup>
+      <MiniappSourceFiles Include="miniapp-src/src/**/*.*" />
+      <MiniappSourceFiles Include="miniapp-src/index.html" />
+      <MiniappSourceFiles Include="miniapp-src/package.json" />
+      <MiniappSourceFiles Include="miniapp-src/vite.config.ts" />
+      <MiniappSourceFiles Include="miniapp-src/tailwind.config.js" />
+      <MiniappSourceFiles Include="miniapp-src/postcss.config.js" />
+      <MiniappSourceFiles Include="miniapp-src/tsconfig.json" />
+    </ItemGroup>
+
+    <Target Name="BuildMiniapp"
+            BeforeTargets="BeforeBuild"
+            Inputs="@(MiniappSourceFiles)"
+            Outputs="wwwroot/index.html"
+            Condition="Exists('miniapp-src/package.json') AND '$(SkipMiniappBuild)' != 'true'">
+      <Message Importance="high" Text="Building mini-app SPA (vite) — sources changed since last bundle..." />
+      <Exec Command="npm run build" WorkingDirectory="miniapp-src" />
+    </Target>
 </Project>

--- a/tests/Infrastructure.UnitTests/MiniappBundleConsistencyTests.cs
+++ b/tests/Infrastructure.UnitTests/MiniappBundleConsistencyTests.cs
@@ -1,0 +1,84 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace Infrastructure.UnitTests;
+
+// Guards src/Trale/wwwroot/index.html against referencing Vite-generated bundle
+// hashes that no longer exist on disk.
+//
+// Failure scenario: dotnet build regenerates wwwroot/index.html (via something in
+// the .csproj or msbuild flow) referencing a fresh hash, but vite hasn't been
+// re-run, so assets/index-<hash>.js / .css are stale. Browser fetches the new
+// hash → 404 → React never starts → mini-app shows blank screen.
+//
+// When this test fails, the fix is: cd src/Trale/miniapp-src && npm run build
+public class MiniappBundleConsistencyTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "FEATURES.md"))
+                && Directory.Exists(Path.Combine(dir.FullName, ".git")))
+                return dir.FullName;
+            dir = dir.Parent!;
+        }
+        throw new InvalidOperationException("Could not locate the repo root (directory containing FEATURES.md and .git).");
+    }
+
+    private static readonly Regex AssetReferenceRegex = new(
+        @"(?:src|href)\s*=\s*""(/assets/[A-Za-z0-9_\-\.]+)""",
+        RegexOptions.Compiled);
+
+    [Test]
+    public void Index_html_references_existing_assets()
+    {
+        var indexHtml = Path.Combine(RepoRoot, "src/Trale/wwwroot/index.html");
+        var assetsDir = Path.Combine(RepoRoot, "src/Trale/wwwroot/assets");
+
+        if (!File.Exists(indexHtml))
+            Assert.Inconclusive($"index.html not found at {indexHtml} — skipping bundle check.");
+
+        if (!Directory.Exists(assetsDir))
+            Assert.Inconclusive($"wwwroot/assets/ not found — skipping bundle check.");
+
+        var html = File.ReadAllText(indexHtml);
+        var referencedPaths = AssetReferenceRegex.Matches(html)
+            .Select(m => m.Groups[1].Value)
+            .Where(p => p.StartsWith("/assets/index-"))  // only fingerprinted Vite bundle, ignore /assets/audio/* etc.
+            .Distinct()
+            .ToList();
+
+        referencedPaths.Count.ShouldBeGreaterThan(0,
+            "index.html should reference at least one /assets/index-*.js bundle");
+
+        var missing = new List<string>();
+        foreach (var refPath in referencedPaths)
+        {
+            // refPath looks like "/assets/index-AbCd1234.js"
+            var fileName = Path.GetFileName(refPath);
+            var fullPath = Path.Combine(assetsDir, fileName);
+            if (!File.Exists(fullPath))
+                missing.Add(refPath);
+        }
+
+        if (missing.Count > 0)
+        {
+            var existing = Directory.EnumerateFiles(assetsDir, "index-*")
+                .Select(Path.GetFileName)
+                .ToList();
+
+            var msg =
+                $"index.html references {missing.Count} bundle file(s) that don't exist on disk:\n" +
+                string.Join("\n", missing.Select(m => $"  - {m}")) +
+                "\n\nFiles actually in wwwroot/assets/:\n" +
+                string.Join("\n", existing.Select(e => $"  - {e}")) +
+                "\n\nFix: cd src/Trale/miniapp-src && npm run build";
+
+            Assert.Fail(msg);
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Recurring bug: `dotnet build` regenerates `wwwroot/index.html` with a fresh fingerprint while `wwwroot/assets/` keeps the old bundle. Browser fetches a hash that doesn't exist → React never starts → mini-app blank screen. Fixed manually three times in the past two days.

## Two guards
1. **MSBuild target `BuildMiniapp`** in `src/Trale/Trale.csproj` — auto-runs `npm run build` before .NET build when sources are newer than wwwroot/index.html. Inputs/Outputs make MSBuild skip the target on incremental builds.
2. **Test `MiniappBundleConsistencyTests.cs`** — reads index.html, regex-extracts `/assets/index-*.*` refs, asserts each exists in wwwroot/assets/. Failure message points dev to the fix.

## CI manual step (OAuth scope blocked the workflow edit)
Add Node setup to `.github/workflows/test.yml` after the `Setup dotnet` step:

```yaml
      - name: Setup Node.js
        uses: actions/setup-node@v4
        with:
          node-version: '20'
          cache: 'npm'
          cache-dependency-path: src/Trale/miniapp-src/package-lock.json

      - name: Install miniapp deps
        run: npm ci
        working-directory: src/Trale/miniapp-src
```

Without this, CI's `dotnet build` will fail at the new MSBuild target because npm isn't installed on the runner.

## Test plan
- [x] Local: dotnet build with stale source → vite rebuilds → bundle in sync
- [x] Local: `dotnet test --filter MiniappBundleConsistency` passes
- [ ] CI: after adding Node step, this PR's run validates Node setup + cached `npm ci` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)