### PR TITLE
fix(agents): stale-tip regression guard + daytime cron schedule

### DIFF
--- a/deploy/agents/crontab
+++ b/deploy/agents/crontab
@@ -1,25 +1,30 @@
 # Бомбора Agent Pipeline (время по Батуми, Asia/Tbilisi UTC+4)
-# Epic-driven: одна общая ночная ветка agents/nightly-YYYY-MM-DD.
+# Epic-driven: одна общая ветка agents/nightly-YYYY-MM-DD (название
+# историческое — пайплайн теперь дневной, но ветка называется так же).
 # Скрипт запускается в режиме auto и сам решает что делать:
 #   - нет открытого sprint-plan-issue       → planning phases (1–6: discovery →
 #                                              review → finalize → breakdown →
 #                                              publish-plan)
 #   - открытый sprint-plan ждёт «поехали»   → выходим, ничего не тратим
 #   - sprint-plan одобрен («поехали»)        → build phases (qa-prep → dev loop
-#                                              → end-of-night refactor)
-# Утром в 09:00 — открытие/обновление ежедневного PR.
+#                                              → end-of-night refactor →
+#                                              test-scenarios)
+# В 18:00 — открытие/обновление ежедневного PR.
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# Ночные прогоны — каждый час с 01:00 до 08:00 в auto-режиме.
+# Дневные прогоны — каждый час с 11:00 до 17:00 в auto-режиме.
 # Один прогон = один час = одна фаза или один кусок dev-loop'а.
-0 1 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-0 2 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-0 3 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-0 4 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-0 5 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-0 6 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-0 7 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-0 8 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+# Время выбрано чтобы пайплайн крутился, пока владелец бодрствует и
+# может смерджить PR в main без гонки с cron'ом — у предыдущей ночной
+# схемы регулярно случался кейс «owner мерджит pre-PR в main в 02:30,
+# а cron уже стартанул в 02:00 на старом main → нечего работать».
+0 11 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+0 12 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+0 13 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+0 14 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+0 15 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+0 16 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+0 17 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
 
-# Утренний QA — тестит ночную ветку и открывает PR
-0 9 * * * su -s /bin/bash agent -c '/scripts/run-qa.sh >> /logs/agents.log 2>&1'
+# Вечерний QA — собирает результаты дня и открывает PR
+0 18 * * * su -s /bin/bash agent -c '/scripts/run-qa.sh >> /logs/agents.log 2>&1'

--- a/deploy/agents/scripts/run-pipeline.sh
+++ b/deploy/agents/scripts/run-pipeline.sh
@@ -91,11 +91,48 @@ if git ls-remote --exit-code --heads origin "${BRANCH}" > /dev/null 2>&1; then
     if git merge "origin/${BASE_BRANCH}" --no-edit; then
         git push origin "${BRANCH}" 2>/dev/null || true
     else
-        echo ">>> WARNING: auto-merge of origin/${BASE_BRANCH} into ${BRANCH} hit a conflict — agents will work on stale tip."
+        echo ">>> WARNING: auto-merge of origin/${BASE_BRANCH} into ${BRANCH} hit a conflict."
         git merge --abort 2>/dev/null || true
+        # Conflict resolution policy: hard-reset the nightly branch onto
+        # origin/${BASE_BRANCH}. We lose any commits that were on the old
+        # nightly tip but conflicted with main, but staying current with
+        # main beats shipping a regression.
+        # Why this case happens: owner merges a PR into main while a
+        # nightly is in flight, and the same files were touched on both
+        # sides. Without this reset the agents would continue working on
+        # a stale base for the rest of the cycle (real incident on
+        # 2026-05-09 — a refactor pass extracted the same helper an
+        # earlier merge had already landed under a different name, and
+        # the morning PR showed -8000/+1500 phantom regression).
+        # Lost work is reported as a comment on the active sprint plan
+        # so the owner sees what got dropped — task issues stay in
+        # GitHub regardless, so the next iteration just redoes the work
+        # against a fresh base.
+        local conflicted_head
+        conflicted_head=$(git rev-parse HEAD)
+        local lost_log
+        lost_log=$(git log --oneline "origin/${BASE_BRANCH}..${conflicted_head}" 2>/dev/null | head -10)
+
+        echo ">>> Hard-resetting ${BRANCH} to origin/${BASE_BRANCH} to avoid stale-tip regression."
+        git reset --hard "origin/${BASE_BRANCH}"
+        git push --force-with-lease origin "${BRANCH}" 2>/dev/null || true
+
+        if [ -n "${lost_log}" ]; then
+            local sprint_num
+            sprint_num=$(gh issue list --label sprint-plan --state open --limit 1 --json number -q '.[0].number' 2>/dev/null)
+            if [ -n "${sprint_num}" ]; then
+                gh issue comment "${sprint_num}" --body "⚠️ ${HOUR_STAMP}: nightly tip conflicted with origin/${BASE_BRANCH} during the hourly auto-merge. Hard-reset performed; the following commits were dropped:
+
+\`\`\`
+${lost_log}
+\`\`\`
+
+The pipeline will redo any pending task issues from a clean base on the next iteration. Closed/done issues are unaffected." 2>/dev/null || true
+            fi
+        fi
     fi
 else
-    echo ">>> First run of the night — creating ${BRANCH} from ${BASE_BRANCH}."
+    echo ">>> First run of the cycle — creating ${BRANCH} from ${BASE_BRANCH}."
     git checkout -B "${BRANCH}" "${BASE_BRANCH}"
     git push -u origin "${BRANCH}" 2>/dev/null || true
 fi


### PR DESCRIPTION
## Summary

Два связанных фикса из разбора провалившегося цикла 2026-05-09.

### 1. Stale-tip regression guard (`run-pipeline.sh`)

Раньше, когда ежечасный auto-merge `origin/main` в nightly-ветку получал конфликт — скрипт аборт'ил merge и продолжал работать на старой базе. Реальный инцидент 2026-05-09: владелец смерджил #866/#867/#868 в main в 02:04-02:45 Тбилиси, пока cron 01:00 уже работал. К 03:00 cron попробовал смерджить новый main, поймал конфликты в `OWNER-PRIORITIES.md` и `wwwroot/index.html`, тихо свалился на stale tip. Следующие 6 часов делали boy-scout рефакторы на базе, отстающей от main на 6 часов. Утренний PR показал -8000/+1500 phantom-регресс — diff был просто «что nightly не хватает по сравнению с main», а не реальные изменения.

Новая политика на конфликте:
- `git merge --abort` → hard-reset nightly на `origin/${BASE_BRANCH}` → force-push с `--force-with-lease`.
- Коммент на активный sprint-plan со списком потерянных коммитов, чтобы владелец видел что отвалилось.
- Issue tracker — источник правды; следующая итерация переделает pending-таски на свежей базе. Done-issues не страдают.

Trade-off: час рефактор-коммитов может пропасть на конфликте. Приемлемо — обычно это дубль того, что мерж как раз и приносит (в кейсе 2026-05-09 `applyLocalProgress` был почти идентичной экстракцией `applyOfflineProgress` из #866).

### 2. Reschedule cron night → daytime (`deploy/agents/crontab`)

Старое расписание: 01:00-08:00 + 09:00 QA Тбилиси. Регулярная гонка: владелец мерджит PR в main около 02:00-03:00 Тбилиси (22:00-23:00 UTC, то есть вечер по его таймзоне), а cron 01:00 уже работает на pre-merge main.

Новое: 11:00-17:00 + 18:00 QA Тбилиси. Рабочий день владельца, мерджи и cron-тики идут с его вниманием, а не на автопилоте.

Имя ветки `agents/nightly-YYYY-MM-DD` сохранено для совместимости — переименовать пришлось бы во многих местах в скриптах, которые grep'ают этот префикс. Хедер крон-таба отмечает что «nightly» теперь дневной.

## Test plan
- [x] `bash -n run-pipeline.sh` clean.
- [x] Конфликт-handler покрывает три кейса: успешный merge (push), conflict (reset + comment + force-push), первый запуск дня (создание из base).
- [x] Crontab синтаксически валиден (7 ticks + 1 QA), TZ=Asia/Tbilisi inherited from container ENV.
- [ ] Будет верифицировано на следующем cron-тике (11:00 Тбилиси) — agentов также прогоню вручную сейчас, чтобы не ждать час.

🤖 Generated with [Claude Code](https://claude.com/claude-code)