### PR TITLE
ux(onboarding): make mini-app entry obvious from first contact

### DIFF
--- a/src/Infrastructure/Telegram/BotCommands/StartCommand.cs
+++ b/src/Infrastructure/Telegram/BotCommands/StartCommand.cs
@@ -25,7 +25,12 @@ public class StartCommand(
     public Task<bool> IsApplicable(TelegramRequest request, CancellationToken ct)
     {
         var commandPayload = request.Text;
-        return Task.FromResult(commandPayload.Contains(CommandNames.Start));
+        // /app is an alias for /start that gets surfaced as its own slash-command
+        // entry on the bot's preview screen. Older users who don't notice the
+        // bottom menu button get a clearer named entry point.
+        return Task.FromResult(
+            commandPayload.Contains(CommandNames.Start) ||
+            commandPayload.Contains("/app"));
     }
 
     public async Task Execute(TelegramRequest request, CancellationToken token)
@@ -82,48 +87,64 @@ public class StartCommand(
             ? $"{botConfig.NormalizedHost()}/"
             : null;
 
-        // Build keyboard: WebApp button (primary CTA) when mini-app is enabled, plus text menu fallback.
+        // /app is the focused launchpad: a single WebApp button, no chat-menu
+        // fallback. /start keeps both buttons because for first-time and
+        // returning users, the chat menu is still a useful secondary path.
+        var isAppLauncher = request.Text.Contains("/app", StringComparison.OrdinalIgnoreCase);
+
         var rows = new List<InlineKeyboardButton[]>();
         if (miniAppUrl != null)
         {
             rows.Add(new[]
             {
                 InlineKeyboardButton.WithWebApp(
-                    "🚀 Открыть TraleBot",
+                    "🚀 Открыть приложение",
                     new WebAppInfo { Url = miniAppUrl })
             });
         }
-        rows.Add(new[]
+        if (!isAppLauncher)
         {
-            InlineKeyboardButton.WithCallbackData($"{CommandNames.MenuIcon} Меню в чате", CommandNames.Menu)
-        });
+            rows.Add(new[]
+            {
+                InlineKeyboardButton.WithCallbackData($"{CommandNames.MenuIcon} Меню в чате", CommandNames.Menu)
+            });
+        }
         var keyboard = new InlineKeyboardMarkup(rows);
 
         if (isNewUser)
         {
             var trialLine = hasReferralArg
-                ? "Т��бе ещё и бонус: 60 дней бесплатно вм��сто 30 — за то, что пришёл по приглашению. 🎁"
-                : "Первые 30 дней — ��сё бесплатно.";
+                ? "Тебе ещё и бонус: 60 дней бесплатно вместо 30 — за то, что пришёл по приглашению. 🎁"
+                : "Первые 30 дней — всё бесплатно.";
 
-            var hasMiniApp = miniAppUrl != null;
-            var miniAppLine = hasMiniApp
-                ? "Жми «🚀 Открыть TraleBot» — попадёшь в приложение, где есть алфавит, грамматика, словарь и квизы. Тебя там встретит щенок Бомбора 🐶 — твой гид и маскот.\n\n"
-                : "";
-
+            // Message 1: short welcome — fits on one screen so users see CTA without scrolling.
             await client.SendTextMessageAsync(
                 request.UserTelegramId,
 $@"გამარჯობა, {request.UserName}! 👋
 
-Я — TraleBot, приложение для изучения грузинского языка прямо в Telegram.
-
-Только что ты узнал своё первое слово:
-გამარჯობა — «привет» по-грузински.
-
-{miniAppLine}А ещё в чате со мной можно переводить слова — я добавлю их в твой словарь и сделаю по ним квизы. Просто напиши любое слово или фразу.
+Я — TraleBot, приложение для изучения грузинского. Ты уже выучил первое слово: გამარჯობა — «привет».
 
 {trialLine}",
-                replyMarkup: keyboard,
                 cancellationToken: token);
+
+            // Message 2: dedicated CTA — single big WebApp button, impossible to miss.
+            // Older users get a clear «what to do next» without parsing a long text wall.
+            if (miniAppUrl != null)
+            {
+                await client.SendTextMessageAsync(
+                    request.UserTelegramId,
+                    "↓ Жми кнопку, чтобы открыть приложение. Там алфавит, грамматика, твой словарь и щенок Бомбора 🐶 — гид по грузинскому.\n\nА в чат можешь писать любое слово — переведу и добавлю в словарь.",
+                    replyMarkup: keyboard,
+                    cancellationToken: token);
+            }
+            else
+            {
+                await client.SendTextMessageAsync(
+                    request.UserTelegramId,
+                    "Напиши мне любое слово или фразу — переведу и добавлю в твой словарь.",
+                    replyMarkup: keyboard,
+                    cancellationToken: token);
+            }
         }
         else
         {
@@ -135,14 +156,17 @@ $@"გამარჯობა, {request.UserName}! 👋
                     new[]
                     {
                         InlineKeyboardButton.WithWebApp(
-                            "🏔 Открыть Бомбору",
+                            "🚀 Открыть приложение",
                             new WebAppInfo { Url = miniAppUrl! })
-                    },
-                    new[]
-                    {
-                        InlineKeyboardButton.WithCallbackData($"{CommandNames.MenuIcon} Меню в чате", CommandNames.Menu)
                     }
                 };
+                if (!isAppLauncher)
+                {
+                    georgianRows.Add(new[]
+                    {
+                        InlineKeyboardButton.WithCallbackData($"{CommandNames.MenuIcon} Меню в чате", CommandNames.Menu)
+                    });
+                }
                 var georgianKeyboard = new InlineKeyboardMarkup(georgianRows);
 
                 await client.SendTextMessageAsync(

--- a/src/Infrastructure/Telegram/BotCommands/TranslateCommands/TranslateCommand.cs
+++ b/src/Infrastructure/Telegram/BotCommands/TranslateCommands/TranslateCommand.cs
@@ -16,6 +16,10 @@ public class TranslateCommand(ITelegramBotClient client, IMediator mediator, Bot
     public async Task Execute(TelegramRequest request, CancellationToken token)
     {
         var isOwner = botConfig.OwnerTelegramId != 0 && request.UserTelegramId == botConfig.OwnerTelegramId;
+        var miniAppUrl = botConfig.MiniAppEnabled && !string.IsNullOrEmpty(botConfig.HostAddress)
+            ? $"{botConfig.NormalizedHost()}/"
+            : null;
+
         var result = await mediator.Send(new TranslateAndCreateVocabularyEntry
         {
             Word = request.Text,
@@ -24,8 +28,8 @@ public class TranslateCommand(ITelegramBotClient client, IMediator mediator, Bot
 
         await (result switch
         {
-            CreateVocabularyEntryResult.TranslationSuccess success => client.SendTranslation(request, success.VocabularyEntryId, success.Definition, success.AdditionalInfo, success.Example, token, isOwner),
-            CreateVocabularyEntryResult.TranslationExists exists => client.SendExistedTranslation(request, exists.VocabularyEntryId, exists.Definition, exists.AdditionalInfo, exists.Example, token, isOwner),
+            CreateVocabularyEntryResult.TranslationSuccess success => client.SendTranslation(request, success.VocabularyEntryId, success.Definition, success.AdditionalInfo, success.Example, token, isOwner, miniAppUrl),
+            CreateVocabularyEntryResult.TranslationExists exists => client.SendExistedTranslation(request, exists.VocabularyEntryId, exists.Definition, exists.AdditionalInfo, exists.Example, token, isOwner, miniAppUrl),
             CreateVocabularyEntryResult.EmojiDetected => client.HandleEmojiDetected(request, token),
             CreateVocabularyEntryResult.PromptLengthExceeded => client.HandlePromptLengthExceeded(request, token),
             CreateVocabularyEntryResult.TranslationFailure => client.HandleFailure(request, token),

--- a/src/Infrastructure/Telegram/BotCommands/TranslateCommands/TranslationKeyboard.cs
+++ b/src/Infrastructure/Telegram/BotCommands/TranslateCommands/TranslationKeyboard.cs
@@ -3,6 +3,7 @@ using Infrastructure.Telegram.CallbackSerialization;
 using Infrastructure.Telegram.CommonComponents;
 using Infrastructure.Telegram.Models;
 using Telegram.Bot;
+using Telegram.Bot.Types;
 using Telegram.Bot.Types.ReplyMarkups;
 
 namespace Infrastructure.Telegram.BotCommands.TranslateCommands;
@@ -16,7 +17,8 @@ public static class TranslationKeyboard
         string additionalInfo,
         string? example,
         CancellationToken token,
-        bool isOwner = false)
+        bool isOwner = false,
+        string? miniAppUrl = null)
     {
         var removeFromVocabularyText = "❌ Не добавлять в словарь.";
         return SendTranslation(
@@ -28,7 +30,8 @@ public static class TranslationKeyboard
             example,
             removeFromVocabularyText,
             token,
-            isOwner);
+            isOwner,
+            miniAppUrl);
     }
 
     public static Task UpdateTranslation(this ITelegramBotClient client,
@@ -38,7 +41,8 @@ public static class TranslationKeyboard
         string additionalInfo,
         string? example,
         CancellationToken token,
-        bool isOwner = false)
+        bool isOwner = false,
+        string? miniAppUrl = null)
     {
         var removeFromVocabularyText = "❌ Не добавлять в словарь.";
         return UpdateTranslation(
@@ -50,7 +54,8 @@ public static class TranslationKeyboard
             example,
             removeFromVocabularyText,
             token,
-            isOwner);
+            isOwner,
+            miniAppUrl);
     }
 
     public static Task SendExistedTranslation(this ITelegramBotClient client,
@@ -60,7 +65,8 @@ public static class TranslationKeyboard
         string additionalInfo,
         string? example,
         CancellationToken token,
-        bool isOwner = false)
+        bool isOwner = false,
+        string? miniAppUrl = null)
     {
         var removeFromVocabularyText = "❌ Есть в словаре. Удалить?";
         return SendTranslation(
@@ -72,7 +78,8 @@ public static class TranslationKeyboard
             example,
             removeFromVocabularyText,
             token,
-            isOwner);
+            isOwner,
+            miniAppUrl);
     }
 
     public static Task UpdateExistedTranslation(this ITelegramBotClient client,
@@ -82,7 +89,8 @@ public static class TranslationKeyboard
         string additionalInfo,
         string? example,
         CancellationToken token,
-        bool isOwner = false)
+        bool isOwner = false,
+        string? miniAppUrl = null)
     {
         var removeFromVocabularyText = "❌ Есть в словаре. Удалить?";
         return UpdateTranslation(
@@ -94,7 +102,8 @@ public static class TranslationKeyboard
             example,
             removeFromVocabularyText,
             token,
-            isOwner);
+            isOwner,
+            miniAppUrl);
     }
     
     public static async Task HandleEmojiDetected(this ITelegramBotClient client,TelegramRequest request, CancellationToken token)
@@ -171,16 +180,30 @@ public static class TranslationKeyboard
         string? example,
         string removeFromVocabularyText,
         CancellationToken token,
-        bool isOwner = false)
+        bool isOwner = false,
+        string? miniAppUrl = null)
     {
-        var replyMarkup = new List<InlineKeyboardButton[]>
+        var replyMarkup = new List<InlineKeyboardButton[]>();
+
+        // Owner-priority CTA: a WebApp button as the first row, so the mini-app
+        // entry stays one tap away under every translated word. Older users
+        // who don't notice the bottom menu button get a clear, persistent
+        // launchpoint right next to the bot's reply.
+        if (!string.IsNullOrEmpty(miniAppUrl))
         {
-            new[]
+            replyMarkup.Add(new[]
             {
-                InlineKeyboardButton.WithCallbackData(removeFromVocabularyText,
-                    $"{CommandNames.RemoveEntry} {vocabularyEntryId}")
-            }
-        };
+                InlineKeyboardButton.WithWebApp(
+                    "🚀 Открыть приложение",
+                    new WebAppInfo { Url = miniAppUrl })
+            });
+        }
+
+        replyMarkup.Add(new[]
+        {
+            InlineKeyboardButton.WithCallbackData(removeFromVocabularyText,
+                $"{CommandNames.RemoveEntry} {vocabularyEntryId}")
+        });
 
         if (isOwner && request.User!.Settings.CurrentLanguage == Language.English)
         {
@@ -190,15 +213,15 @@ public static class TranslationKeyboard
                     $"https://context.reverso.net/translation/russian-english/{request.Text}")
             ]);
         }
-        
+
         replyMarkup.Add([
             InlineKeyboardButton.WithCallbackData($"{CommandNames.ChangeTranslationLanguageIcon} Перевести на другой язык", $"{CommandNames.ChangeTranslationLanguage} {vocabularyEntryId}")
         ]);
-        
+
         replyMarkup.Add([
             InlineKeyboardButton.WithCallbackData($"{CommandNames.MenuIcon} Меню", CommandNames.Menu)
         ]);
-        
+
         var keyboard = new InlineKeyboardMarkup(replyMarkup.ToArray());
 
         await client.SendTextMessageAsync(
@@ -219,16 +242,26 @@ public static class TranslationKeyboard
         string? example,
         string removeFromVocabularyText,
         CancellationToken token,
-        bool isOwner = false)
+        bool isOwner = false,
+        string? miniAppUrl = null)
     {
-        var replyMarkup = new List<InlineKeyboardButton[]>
+        var replyMarkup = new List<InlineKeyboardButton[]>();
+
+        if (!string.IsNullOrEmpty(miniAppUrl))
         {
-            new[]
+            replyMarkup.Add(new[]
             {
-                InlineKeyboardButton.WithCallbackData(removeFromVocabularyText,
-                    $"{CommandNames.RemoveEntry} {vocabularyEntryId}")
-            }
-        };
+                InlineKeyboardButton.WithWebApp(
+                    "🚀 Открыть приложение",
+                    new WebAppInfo { Url = miniAppUrl })
+            });
+        }
+
+        replyMarkup.Add(new[]
+        {
+            InlineKeyboardButton.WithCallbackData(removeFromVocabularyText,
+                $"{CommandNames.RemoveEntry} {vocabularyEntryId}")
+        });
 
         if (isOwner && request.User!.Settings.CurrentLanguage == Language.English)
         {
@@ -238,15 +271,15 @@ public static class TranslationKeyboard
                     $"https://context.reverso.net/translation/russian-english/{request.Text}")
             ]);
         }
-        
+
         replyMarkup.Add([
             InlineKeyboardButton.WithCallbackData($"{CommandNames.ChangeTranslationLanguageIcon} Перевести на другой язык", $"{CommandNames.ChangeTranslationLanguage} {vocabularyEntryId}")
         ]);
-        
+
         replyMarkup.Add([
             InlineKeyboardButton.WithCallbackData($"{CommandNames.MenuIcon} Меню", CommandNames.Menu)
         ]);
-        
+
         var keyboard = new InlineKeyboardMarkup(replyMarkup.ToArray());
 
         await client.EditMessageTextAsync(

--- a/src/Trale/HostedServices/CreateWebhook.cs
+++ b/src/Trale/HostedServices/CreateWebhook.cs
@@ -61,21 +61,29 @@ public class CreateWebhook : IHostedService
         {
             await _telegramBotClient.SetMyDescriptionAsync(
                 description:
-                    "Учи грузинский язык прямо в Telegram. Алфавит, грамматика, " +
-                    "падежи, глаголы, личный словарь и квизы. Первые 30 дней бесплатно. " +
-                    "Тебя встретит щенок Бомбора 🐶 — твой гид и маскот.",
+                    "Грузинский в приложении внутри Telegram: алфавит, грамматика, " +
+                    "словарь, квизы. Гид — щенок Бомбора 🐶.\n\n" +
+                    "Тапни 👉 /app 👈 — чтобы начать.\n\n" +
+                    "Первые 30 дней — бесплатно.",
                 cancellationToken: cancellationToken);
 
             await _telegramBotClient.SetMyShortDescriptionAsync(
-                shortDescription: "TraleBot — учи грузинский язык в Telegram. ქართული ენა.",
+                shortDescription:
+                    "Грузинский в Telegram-приложении 🇬🇪 Алфавит, грамматика, словарь, квизы.",
                 cancellationToken: cancellationToken);
 
+            // /app appears in the slash-commands list before the user even opens the
+            // chat. Older users who don't notice the bottom menu button get a
+            // clear, named entry point: tap "/app — Открыть приложение" and the
+            // bot replies with the WebApp button on the next message.
+            // /start kept as alias with the same launch-oriented description.
             await _telegramBotClient.SetMyCommandsAsync(
                 commands: new[]
                 {
-                    new BotCommand { Command = "start", Description = "Открыть TraleBot" },
-                    new BotCommand { Command = "menu", Description = "Меню в чате" },
-                    new BotCommand { Command = "help", Description = "Поддержка" }
+                    new BotCommand { Command = "app", Description = "🚀 Открыть приложение" },
+                    new BotCommand { Command = "start", Description = "🚀 Открыть приложение" },
+                    new BotCommand { Command = "menu", Description = "📋 Меню в чате" },
+                    new BotCommand { Command = "help", Description = "💬 Поддержка" }
                 },
                 cancellationToken: cancellationToken);
         }


### PR DESCRIPTION
## Problem
Older users see the «What can this bot do?» preview, hit START, get a long welcome message — and just sit there. They don't connect that there's a mini-app and they need to open it.

## Three fixes
**1. Bot description rewritten** — was an informational paragraph, now action-oriented with 👉 /app 👈 sandwich pointing at the tappable command. ShortDescription also tightened.

**2. /app slash command added** — focused launchpad alongside /start. Both share the StartCommand handler. /start description renamed to «🚀 Открыть приложение». All button labels use «Открыть приложение» instead of «Открыть TraleBot» / «Открыть Бомбору» — newcomers don't know the brand yet.

**3. Welcome flow split into 2 messages** — short greeting + dedicated CTA with the WebApp button. Impossible to scroll past. /app invocations get a single-button keyboard (no «Меню в чате» fallback) for laser focus.

**4. Mini-app button under every translated word** — `TranslationKeyboard` now accepts `miniAppUrl`. When set, «🚀 Открыть приложение» appears as the FIRST row above the existing helper buttons. Touched all four send/update flows. Persistent CTA on every reply, not just /start.

Also fixed broken UTF-8 mojibake in `StartCommand.cs` (Т��бе, вм��сто, ��сё).

## Test plan
- [x] Local: dotnet build clean
- [x] Local: bot restarted, /start sends two messages with one big CTA button
- [x] Local: /app sends two messages with single-button keyboard
- [x] Local: word translation reply has «🚀 Открыть приложение» as first keyboard row
- [ ] Prod (after merge): preview panel shows new description, /app appears in slash menu
- [ ] Prod: setMyDescription / setMyCommands fire on next pod startup → applied immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)