### PR TITLE
chore: nightly 2026-05-09 boy-scout cleanup (DependencyInjection)

### DIFF
--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -78,8 +78,7 @@ public static class DependencyInjection
         // Georgian quiz services
         services.AddScoped<IGeorgianQuizSessionService, GeorgianQuizSessionService>();
         services.AddSingleton<IGeorgianQuestionsLoaderFactory, GeorgianQuestionsLoaderFactory>();
-        // SRS service removed per request
-        
+
         services.AddScoped<IDialogProcessor, TelegramDialogProcessor>();
         services.AddScoped<IBotCommand, StartCommand>();
         services.AddScoped<IBotCommand, StopCommand>();

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -15,7 +15,6 @@ using Infrastructure.Telegram.BotCommands.PaymentCommands;
 using Infrastructure.Telegram.BotCommands.Quiz;
 using Infrastructure.Telegram.BotCommands.TranslateCommands;
 using Infrastructure.Telegram.Models;
-using Infrastructure.Telegram.Services;
 using Infrastructure.Services;
 using Infrastructure.Translation;
 using Infrastructure.Translation.GoogleTranslation;


### PR DESCRIPTION
## Summary

Cherry-pick двух чистых boy-scout коммитов с ветки agents/nightly-2026-05-09 — без stale-tip-регресса, что висел в PR #869.

- **339c943** — убран stale-комментарий о удалённом SRS-сервисе в `DependencyInjection.cs` (коммент пережил удаление сервиса).
- **e22b85f** — убран дублирующийся `using Infrastructure.Telegram.Services` (CS0105 на каждый билд).

Итого: `src/Infrastructure/DependencyInjection.cs` 1+/3-.

## Что выпало

Третий коммит ночи (`2dfb3bf — refactor(practice): extract applyLocalProgress`) намеренно НЕ пикался: ночной агент не знал про `applyOfflineProgress`, который вчера уже извлёк refactor-pass из PR #866 (0818033). Функционально это тот же DRY, просто под другим именем — мердж этих двух конфликтнул бы. Текущая `applyOfflineProgress` уже на main и покрывает тот же кейс.

## Test plan

- [x] `dotnet build` clean (DependencyInjection синтаксически корректен после удалений)
- [x] Поведение не меняется — это чистая чистка кода

🤖 Generated with [Claude Code](https://claude.com/claude-code)