### PR TITLE
fix(agents): clean working tree before run-qa.sh checkout

### DIFF
--- a/deploy/agents/scripts/run-qa.sh
+++ b/deploy/agents/scripts/run-qa.sh
@@ -30,6 +30,16 @@ if ! git ls-remote --exit-code --heads origin "${BRANCH}" > /dev/null 2>&1; then
     exit 0
 fi
 
+# Drop any uncommitted changes left over from a concurrent run-pipeline tick.
+# Real incident on 2026-05-10: 18:00 run-qa.sh kicked off while 17:00's
+# refactor phase was still mid-flight, leaving FEATURES.md dirty in the
+# working tree. `git checkout main` then aborted with «local changes to
+# … would be overwritten», and no PR was opened. Anything truly important
+# would already be committed by run_agent's pre/post commit hooks, so a
+# hard reset here is safe.
+git reset --hard HEAD 2>/dev/null || true
+git clean -fd 2>/dev/null || true
+
 git checkout main
 git reset --hard origin/main
 git checkout -B "${BRANCH}" "origin/${BRANCH}"


### PR DESCRIPTION
## Summary

Когда 17:00 cron-тик задерживается (refactor + test-scenarios идут 1h+), 18:00 run-qa.sh запускается параллельно и попадает в момент, когда refactor-агент уже коммитнул, но ещё может оставить грязные файлы в working tree (например после правки FEATURES.md, до следующего pre-commit-hook). `git checkout main` тогда аборт'ится с «local changes would be overwritten by checkout» и утренний PR не открывается.

Реальный инцидент 2026-05-10 — пришлось дёргать run-qa.sh руками после успокоения refactor'a.

## Фикс

Перед `git checkout main` делаем:

```bash
git reset --hard HEAD 2>/dev/null || true
git clean -fd 2>/dev/null || true
```

Сбрасывает всё, что не закоммичено. Безопасно — run_agent коммитит перед и после каждого вызова через `git commit … --allow-empty`, так что любые остатки в WT по определению mid-flight scratch без ценности.

## Trade-off

Если refactor реально мид-коммит когда 18:00 фарится, его незакоммиченная работа отбрасывается. Окно узкое (run_agent коммитит агрессивно), и альтернатива — вовсе нет утреннего PR — хуже.

## Test plan
- [x] `bash -n run-qa.sh` clean
- [x] CI зелёный
- [ ] Будет верифицировано на завтрашнем 18:00 cron-тике

🤖 Generated with [Claude Code](https://claude.com/claude-code)