### PR TITLE
feat(subscription): stack plan on top of remaining trial + fix referral copy

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -270,6 +270,7 @@ Location: `src/Persistence/Migrations/`. Test greps the migration class name (af
 | `AddLastFedAtUtc` | Last-fed timestamp. |
 | `AddLastTreatIndex` | Last-treat index for rotation. |
 | `AddSentenceBuilderProgressJson` | Per-user sentence-builder mastery progress (questionId → correct-count map) for L4/L5 progression gate. |
+| `AddTrialBonusDays` | Cumulative referral trial-bonus days on User; lets bonuses stack and survive trial expiry without rewriting RegisteredAtUtc. |
 
 ---
 

--- a/src/Application/Admin/BroadcastService.cs
+++ b/src/Application/Admin/BroadcastService.cs
@@ -93,7 +93,10 @@ public class BroadcastService(
                     var planInfo = SubscriptionPlans.ByPlan(plan.Value);
                     if (planInfo?.DurationDays != null)
                     {
-                        user.SubscribedUntil = now.AddDays(planInfo.DurationDays.Value);
+                        // !user.IsPro guard above means the recipient is in (or past) the free trial —
+                        // stack the gifted plan on top of whatever trial days remain.
+                        var startFrom = user.TrialEndsAtUtc > now ? user.TrialEndsAtUtc : now;
+                        user.SubscribedUntil = startFrom.AddDays(planInfo.DurationDays.Value);
                     }
                 }
                 granted++;

--- a/src/Application/Admin/GrantProService.cs
+++ b/src/Application/Admin/GrantProService.cs
@@ -37,6 +37,7 @@ public class GrantProService(ITraleDbContext db, ILoggerFactory loggerFactory)
         }
 
         var now = DateTime.UtcNow;
+        var wasAlreadyPro = user.IsPro;
         user.IsPro = true;
         user.SubscriptionPlan = plan;
         if (!user.ProPurchasedAtUtc.HasValue) user.ProPurchasedAtUtc = now;
@@ -47,9 +48,11 @@ public class GrantProService(ITraleDbContext db, ILoggerFactory loggerFactory)
         }
         else if (planInfo.DurationDays.HasValue)
         {
-            var startFrom = user.SubscribedUntil.HasValue && user.SubscribedUntil.Value > now
-                ? user.SubscribedUntil.Value
-                : now;
+            var startFrom = now;
+            if (user.SubscribedUntil.HasValue && user.SubscribedUntil.Value > startFrom)
+                startFrom = user.SubscribedUntil.Value;
+            if (!wasAlreadyPro && user.TrialEndsAtUtc > startFrom)
+                startFrom = user.TrialEndsAtUtc;
             user.SubscribedUntil = startFrom.AddDays(planInfo.DurationDays.Value);
         }
 

--- a/src/Application/MiniApp/Commands/ActivateProStars.cs
+++ b/src/Application/MiniApp/Commands/ActivateProStars.cs
@@ -57,10 +57,13 @@ public class ActivateProStars : IRequest<ActivateProStarsResult>
                 }
                 else if (planInfo.DurationDays.HasValue)
                 {
-                    // If user already has active subscription, extend from the later of (now, current expiry)
-                    var startFrom = user.SubscribedUntil.HasValue && user.SubscribedUntil.Value > now
-                        ? user.SubscribedUntil.Value
-                        : now;
+                    // Extend from the latest of: now, existing paid expiry, remaining free trial.
+                    // Trial-period purchases stack instead of forfeiting the trial days.
+                    var startFrom = now;
+                    if (user.SubscribedUntil.HasValue && user.SubscribedUntil.Value > startFrom)
+                        startFrom = user.SubscribedUntil.Value;
+                    if (!wasAlreadyPro && user.TrialEndsAtUtc > startFrom)
+                        startFrom = user.TrialEndsAtUtc;
                     user.SubscribedUntil = startFrom.AddDays(planInfo.DurationDays.Value);
                 }
             }

--- a/src/Application/MiniApp/Commands/RecordReferralLinkService.cs
+++ b/src/Application/MiniApp/Commands/RecordReferralLinkService.cs
@@ -39,9 +39,9 @@ public class RecordReferralLinkService(ITraleDbContext db, ILoggerFactory logger
 
         var now = DateTime.UtcNow;
 
-        // Referee bonus: extended trial. Shift RegisteredAtUtc earlier so trialDaysLeft
-        // calculation in GetMiniAppProfile gives more days.
-        newUser.RegisteredAtUtc = newUser.RegisteredAtUtc.AddDays(-RefereeTrialBonusDays);
+        // Referee bonus: shift RegisteredAtUtc *forward* so trialDaysLeft = (RegisteredAt + 30 - now)
+        // includes the bonus days. (Earlier shift was a sign bug — gave 0 days instead of 60.)
+        newUser.RegisteredAtUtc = newUser.RegisteredAtUtc.AddDays(RefereeTrialBonusDays);
 
         db.Referrals.Add(new Referral
         {

--- a/src/Application/MiniApp/Commands/RecordReferralLinkService.cs
+++ b/src/Application/MiniApp/Commands/RecordReferralLinkService.cs
@@ -39,9 +39,10 @@ public class RecordReferralLinkService(ITraleDbContext db, ILoggerFactory logger
 
         var now = DateTime.UtcNow;
 
-        // Referee bonus: shift RegisteredAtUtc *forward* so trialDaysLeft = (RegisteredAt + 30 - now)
-        // includes the bonus days. (Earlier shift was a sign bug — gave 0 days instead of 60.)
-        newUser.RegisteredAtUtc = newUser.RegisteredAtUtc.AddDays(RefereeTrialBonusDays);
+        // Referee bonus: accumulate trial days into TrialBonusDays.
+        // TrialEndsAtUtc = RegisteredAtUtc + TrialDays + TrialBonusDays, so the bonus
+        // stacks cleanly and RegisteredAtUtc stays as the real registration timestamp.
+        newUser.TrialBonusDays += RefereeTrialBonusDays;
 
         db.Referrals.Add(new Referral
         {

--- a/src/Application/MiniApp/Commands/TryActivateReferralService.cs
+++ b/src/Application/MiniApp/Commands/TryActivateReferralService.cs
@@ -61,17 +61,23 @@ public class TryActivateReferralService(ITraleDbContext db, ILoggerFactory logge
         var referrer = await db.Users.FirstOrDefaultAsync(u => u.Id == referral.ReferrerUserId, ct);
         if (referrer == null) return TryActivateReferralResult.ReferrerGone;
 
-        // Apply the referrer reward based on their CURRENT entitlement (not stored IsPro flag —
-        // a user with expired Pro should earn the trial-style bonus, not the Pro one).
+        // Apply the referrer reward. Anyone who's ever bought Pro (excl. Lifetime)
+        // gets the +30d Pro bonus — extends an active sub or reactivates a lapsed one.
+        // Free/trial users get +7d that accumulates into TrialBonusDays.
         int days;
         if (referrer.IsLifetime)
         {
             days = 0; // Lifetime gets nothing extra — counter only.
         }
-        else if (referrer.HasActivePro(now))
+        else if (referrer.IsPro)
         {
             days = ReferrerProBonusDays;
-            referrer.SubscribedUntil = referrer.SubscribedUntil!.Value.AddDays(days);
+            // For active sub: extend from current expiry. For lapsed sub: restart from now,
+            // effectively reactivating Pro access on the strength of the referral.
+            var startFrom = referrer.SubscribedUntil.HasValue && referrer.SubscribedUntil.Value > now
+                ? referrer.SubscribedUntil.Value
+                : now;
+            referrer.SubscribedUntil = startFrom.AddDays(days);
         }
         else
         {

--- a/src/Application/MiniApp/Commands/TryActivateReferralService.cs
+++ b/src/Application/MiniApp/Commands/TryActivateReferralService.cs
@@ -21,9 +21,8 @@ public class TryActivateReferralService(ITraleDbContext db, ILoggerFactory logge
     public const int ReferrerProBonusDays = 30;
     public const int ReferrerTrialBonusDays = 7;
     private const int MinSecondsBetweenRegistrationAndActivation = 3600; // 1 hour
-    /// <summary>Hard lifetime cap on bonus-earning activations per referrer.
-    /// Lifetime-plan users are exempt (they earn no bonus anyway).</summary>
-    public const int LifetimeActivationCap = 3;
+    public const int DailyActivationCap = 5;
+    public const int YearlyActivationCap = 12;
 
     public async Task<TryActivateReferralResult> ExecuteAsync(
         Referral referral, string trigger, CancellationToken ct)
@@ -38,22 +37,29 @@ public class TryActivateReferralService(ITraleDbContext db, ILoggerFactory logge
             return TryActivateReferralResult.TooEarly;
         }
 
+        // Anti-fraud: per-day and per-year activation caps per referrer.
+        var startOfDay = now.Date;
+        var todayActivations = await db.Referrals
+            .CountAsync(r => r.ReferrerUserId == referral.ReferrerUserId
+                          && r.ActivatedAtUtc != null
+                          && r.ActivatedAtUtc >= startOfDay, ct);
+        if (todayActivations >= DailyActivationCap)
+        {
+            return TryActivateReferralResult.DailyCapReached;
+        }
+
+        var yearAgo = now.AddDays(-365);
+        var yearActivations = await db.Referrals
+            .CountAsync(r => r.ReferrerUserId == referral.ReferrerUserId
+                          && r.ActivatedAtUtc != null
+                          && r.ActivatedAtUtc >= yearAgo, ct);
+        if (yearActivations >= YearlyActivationCap)
+        {
+            return TryActivateReferralResult.YearlyCapReached;
+        }
+
         var referrer = await db.Users.FirstOrDefaultAsync(u => u.Id == referral.ReferrerUserId, ct);
         if (referrer == null) return TryActivateReferralResult.ReferrerGone;
-
-        // Hard lifetime cap of 3 bonus-earning activations. Lifetime users are exempt
-        // because they earn zero bonus — the counter is informational only for them.
-        var isLifetime = referrer.IsPro && referrer.SubscriptionPlan == SubscriptionPlan.Lifetime;
-        if (!isLifetime)
-        {
-            var totalActivations = await db.Referrals
-                .CountAsync(r => r.ReferrerUserId == referral.ReferrerUserId
-                              && r.ActivatedAtUtc != null, ct);
-            if (totalActivations >= LifetimeActivationCap)
-            {
-                return TryActivateReferralResult.LifetimeCapReached;
-            }
-        }
 
         // Apply the referrer reward
         int days;
@@ -69,7 +75,10 @@ public class TryActivateReferralService(ITraleDbContext db, ILoggerFactory logge
         else
         {
             days = ReferrerTrialBonusDays;
-            referrer.RegisteredAtUtc = referrer.RegisteredAtUtc.AddDays(-days);
+            // Shift RegisteredAtUtc forward so TrialEndsAtUtc = RegisteredAt + 30 extends by `days`.
+            // For active trials this stacks (more remaining days). For expired trials the bonus
+            // is absorbed silently — those users should upgrade to Pro to earn meaningful bonuses.
+            referrer.RegisteredAtUtc = referrer.RegisteredAtUtc.AddDays(days);
         }
 
         referral.ActivatedAtUtc = now;
@@ -90,6 +99,7 @@ public enum TryActivateReferralResult
     AlreadyActivated,
     NoPendingReferral,
     TooEarly,
-    LifetimeCapReached,
+    DailyCapReached,
+    YearlyCapReached,
     ReferrerGone
 }

--- a/src/Application/MiniApp/Commands/TryActivateReferralService.cs
+++ b/src/Application/MiniApp/Commands/TryActivateReferralService.cs
@@ -21,14 +21,9 @@ public class TryActivateReferralService(ITraleDbContext db, ILoggerFactory logge
     public const int ReferrerProBonusDays = 30;
     public const int ReferrerTrialBonusDays = 7;
     private const int MinSecondsBetweenRegistrationAndActivation = 3600; // 1 hour
-    private const int DailyActivationCapPerReferrer = 5;
-    private const int YearlyActivationCapPerReferrer = 12;
-    /// <summary>Trial/free users can only earn this many activations total — ever.
-    /// 3 × 7 = 21 bonus days + 30 base trial ≈ 2 months free. After that, go Pro.</summary>
-    public const int TrialLifetimeActivationCap = 3;
-
-    public const int DailyActivationCap = DailyActivationCapPerReferrer;
-    public const int YearlyActivationCap = YearlyActivationCapPerReferrer;
+    /// <summary>Hard lifetime cap on bonus-earning activations per referrer.
+    /// Lifetime-plan users are exempt (they earn no bonus anyway).</summary>
+    public const int LifetimeActivationCap = 3;
 
     public async Task<TryActivateReferralResult> ExecuteAsync(
         Referral referral, string trigger, CancellationToken ct)
@@ -43,41 +38,20 @@ public class TryActivateReferralService(ITraleDbContext db, ILoggerFactory logge
             return TryActivateReferralResult.TooEarly;
         }
 
-        // Anti-fraud: cap daily activations per referrer
-        var startOfDay = now.Date;
-        var todayActivations = await db.Referrals
-            .CountAsync(r => r.ReferrerUserId == referral.ReferrerUserId
-                          && r.ActivatedAtUtc != null
-                          && r.ActivatedAtUtc >= startOfDay, ct);
-        if (todayActivations >= DailyActivationCapPerReferrer)
-        {
-            return TryActivateReferralResult.DailyCapReached;
-        }
-
-        // Anti-fraud: cap yearly activations per referrer
-        var yearAgo = now.AddDays(-365);
-        var yearActivations = await db.Referrals
-            .CountAsync(r => r.ReferrerUserId == referral.ReferrerUserId
-                          && r.ActivatedAtUtc != null
-                          && r.ActivatedAtUtc >= yearAgo, ct);
-        if (yearActivations >= YearlyActivationCapPerReferrer)
-        {
-            return TryActivateReferralResult.YearlyCapReached;
-        }
-
         var referrer = await db.Users.FirstOrDefaultAsync(u => u.Id == referral.ReferrerUserId, ct);
         if (referrer == null) return TryActivateReferralResult.ReferrerGone;
 
-        // Trial/free users have a hard lifetime cap on activations (≈2 months free total)
-        var isTrialOrFree = !referrer.IsPro;
-        if (isTrialOrFree)
+        // Hard lifetime cap of 3 bonus-earning activations. Lifetime users are exempt
+        // because they earn zero bonus — the counter is informational only for them.
+        var isLifetime = referrer.IsPro && referrer.SubscriptionPlan == SubscriptionPlan.Lifetime;
+        if (!isLifetime)
         {
             var totalActivations = await db.Referrals
                 .CountAsync(r => r.ReferrerUserId == referral.ReferrerUserId
                               && r.ActivatedAtUtc != null, ct);
-            if (totalActivations >= TrialLifetimeActivationCap)
+            if (totalActivations >= LifetimeActivationCap)
             {
-                return TryActivateReferralResult.TrialCapReached;
+                return TryActivateReferralResult.LifetimeCapReached;
             }
         }
 
@@ -116,8 +90,6 @@ public enum TryActivateReferralResult
     AlreadyActivated,
     NoPendingReferral,
     TooEarly,
-    DailyCapReached,
-    YearlyCapReached,
-    TrialCapReached,
+    LifetimeCapReached,
     ReferrerGone
 }

--- a/src/Application/MiniApp/Commands/TryActivateReferralService.cs
+++ b/src/Application/MiniApp/Commands/TryActivateReferralService.cs
@@ -75,10 +75,9 @@ public class TryActivateReferralService(ITraleDbContext db, ILoggerFactory logge
         else
         {
             days = ReferrerTrialBonusDays;
-            // Shift RegisteredAtUtc forward so TrialEndsAtUtc = RegisteredAt + 30 extends by `days`.
-            // For active trials this stacks (more remaining days). For expired trials the bonus
-            // is absorbed silently — those users should upgrade to Pro to earn meaningful bonuses.
-            referrer.RegisteredAtUtc = referrer.RegisteredAtUtc.AddDays(days);
+            // Accumulate into TrialBonusDays — additive, stacks across activations
+            // and survives trial expiry without rewriting the user's registration date.
+            referrer.TrialBonusDays += days;
         }
 
         referral.ActivatedAtUtc = now;

--- a/src/Application/MiniApp/Commands/TryActivateReferralService.cs
+++ b/src/Application/MiniApp/Commands/TryActivateReferralService.cs
@@ -61,16 +61,17 @@ public class TryActivateReferralService(ITraleDbContext db, ILoggerFactory logge
         var referrer = await db.Users.FirstOrDefaultAsync(u => u.Id == referral.ReferrerUserId, ct);
         if (referrer == null) return TryActivateReferralResult.ReferrerGone;
 
-        // Apply the referrer reward
+        // Apply the referrer reward based on their CURRENT entitlement (not stored IsPro flag —
+        // a user with expired Pro should earn the trial-style bonus, not the Pro one).
         int days;
-        if (referrer.IsPro && referrer.SubscriptionPlan == SubscriptionPlan.Lifetime)
+        if (referrer.IsLifetime)
         {
-            days = 0; // Lifetime gets nothing extra — counter only
+            days = 0; // Lifetime gets nothing extra — counter only.
         }
-        else if (referrer.IsPro && referrer.SubscribedUntil.HasValue)
+        else if (referrer.HasActivePro(now))
         {
             days = ReferrerProBonusDays;
-            referrer.SubscribedUntil = referrer.SubscribedUntil.Value.AddDays(days);
+            referrer.SubscribedUntil = referrer.SubscribedUntil!.Value.AddDays(days);
         }
         else
         {

--- a/src/Application/MiniApp/Queries/GetMiniAppProfile.cs
+++ b/src/Application/MiniApp/Queries/GetMiniAppProfile.cs
@@ -39,11 +39,8 @@ public class GetMiniAppProfile : IRequest<GetMiniAppProfileResult>
                 .Where(v => v.UserId == user.Id && v.Language == user.Settings.CurrentLanguage)
                 .CountAsync(ct);
 
-            // 30-day free trial from registration
-            const int trialDays = 30;
             var now = DateTime.UtcNow;
-            var trialEndsAt = user.RegisteredAtUtc.AddDays(trialDays);
-            var trialDaysLeft = (int)Math.Ceiling((trialEndsAt - now).TotalDays);
+            var trialDaysLeft = (int)Math.Ceiling((user.TrialEndsAtUtc - now).TotalDays);
             var isTrialActive = !user.IsPro && trialDaysLeft > 0;
 
             // Owner has English fallback and debug tooling

--- a/src/Application/MiniApp/Queries/GetMiniAppProfile.cs
+++ b/src/Application/MiniApp/Queries/GetMiniAppProfile.cs
@@ -40,8 +40,10 @@ public class GetMiniAppProfile : IRequest<GetMiniAppProfileResult>
                 .CountAsync(ct);
 
             var now = DateTime.UtcNow;
-            var trialDaysLeft = (int)Math.Ceiling((user.TrialEndsAtUtc - now).TotalDays);
-            var isTrialActive = !user.IsPro && trialDaysLeft > 0;
+            // Entitlement state — single source of truth lives on User entity.
+            var hasActivePro = user.HasActivePro(now);
+            var isTrialActive = user.HasActiveTrial(now);
+            var trialDaysLeft = user.TrialDaysLeft(now);
 
             // Owner has English fallback and debug tooling
             const long ownerTelegramId = 309149393;
@@ -55,9 +57,9 @@ public class GetMiniAppProfile : IRequest<GetMiniAppProfileResult>
                 VocabularyCount = vocabCount,
                 Level = progress.Level,
                 Progress = progressCalculator.SerializeProgress(progress),
-                IsPro = user.IsPro,
+                IsPro = hasActivePro,
                 IsTrialActive = isTrialActive,
-                TrialDaysLeft = isTrialActive ? trialDaysLeft : 0,
+                TrialDaysLeft = trialDaysLeft,
                 SubscriptionPlan = user.SubscriptionPlan?.ToString(),
                 SubscribedUntil = user.SubscribedUntil,
                 IsOwner = isOwner

--- a/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
+++ b/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
@@ -34,7 +34,9 @@ public class GetReferralInfoQuery(ITraleDbContext db)
 
         var now = DateTime.UtcNow;
         var isLifetime = user.IsLifetime;
-        var hasActivePro = user.HasActivePro(now);
+        // Pro bonus is earned by anyone who ever bought Pro (excl. Lifetime) — including
+        // expired-Pro users, whose +30d will reactivate their subscription.
+        var earnsProBonus = user.IsPro && !isLifetime;
         var inviteeTotalTrial = User.TrialDays + RecordReferralLinkService.RefereeTrialBonusDays;
         var dailyCap = TryActivateReferralService.DailyActivationCap;
         var yearlyCap = TryActivateReferralService.YearlyActivationCap;
@@ -54,8 +56,7 @@ public class GetReferralInfoQuery(ITraleDbContext db)
         }
         else
         {
-            // Pro-expired users earn the trial-style bonus, matching the activator logic.
-            var yourBonus = hasActivePro
+            var yourBonus = earnsProBonus
                 ? $"+{proBonus} дней Pro"
                 : $"+{trialBonus} дней триала";
             rules.Add($"Ты получишь {yourBonus} за каждого активного друга. Бонусы стакаются.");

--- a/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
+++ b/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
@@ -25,26 +25,12 @@ public class GetReferralInfoQuery(ITraleDbContext db)
         var activated = await db.Referrals
             .CountAsync(r => r.ReferrerUserId == userId && r.ActivatedAtUtc != null, ct);
 
-        var todayActivated = await db.Referrals
-            .CountAsync(r => r.ReferrerUserId == userId
-                          && r.ActivatedAtUtc != null
-                          && r.ActivatedAtUtc >= DateTime.UtcNow.Date, ct);
-
-        var yearAgo = DateTime.UtcNow.AddDays(-365);
-        var yearActivated = await db.Referrals
-            .CountAsync(r => r.ReferrerUserId == userId
-                          && r.ActivatedAtUtc != null
-                          && r.ActivatedAtUtc >= yearAgo, ct);
-
         var isLifetime = user.IsPro && user.SubscriptionPlan == SubscriptionPlan.Lifetime;
-        var isTrialOrFree = !user.IsPro;
         var inviteeTotalTrial = User.TrialDays + RecordReferralLinkService.RefereeTrialBonusDays;
-        var dailyCap = TryActivateReferralService.DailyActivationCap;
-        var yearlyCap = TryActivateReferralService.YearlyActivationCap;
-        var trialCap = TryActivateReferralService.TrialLifetimeActivationCap;
+        var lifetimeCap = TryActivateReferralService.LifetimeActivationCap;
         var proBonus = TryActivateReferralService.ReferrerProBonusDays;
         var trialBonus = TryActivateReferralService.ReferrerTrialBonusDays;
-        var trialCapReached = isTrialOrFree && activated >= trialCap;
+        var capReached = !isLifetime && activated >= lifetimeCap;
 
         // Single self-contained sentence describing who gets what.
         string bonusLabel = isLifetime
@@ -53,25 +39,17 @@ public class GetReferralInfoQuery(ITraleDbContext db)
                 ? $"Другу — {inviteeTotalTrial} дней триала вместо {User.TrialDays}. Тебе — +{proBonus} дней Pro, когда друг пройдёт первый урок или добавит 5 слов."
                 : $"Другу — {inviteeTotalTrial} дней триала вместо {User.TrialDays}. Тебе — +{trialBonus} дней триала, когда друг пройдёт первый урок или добавит 5 слов.";
 
-        // Cap line — state-specific. Null hides the line in UI.
+        // Cap line — null hides the line in UI.
         string? limitsLabel;
         if (isLifetime)
         {
             limitsLabel = null;
         }
-        else if (isTrialOrFree)
-        {
-            limitsLabel = trialCapReached
-                ? $"Максимум бонусов получен ({trialCap} друга). Оформи Pro — и получай +{proBonus} дней за каждого следующего."
-                : $"Бонус начисляется за первых {trialCap} друзей. Дальше — оформи Pro, и бонусы продолжатся.";
-        }
-        else if (todayActivated >= dailyCap)
-        {
-            limitsLabel = "Дневной лимит достигнут, бонусы продолжатся завтра.";
-        }
         else
         {
-            limitsLabel = $"До {dailyCap} друзей в день · до {yearlyCap} в год.";
+            limitsLabel = capReached
+                ? $"Максимум бонусов получен ({lifetimeCap} друга)."
+                : $"Бонус начисляется за первых {lifetimeCap} друзей.";
         }
 
         return new GetReferralInfoResult
@@ -81,12 +59,8 @@ public class GetReferralInfoQuery(ITraleDbContext db)
             ActivatedCount = activated,
             BonusLabel = bonusLabel,
             LimitsLabel = limitsLabel,
-            TodayActivated = todayActivated,
-            DailyLimit = dailyCap,
-            YearActivated = yearActivated,
-            YearlyLimit = yearlyCap,
-            TrialCapReached = trialCapReached,
-            TrialLimit = trialCap
+            LifetimeCap = lifetimeCap,
+            CapReached = capReached
         };
     }
 }
@@ -98,10 +72,6 @@ public class GetReferralInfoResult
     public int ActivatedCount { get; init; }
     public string BonusLabel { get; init; } = "";
     public string? LimitsLabel { get; init; }
-    public int TodayActivated { get; init; }
-    public int DailyLimit { get; init; }
-    public int YearActivated { get; init; }
-    public int YearlyLimit { get; init; }
-    public bool TrialCapReached { get; init; }
-    public int TrialLimit { get; init; }
+    public int LifetimeCap { get; init; }
+    public bool CapReached { get; init; }
 }

--- a/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
+++ b/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
@@ -36,21 +36,43 @@ public class GetReferralInfoQuery(ITraleDbContext db)
                           && r.ActivatedAtUtc != null
                           && r.ActivatedAtUtc >= yearAgo, ct);
 
-        string bonusLabel;
-        if (user.IsPro && user.SubscriptionPlan == SubscriptionPlan.Lifetime)
+        var isLifetime = user.IsPro && user.SubscriptionPlan == SubscriptionPlan.Lifetime;
+        var isTrialOrFree = !user.IsPro;
+        var inviteeTotalTrial = User.TrialDays + RecordReferralLinkService.RefereeTrialBonusDays;
+        var dailyCap = TryActivateReferralService.DailyActivationCap;
+        var yearlyCap = TryActivateReferralService.YearlyActivationCap;
+        var trialCap = TryActivateReferralService.TrialLifetimeActivationCap;
+        var proBonus = TryActivateReferralService.ReferrerProBonusDays;
+        var trialBonus = TryActivateReferralService.ReferrerTrialBonusDays;
+        var trialCapReached = isTrialOrFree && activated >= trialCap;
+
+        // Single self-contained sentence describing who gets what.
+        string bonusLabel = isLifetime
+            ? $"Другу — {inviteeTotalTrial} дней триала вместо {User.TrialDays}. У тебя Lifetime — бонусы не начисляются, но счётчик приглашённых растёт."
+            : user.IsPro
+                ? $"Другу — {inviteeTotalTrial} дней триала вместо {User.TrialDays}. Тебе — +{proBonus} дней Pro, когда друг пройдёт первый урок или добавит 5 слов."
+                : $"Другу — {inviteeTotalTrial} дней триала вместо {User.TrialDays}. Тебе — +{trialBonus} дней триала, когда друг пройдёт первый урок или добавит 5 слов.";
+
+        // Cap line — state-specific. Null hides the line in UI.
+        string? limitsLabel;
+        if (isLifetime)
         {
-            bonusLabel = "счётчик друзей (Lifetime — без бонуса)";
+            limitsLabel = null;
         }
-        else if (user.IsPro)
+        else if (isTrialOrFree)
         {
-            bonusLabel = $"+{TryActivateReferralService.ReferrerProBonusDays} дней Pro за каждого активного друга";
+            limitsLabel = trialCapReached
+                ? $"Максимум бонусов получен ({trialCap} друга). Оформи Pro — и получай +{proBonus} дней за каждого следующего."
+                : $"Бонус начисляется за первых {trialCap} друзей. Дальше — оформи Pro, и бонусы продолжатся.";
+        }
+        else if (todayActivated >= dailyCap)
+        {
+            limitsLabel = "Дневной лимит достигнут, бонусы продолжатся завтра.";
         }
         else
         {
-            bonusLabel = $"+{TryActivateReferralService.ReferrerTrialBonusDays} дней триала за каждого активного друга";
+            limitsLabel = $"До {dailyCap} друзей в день · до {yearlyCap} в год.";
         }
-
-        var isTrialOrFree = !user.IsPro;
 
         return new GetReferralInfoResult
         {
@@ -58,12 +80,13 @@ public class GetReferralInfoQuery(ITraleDbContext db)
             InvitedCount = invited,
             ActivatedCount = activated,
             BonusLabel = bonusLabel,
+            LimitsLabel = limitsLabel,
             TodayActivated = todayActivated,
-            DailyLimit = TryActivateReferralService.DailyActivationCap,
+            DailyLimit = dailyCap,
             YearActivated = yearActivated,
-            YearlyLimit = TryActivateReferralService.YearlyActivationCap,
-            TrialCapReached = isTrialOrFree && activated >= TryActivateReferralService.TrialLifetimeActivationCap,
-            TrialLimit = TryActivateReferralService.TrialLifetimeActivationCap
+            YearlyLimit = yearlyCap,
+            TrialCapReached = trialCapReached,
+            TrialLimit = trialCap
         };
     }
 }
@@ -74,6 +97,7 @@ public class GetReferralInfoResult
     public int InvitedCount { get; init; }
     public int ActivatedCount { get; init; }
     public string BonusLabel { get; init; } = "";
+    public string? LimitsLabel { get; init; }
     public int TodayActivated { get; init; }
     public int DailyLimit { get; init; }
     public int YearActivated { get; init; }

--- a/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
+++ b/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,24 +33,23 @@ public class GetReferralInfoQuery(ITraleDbContext db)
         var trialBonus = TryActivateReferralService.ReferrerTrialBonusDays;
         var capReached = !isLifetime && activated >= lifetimeCap;
 
-        // Single self-contained sentence describing who gets what.
-        string bonusLabel = isLifetime
-            ? $"Другу — {inviteeTotalTrial} дней триала вместо {User.TrialDays}. У тебя Lifetime — бонусы не начисляются, но счётчик приглашённых растёт."
-            : user.IsPro
-                ? $"Другу — {inviteeTotalTrial} дней триала вместо {User.TrialDays}. Тебе — +{proBonus} дней Pro, когда друг пройдёт первый урок или добавит 5 слов."
-                : $"Другу — {inviteeTotalTrial} дней триала вместо {User.TrialDays}. Тебе — +{trialBonus} дней триала, когда друг пройдёт первый урок или добавит 5 слов.";
-
-        // Cap line — null hides the line in UI.
-        string? limitsLabel;
+        // Rules rendered as a plain bullet list in the UI. Each entry = one line.
+        var rules = new List<string>
+        {
+            $"Друг получит {inviteeTotalTrial} дней триала вместо {User.TrialDays}."
+        };
         if (isLifetime)
         {
-            limitsLabel = null;
+            rules.Add("У тебя Lifetime — бонус не начисляется, но счётчик приглашённых растёт.");
         }
         else
         {
-            limitsLabel = capReached
-                ? $"Максимум бонусов получен ({lifetimeCap} друга)."
-                : $"Бонус начисляется за первых {lifetimeCap} друзей.";
+            var yourBonus = user.IsPro
+                ? $"+{proBonus} дней Pro"
+                : $"+{trialBonus} дней триала";
+            rules.Add($"Ты получишь {yourBonus} за каждого активного друга.");
+            rules.Add("Активным считается тот, кто прошёл первый урок или добавил 5 слов.");
+            rules.Add($"Можно пригласить до {lifetimeCap} друзей.");
         }
 
         return new GetReferralInfoResult
@@ -57,8 +57,7 @@ public class GetReferralInfoQuery(ITraleDbContext db)
             ReferrerTelegramId = user.TelegramId,
             InvitedCount = invited,
             ActivatedCount = activated,
-            BonusLabel = bonusLabel,
-            LimitsLabel = limitsLabel,
+            Rules = rules,
             LifetimeCap = lifetimeCap,
             CapReached = capReached
         };
@@ -70,8 +69,7 @@ public class GetReferralInfoResult
     public long ReferrerTelegramId { get; init; }
     public int InvitedCount { get; init; }
     public int ActivatedCount { get; init; }
-    public string BonusLabel { get; init; } = "";
-    public string? LimitsLabel { get; init; }
+    public IReadOnlyList<string> Rules { get; init; } = new List<string>();
     public int LifetimeCap { get; init; }
     public bool CapReached { get; init; }
 }

--- a/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
+++ b/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
@@ -32,7 +32,9 @@ public class GetReferralInfoQuery(ITraleDbContext db)
                           && r.ActivatedAtUtc != null
                           && r.ActivatedAtUtc >= yearAgo, ct);
 
-        var isLifetime = user.IsPro && user.SubscriptionPlan == SubscriptionPlan.Lifetime;
+        var now = DateTime.UtcNow;
+        var isLifetime = user.IsLifetime;
+        var hasActivePro = user.HasActivePro(now);
         var inviteeTotalTrial = User.TrialDays + RecordReferralLinkService.RefereeTrialBonusDays;
         var dailyCap = TryActivateReferralService.DailyActivationCap;
         var yearlyCap = TryActivateReferralService.YearlyActivationCap;
@@ -52,7 +54,8 @@ public class GetReferralInfoQuery(ITraleDbContext db)
         }
         else
         {
-            var yourBonus = user.IsPro
+            // Pro-expired users earn the trial-style bonus, matching the activator logic.
+            var yourBonus = hasActivePro
                 ? $"+{proBonus} дней Pro"
                 : $"+{trialBonus} дней триала";
             rules.Add($"Ты получишь {yourBonus} за каждого активного друга. Бонусы стакаются.");

--- a/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
+++ b/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
@@ -26,12 +26,20 @@ public class GetReferralInfoQuery(ITraleDbContext db)
         var activated = await db.Referrals
             .CountAsync(r => r.ReferrerUserId == userId && r.ActivatedAtUtc != null, ct);
 
+        var yearAgo = DateTime.UtcNow.AddDays(-365);
+        var yearActivated = await db.Referrals
+            .CountAsync(r => r.ReferrerUserId == userId
+                          && r.ActivatedAtUtc != null
+                          && r.ActivatedAtUtc >= yearAgo, ct);
+
         var isLifetime = user.IsPro && user.SubscriptionPlan == SubscriptionPlan.Lifetime;
         var inviteeTotalTrial = User.TrialDays + RecordReferralLinkService.RefereeTrialBonusDays;
-        var lifetimeCap = TryActivateReferralService.LifetimeActivationCap;
+        var dailyCap = TryActivateReferralService.DailyActivationCap;
+        var yearlyCap = TryActivateReferralService.YearlyActivationCap;
         var proBonus = TryActivateReferralService.ReferrerProBonusDays;
         var trialBonus = TryActivateReferralService.ReferrerTrialBonusDays;
-        var capReached = !isLifetime && activated >= lifetimeCap;
+        // "Cap reached" for hiding the card = non-Lifetime users who hit the yearly limit.
+        var capReached = !isLifetime && yearActivated >= yearlyCap;
 
         // Rules rendered as a plain bullet list in the UI. Each entry = one line.
         var rules = new List<string>
@@ -47,9 +55,9 @@ public class GetReferralInfoQuery(ITraleDbContext db)
             var yourBonus = user.IsPro
                 ? $"+{proBonus} дней Pro"
                 : $"+{trialBonus} дней триала";
-            rules.Add($"Ты получишь {yourBonus} за каждого активного друга.");
+            rules.Add($"Ты получишь {yourBonus} за каждого активного друга. Бонусы стакаются.");
             rules.Add("Активным считается тот, кто прошёл первый урок или добавил 5 слов.");
-            rules.Add($"Можно пригласить до {lifetimeCap} друзей.");
+            rules.Add($"Можно пригласить до {dailyCap} друзей в день, до {yearlyCap} в год.");
         }
 
         return new GetReferralInfoResult
@@ -58,7 +66,6 @@ public class GetReferralInfoQuery(ITraleDbContext db)
             InvitedCount = invited,
             ActivatedCount = activated,
             Rules = rules,
-            LifetimeCap = lifetimeCap,
             CapReached = capReached
         };
     }
@@ -70,6 +77,5 @@ public class GetReferralInfoResult
     public int InvitedCount { get; init; }
     public int ActivatedCount { get; init; }
     public IReadOnlyList<string> Rules { get; init; } = new List<string>();
-    public int LifetimeCap { get; init; }
     public bool CapReached { get; init; }
 }

--- a/src/Application/VocabularyEntries/Commands/TranslateAndCreateVocabularyEntry/TranslateAndCreateVocabularyEntry.cs
+++ b/src/Application/VocabularyEntries/Commands/TranslateAndCreateVocabularyEntry/TranslateAndCreateVocabularyEntry.cs
@@ -26,6 +26,13 @@ public class TranslateAndCreateVocabularyEntry : IRequest<CreateVocabularyEntryR
         {
             var user = await GetUser(request, ct);
 
+            // Hard entitlement gate: translation in chat is for paid subscribers and trial users.
+            // Lapsed Pro / expired trial → user sees a renewal prompt, not a translation.
+            if (!user.HasMiniAppAccess())
+            {
+                return new CreateVocabularyEntryResult.SubscriptionRequired();
+            }
+
             if (IsContainsEmoji(request.Word))
             {
                 return new CreateVocabularyEntryResult.EmojiDetected();

--- a/src/Application/VocabularyEntries/Commands/TranslateAndCreateVocabularyEntry/TranslateAndCreateVocabularyEntryResult.cs
+++ b/src/Application/VocabularyEntries/Commands/TranslateAndCreateVocabularyEntry/TranslateAndCreateVocabularyEntryResult.cs
@@ -23,4 +23,9 @@ public abstract record CreateVocabularyEntryResult
     public sealed record EmojiDetected: CreateVocabularyEntryResult;
 
     public sealed record PremiumRequired(Language SourceLanguage, Language TargetLanguage) : CreateVocabularyEntryResult;
+
+    /// <summary>User has neither active Pro nor an active trial — translation is gated.
+    /// Distinct from PremiumRequired (which is the "multi-language" gate) — this one
+    /// fires when the user has no entitlement at all.</summary>
+    public sealed record SubscriptionRequired : CreateVocabularyEntryResult;
 }

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -29,7 +29,7 @@ public class User
     public virtual ICollection<Achievement> Achievements { get; set; }
     public virtual ICollection<ShareableQuiz> ShareableQuizzes { get; set; }
     public virtual ICollection<Payment> Payments { get; set; }
-    
+
     public bool IsActivePremium()
     {
         if (AccountType != UserAccountType.Premium) return false;
@@ -37,4 +37,45 @@ public class User
         if (!SubscribedUntil.HasValue) return true;
         return SubscribedUntil.Value.Date > DateTime.UtcNow;
     }
+
+    // ============================================================================
+    // Mini-app entitlement model — single source of truth.
+    // Mini-app code MUST go through these helpers instead of inspecting IsPro /
+    // SubscribedUntil / TrialBonusDays directly. Keeps the "is the user paid?"
+    // and "is the user on trial?" logic in one place so expiry is handled uniformly.
+    // ============================================================================
+
+    public bool IsLifetime => IsPro && SubscriptionPlan == Entities.SubscriptionPlan.Lifetime;
+
+    /// <summary>User currently has a non-expired paid subscription (or Lifetime).</summary>
+    public bool HasActivePro(DateTime now)
+    {
+        if (!IsPro) return false;
+        if (IsLifetime) return true;
+        return SubscribedUntil.HasValue && SubscribedUntil.Value > now;
+    }
+
+    public bool HasActivePro() => HasActivePro(DateTime.UtcNow);
+
+    /// <summary>User purchased Pro at some point but the subscription has lapsed.
+    /// They're the renewal-prompt audience.</summary>
+    public bool HasExpiredPro(DateTime now) => IsPro && !HasActivePro(now);
+    public bool HasExpiredPro() => HasExpiredPro(DateTime.UtcNow);
+
+    /// <summary>True if user is in their free trial window. False if they ever became Pro
+    /// (even if that subscription has since expired — once Pro, always counted as having used the trial).</summary>
+    public bool HasActiveTrial(DateTime now) => !IsPro && TrialEndsAtUtc > now;
+    public bool HasActiveTrial() => HasActiveTrial(DateTime.UtcNow);
+
+    /// <summary>The single entitlement check: should the user be allowed to use Pro-gated features?</summary>
+    public bool HasMiniAppAccess(DateTime now) => HasActivePro(now) || HasActiveTrial(now);
+    public bool HasMiniAppAccess() => HasMiniAppAccess(DateTime.UtcNow);
+
+    /// <summary>Days remaining in the trial, ceiling. Zero if trial is not active.</summary>
+    public int TrialDaysLeft(DateTime now)
+    {
+        if (!HasActiveTrial(now)) return 0;
+        return (int)Math.Ceiling((TrialEndsAtUtc - now).TotalDays);
+    }
+    public int TrialDaysLeft() => TrialDaysLeft(DateTime.UtcNow);
 }

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -12,7 +12,10 @@ public class User
     public UserAccountType AccountType { get; set; }
     public DateTime? SubscribedUntil { get; set; }
     public DateTime RegisteredAtUtc { get; set; }
-    public DateTime TrialEndsAtUtc => RegisteredAtUtc.AddDays(TrialDays);
+    /// <summary>Cumulative bonus trial days earned via referrals (own or as a referee).
+    /// Added to the base 30-day window so bonuses stack and survive trial expiry.</summary>
+    public int TrialBonusDays { get; set; }
+    public DateTime TrialEndsAtUtc => RegisteredAtUtc.AddDays(TrialDays + TrialBonusDays);
     public Guid UserSettingsId { get; set; }
     public required bool InitialLanguageSet { get; set; }
     public bool IsActive { get; set; }

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -5,11 +5,14 @@ namespace Domain.Entities;
 
 public class User
 {
+    public const int TrialDays = 30;
+
     public Guid Id { get; set; }
     public long TelegramId { get; set; }
     public UserAccountType AccountType { get; set; }
     public DateTime? SubscribedUntil { get; set; }
     public DateTime RegisteredAtUtc { get; set; }
+    public DateTime TrialEndsAtUtc => RegisteredAtUtc.AddDays(TrialDays);
     public Guid UserSettingsId { get; set; }
     public required bool InitialLanguageSet { get; set; }
     public bool IsActive { get; set; }

--- a/src/Infrastructure/Telegram/BotCommands/TranslateCommands/TranslateCommand.cs
+++ b/src/Infrastructure/Telegram/BotCommands/TranslateCommands/TranslateCommand.cs
@@ -34,6 +34,7 @@ public class TranslateCommand(ITelegramBotClient client, IMediator mediator, Bot
             CreateVocabularyEntryResult.PromptLengthExceeded => client.HandlePromptLengthExceeded(request, token),
             CreateVocabularyEntryResult.TranslationFailure => client.HandleFailure(request, token),
             CreateVocabularyEntryResult.PremiumRequired premiumRequired => client.HandlePremiumRequired(request, request.User.Settings.CurrentLanguage, premiumRequired.TargetLanguage, token),
+            CreateVocabularyEntryResult.SubscriptionRequired => client.HandleSubscriptionRequired(request, miniAppUrl, token),
             _ => throw new ArgumentOutOfRangeException(nameof(result))
         });
     }

--- a/src/Infrastructure/Telegram/BotCommands/TranslateCommands/TranslationKeyboard.cs
+++ b/src/Infrastructure/Telegram/BotCommands/TranslateCommands/TranslationKeyboard.cs
@@ -155,7 +155,7 @@ public static class TranslationKeyboard
         CancellationToken token)
     {
         await client.SendTextMessageAsync(
-            request.UserTelegramId, 
+            request.UserTelegramId,
             text: """
                   Бесплатный аккаунт позволяет вести словарь только на одном языке.
 
@@ -168,6 +168,40 @@ public static class TranslationKeyboard
                     InlineKeyboardButton.WithCallbackData("Подробнее о Премиуме", CommandNames.Pay)
                 }
             }),
+            cancellationToken: token);
+    }
+
+    /// <summary>
+    /// User has no entitlement (Pro expired or trial ran out). Send a renewal message
+    /// with a WebApp button that opens the mini-app paywall directly (?paywall=1
+    /// auto-opens the bottom sheet on Dashboard mount).
+    /// </summary>
+    public static async Task HandleSubscriptionRequired(
+        this ITelegramBotClient client,
+        TelegramRequest request,
+        string? miniAppUrl,
+        CancellationToken token)
+    {
+        var rows = new List<InlineKeyboardButton[]>();
+        if (!string.IsNullOrEmpty(miniAppUrl))
+        {
+            var paywallUrl = miniAppUrl.TrimEnd('/') + "/?paywall=1";
+            rows.Add(new[]
+            {
+                InlineKeyboardButton.WithWebApp(
+                    "🚀 Продлить подписку",
+                    new WebAppInfo { Url = paywallUrl })
+            });
+        }
+
+        await client.SendTextMessageAsync(
+            request.UserTelegramId,
+            text: """
+                  Перевод слов и личный словарь — для подписчиков. У тебя сейчас нет активной подписки или триала.
+
+                  Открой приложение и продли, чтобы продолжить.
+                  """,
+            replyMarkup: rows.Count > 0 ? new InlineKeyboardMarkup(rows) : null,
             cancellationToken: token);
     }
     

--- a/src/Persistence/Migrations/20260513204608_AddTrialBonusDays.Designer.cs
+++ b/src/Persistence/Migrations/20260513204608_AddTrialBonusDays.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Persistence;
@@ -11,9 +12,11 @@ using Persistence;
 namespace Persistence.Migrations
 {
     [DbContext(typeof(TraleDbContext))]
-    partial class TraleDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260513204608_AddTrialBonusDays")]
+    partial class AddTrialBonusDays
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/Migrations/20260513204608_AddTrialBonusDays.cs
+++ b/src/Persistence/Migrations/20260513204608_AddTrialBonusDays.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTrialBonusDays : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TrialBonusDays",
+                table: "Users",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TrialBonusDays",
+                table: "Users");
+        }
+    }
+}

--- a/src/Trale/Controllers/MiniAppController.cs
+++ b/src/Trale/Controllers/MiniAppController.cs
@@ -415,12 +415,8 @@ public class MiniAppController : Controller
             activatedCount = info.ActivatedCount,
             bonusLabel = info.BonusLabel,
             limitsLabel = info.LimitsLabel,
-            todayActivated = info.TodayActivated,
-            dailyLimit = info.DailyLimit,
-            yearActivated = info.YearActivated,
-            yearlyLimit = info.YearlyLimit,
-            trialCapReached = info.TrialCapReached,
-            trialLimit = info.TrialLimit
+            lifetimeCap = info.LifetimeCap,
+            capReached = info.CapReached
         });
     }
 

--- a/src/Trale/Controllers/MiniAppController.cs
+++ b/src/Trale/Controllers/MiniAppController.cs
@@ -413,8 +413,7 @@ public class MiniAppController : Controller
             shareText,
             invitedCount = info.InvitedCount,
             activatedCount = info.ActivatedCount,
-            bonusLabel = info.BonusLabel,
-            limitsLabel = info.LimitsLabel,
+            rules = info.Rules,
             lifetimeCap = info.LifetimeCap,
             capReached = info.CapReached
         });

--- a/src/Trale/Controllers/MiniAppController.cs
+++ b/src/Trale/Controllers/MiniAppController.cs
@@ -414,7 +414,6 @@ public class MiniAppController : Controller
             invitedCount = info.InvitedCount,
             activatedCount = info.ActivatedCount,
             rules = info.Rules,
-            lifetimeCap = info.LifetimeCap,
             capReached = info.CapReached
         });
     }

--- a/src/Trale/Controllers/MiniAppController.cs
+++ b/src/Trale/Controllers/MiniAppController.cs
@@ -232,7 +232,8 @@ public class MiniAppController : Controller
             return Unauthorized(new { error = "not_authenticated" });
         }
 
-        if (user.IsPro)
+        // Active-Pro users skip invoice creation; expired-Pro users CAN re-purchase to renew.
+        if (user.HasActivePro())
         {
             return Ok(new { ok = true, alreadyPro = true });
         }

--- a/src/Trale/Controllers/MiniAppController.cs
+++ b/src/Trale/Controllers/MiniAppController.cs
@@ -414,6 +414,7 @@ public class MiniAppController : Controller
             invitedCount = info.InvitedCount,
             activatedCount = info.ActivatedCount,
             bonusLabel = info.BonusLabel,
+            limitsLabel = info.LimitsLabel,
             todayActivated = info.TodayActivated,
             dailyLimit = info.DailyLimit,
             yearActivated = info.YearActivated,

--- a/src/Trale/miniapp-src/e2e/paywall.spec.ts
+++ b/src/Trale/miniapp-src/e2e/paywall.spec.ts
@@ -48,8 +48,8 @@ const expiredProMeResponse = {
 
 const proMeResponse = { ...expiredProMeResponse, isPro: true, hasAccess: true }
 
-// Minimal catalog: one launch (free-tier) module and one Pro module so we can
-// assert the Pro one is gated. "cases" is in PRO_MODULE_IDS; "alphabet-progressive" is not.
+// Minimal catalog: one launch (free-tier) module, one Pro module, and the
+// personal vocabulary module so we can assert each gating type.
 const catalog = {
   botUsername: 'TraleBot',
   miniAppEnabled: true,
@@ -71,6 +71,13 @@ const catalog = {
       lessons: [
         { id: 1, title: 'L1', short: 'L1', theory: { title: 'L1', goal: 'g', blocks: [] } },
       ],
+    },
+    {
+      id: 'my-vocabulary',
+      title: 'Мой словарь',
+      emoji: '📒',
+      description: 'Личный словарь',
+      lessons: [],
     },
   ],
 }
@@ -107,6 +114,29 @@ test('expired-Pro user sees Pro module locked and paywall opens on tap', async (
   // Tapping a locked tile opens the paywall sheet.
   await proTile.click()
   await expect(page.getByRole('dialog', { name: 'Про-доступ' })).toBeVisible()
+})
+
+test('expired-Pro user sees my-vocabulary locked and paywall opens on tap', async ({ page }) => {
+  await setupApi(page, expiredProMeResponse)
+  await page.goto('/?playwright=1')
+
+  const vocabTile = page.getByTestId('module-tile-my-vocabulary')
+  await expect(vocabTile).toBeVisible()
+  await expect(vocabTile.locator('span[aria-label="Про-доступ"]')).toBeVisible()
+
+  await vocabTile.click()
+  await expect(page.getByRole('dialog', { name: 'Про-доступ' })).toBeVisible()
+})
+
+test('trial user has full access to my-vocabulary', async ({ page }) => {
+  const trialMe = { ...expiredProMeResponse, isPro: false, isTrialActive: true, trialDaysLeft: 20, hasAccess: true }
+  await setupApi(page, trialMe)
+  await page.goto('/?playwright=1')
+
+  const vocabTile = page.getByTestId('module-tile-my-vocabulary')
+  await expect(vocabTile).toBeVisible()
+  // No lock badge for trial users.
+  await expect(vocabTile.locator('span[aria-label="Про-доступ"]')).toBeHidden()
 })
 
 test('active-Pro user can tap a Pro module without paywall', async ({ page }) => {

--- a/src/Trale/miniapp-src/e2e/paywall.spec.ts
+++ b/src/Trale/miniapp-src/e2e/paywall.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  // Simulate being inside Telegram WebApp so the app boots out of "not authenticated" mode.
+  await page.addInitScript(() => {
+    ;(window as any).Telegram = {
+      WebApp: {
+        initData: 'user=%7B%22id%22%3A123456%7D',
+        BackButton: { show: () => {}, hide: () => {}, onClick: () => {}, offClick: () => {} },
+        MainButton: { show: () => {}, hide: () => {} },
+        HapticFeedback: { impactOccurred: () => {}, notificationOccurred: () => {} },
+        openTelegramLink: () => {},
+      },
+    }
+    // Clean any previously persisted collapse state so sections render expanded.
+    try { localStorage.removeItem('bombora_collapsed') } catch {}
+  })
+})
+
+// Verifies the entitlement → paywall pipeline end-to-end:
+// when /api/miniapp/me reports isPro=false and isTrialActive=false (the
+// expired-Pro state the backend now returns once SubscribedUntil < now),
+// Pro modules render with the lock affordance and the paywall sheet opens
+// on tap. This is what guarantees a lapsed paying user actually sees the
+// renewal CTA instead of silently keeping their access.
+
+const expiredProMeResponse = {
+  authenticated: true,
+  isPro: false,
+  isTrialActive: false,
+  trialDaysLeft: 0,
+  subscriptionPlan: 'Month',
+  subscribedUntil: '2025-12-01T00:00:00Z',
+  hasAccess: false,
+  level: 'intermediate',
+  vocabularyCount: 12,
+  progress: {
+    xp: 200,
+    streak: 0,
+    lastPlayedAtUtc: null,
+    completedLessons: {},
+    xpSpent: 0,
+    totalTreatsGiven: 0,
+    lastFedAtUtc: null,
+    lastTreatIndex: null,
+  },
+}
+
+const proMeResponse = { ...expiredProMeResponse, isPro: true, hasAccess: true }
+
+// Minimal catalog: one launch (free-tier) module and one Pro module so we can
+// assert the Pro one is gated. "cases" is in PRO_MODULE_IDS; "alphabet-progressive" is not.
+const catalog = {
+  botUsername: 'TraleBot',
+  miniAppEnabled: true,
+  modules: [
+    {
+      id: 'alphabet-progressive',
+      title: 'Алфавит',
+      emoji: '🔤',
+      description: 'Грузинский алфавит',
+      lessons: [
+        { id: 1, title: 'L1', short: 'L1', theory: { title: 'L1', goal: 'g', blocks: [] } },
+      ],
+    },
+    {
+      id: 'cases',
+      title: 'Падежи',
+      emoji: '🧩',
+      description: 'Падежи грузинского',
+      lessons: [
+        { id: 1, title: 'L1', short: 'L1', theory: { title: 'L1', goal: 'g', blocks: [] } },
+      ],
+    },
+  ],
+}
+
+async function setupApi(page: any, me: typeof expiredProMeResponse) {
+  await page.route('**/api/miniapp/content', (route: any) => route.fulfill({ json: catalog }))
+  await page.route('**/api/miniapp/me', (route: any) => route.fulfill({ json: me }))
+  await page.route('**/api/miniapp/activity-days*', (route: any) =>
+    route.fulfill({ json: { dates: [] } })
+  )
+  await page.route('**/api/miniapp/plans', (route: any) =>
+    route.fulfill({
+      json: {
+        plans: [
+          { id: 'Month', payloadId: 'Stars_Pro_Month', stars: 100, durationDays: 30, title: '1 месяц', description: '30 дней' },
+        ],
+      },
+    })
+  )
+}
+
+test('expired-Pro user sees Pro module locked and paywall opens on tap', async ({ page }) => {
+  await setupApi(page, expiredProMeResponse)
+  // ?playwright=1 bypasses the Telegram-WebApp check (App.tsx isInsideTelegram).
+  await page.goto('/?playwright=1')
+
+  // Pro tile must be rendered.
+  const proTile = page.getByTestId('module-tile-cases')
+  await expect(proTile).toBeVisible()
+
+  // Locked tile carries a ★ Про badge; that's the visual hint the user has lost access.
+  await expect(proTile.locator('span[aria-label="Про-доступ"]')).toBeVisible()
+
+  // Tapping a locked tile opens the paywall sheet.
+  await proTile.click()
+  await expect(page.getByRole('dialog', { name: 'Про-доступ' })).toBeVisible()
+})
+
+test('active-Pro user can tap a Pro module without paywall', async ({ page }) => {
+  await setupApi(page, proMeResponse)
+  // ?playwright=1 bypasses the Telegram-WebApp check (App.tsx isInsideTelegram).
+  await page.goto('/?playwright=1')
+
+  const proTile = page.getByTestId('module-tile-cases')
+  await expect(proTile).toBeVisible()
+  await proTile.click()
+
+  // No paywall dialog should pop — Pro user has access.
+  await expect(page.getByRole('dialog', { name: 'Про-доступ' })).toBeHidden()
+  // And the locked-badge isn't shown on the tile.
+  await expect(proTile.locator('span[aria-label="Про-доступ"]')).toBeHidden()
+})

--- a/src/Trale/miniapp-src/src/App.tsx
+++ b/src/Trale/miniapp-src/src/App.tsx
@@ -253,6 +253,8 @@ export default function App() {
             todayLessons={todayLessons}
             userLevel={userLevel ?? 'beginner'}
             isPro={isPro}
+            isTrialActive={isTrialActive}
+            trialDaysLeft={trialDaysLeft}
             onPurchaseSuccess={handleProPurchaseSuccess}
             onProgressUpdate={(patch) => setProgress((p) => ({ ...p, ...patch }))}
             navigate={navigate}

--- a/src/Trale/miniapp-src/src/api.ts
+++ b/src/Trale/miniapp-src/src/api.ts
@@ -200,8 +200,7 @@ export const api = {
       shareText: string
       invitedCount: number
       activatedCount: number
-      bonusLabel: string
-      limitsLabel: string | null
+      rules: string[]
       lifetimeCap: number
       capReached: boolean
     }>('/api/miniapp/referral'),

--- a/src/Trale/miniapp-src/src/api.ts
+++ b/src/Trale/miniapp-src/src/api.ts
@@ -201,7 +201,6 @@ export const api = {
       invitedCount: number
       activatedCount: number
       rules: string[]
-      lifetimeCap: number
       capReached: boolean
     }>('/api/miniapp/referral'),
 

--- a/src/Trale/miniapp-src/src/api.ts
+++ b/src/Trale/miniapp-src/src/api.ts
@@ -201,6 +201,7 @@ export const api = {
       invitedCount: number
       activatedCount: number
       bonusLabel: string
+      limitsLabel: string | null
       todayActivated: number
       dailyLimit: number
       yearActivated: number

--- a/src/Trale/miniapp-src/src/api.ts
+++ b/src/Trale/miniapp-src/src/api.ts
@@ -42,6 +42,13 @@ export interface MeResponse {
   level?: string | null
   progress?: ProgressDto
   isPro?: boolean
+  isTrialActive?: boolean
+  trialDaysLeft?: number
+  isOwner?: boolean
+  telegramId?: number
+  hasAccess?: boolean
+  subscriptionPlan?: string | null
+  subscribedUntil?: string | null
 }
 
 export interface LessonCompleteResponse {

--- a/src/Trale/miniapp-src/src/api.ts
+++ b/src/Trale/miniapp-src/src/api.ts
@@ -202,12 +202,8 @@ export const api = {
       activatedCount: number
       bonusLabel: string
       limitsLabel: string | null
-      todayActivated: number
-      dailyLimit: number
-      yearActivated: number
-      yearlyLimit: number
-      trialCapReached: boolean
-      trialLimit: number
+      lifetimeCap: number
+      capReached: boolean
     }>('/api/miniapp/referral'),
 
   adminStats: () => request<AdminStats>('/api/admin/stats'),

--- a/src/Trale/miniapp-src/src/screens/Dashboard.tsx
+++ b/src/Trale/miniapp-src/src/screens/Dashboard.tsx
@@ -514,17 +514,17 @@ export default function Dashboard({ catalog, progress, todayLessons, userLevel, 
                         : 120 + currentIdx * 50
 
                       const isProLocked = !hasAccess && PRO_MODULE_IDS.has(m.id)
-                      const isVocabAtLimit = !hasAccess && m.id === 'my-vocabulary' && (progress.completedLessons['my-vocabulary']?.length ?? 0) >= 50
+                      // Personal vocabulary is fully gated behind subscription — no free quota.
+                      const isVocabLocked = !hasAccess && m.id === 'my-vocabulary'
+                      const isVocabAtLimit = false // Legacy free-tier limit retired; gating is now binary.
 
                       return (
                         <button
                           key={m.id}
                           data-testid={`module-tile-${m.id}`}
                           onClick={() => {
-                            if (isProLocked) {
+                            if (isProLocked || isVocabLocked) {
                               setPaywall({ trigger: 'module' })
-                            } else if (isVocabAtLimit) {
-                              setPaywall({ trigger: 'vocabulary_limit' })
                             } else if (m.id === 'my-vocabulary') {
                               navigate({ kind: 'vocabulary-list' })
                             } else {
@@ -538,7 +538,7 @@ export default function Dashboard({ catalog, progress, todayLessons, userLevel, 
                             {/* Icon medallion */}
                             <div className="shrink-0 relative">
                               <div
-                                className={`w-12 h-12 rounded-xl ${accentBg} border-[1.5px] border-jewelInk flex items-center justify-center${isProLocked ? ' opacity-60' : ''}`}
+                                className={`w-12 h-12 rounded-xl ${accentBg} border-[1.5px] border-jewelInk flex items-center justify-center${(isProLocked || isVocabLocked) ? ' opacity-60' : ''}`}
                                 style={{ boxShadow: '2px 2px 0 #15100A' }}
                               >
                                 <span className="font-geo text-[24px] font-extrabold text-cream leading-none">
@@ -563,7 +563,7 @@ export default function Dashboard({ catalog, progress, todayLessons, userLevel, 
                                     {moduleGeo}
                                   </span>
                                 )}
-                                {(isProLocked || isVocabAtLimit) && (
+                                {(isProLocked || isVocabLocked) && (
                                   <span className="shrink-0 ml-auto">
                                     <ProBadge />
                                   </span>
@@ -590,7 +590,7 @@ export default function Dashboard({ catalog, progress, todayLessons, userLevel, 
                               ) : (
                                 <div className="mt-1">
                                   <span className="font-sans text-[12px] text-jewelInk-mid">
-                                    {isVocabAtLimit ? '50 слов — лимит Free' : 'твои слова · квизы на выбор'}
+                                    {isVocabLocked ? 'для подписчиков' : 'твои слова · квизы на выбор'}
                                   </span>
                                 </div>
                               )}

--- a/src/Trale/miniapp-src/src/screens/Profile.tsx
+++ b/src/Trale/miniapp-src/src/screens/Profile.tsx
@@ -450,6 +450,9 @@ function ReferralCard() {
   }, [])
 
   if (!data) return null
+  // When the referrer has used up their bonus slots, drop the whole card —
+  // owner wants no visual reminder of an exhausted feature.
+  if (data.capReached) return null
 
   async function copy() {
     if (!data) return
@@ -490,9 +493,9 @@ function ReferralCard() {
       <div className="mn-eyebrow mb-2">пригласи друга</div>
       <div className="jewel-tile px-4 py-4">
         <div className="relative z-[1]">
-          <div className="font-sans text-[13px] text-jewelInk-mid mb-3 leading-snug">
-            {data.bonusLabel}
-          </div>
+          <ul className="font-sans text-[13px] text-jewelInk-mid mb-3 leading-snug list-disc pl-5 space-y-1">
+            {data.rules.map((line, i) => <li key={i}>{line}</li>)}
+          </ul>
           <div className="flex items-center gap-2 mb-3 jewel-tile px-3 py-2">
             <div className="relative z-[1] flex-1 min-w-0 font-sans text-[12px] text-jewelInk truncate">
               {data.link}
@@ -516,11 +519,6 @@ function ReferralCard() {
           {data.invitedCount > 0 && (
             <div className="mt-3 font-sans text-[11px] text-jewelInk-mid">
               Пригласил: {data.invitedCount} · активных: {data.activatedCount}
-            </div>
-          )}
-          {data.limitsLabel && (
-            <div className="mt-2 font-sans text-[10px] text-jewelInk-hint">
-              {data.limitsLabel}
             </div>
           )}
         </div>

--- a/src/Trale/miniapp-src/src/screens/Profile.tsx
+++ b/src/Trale/miniapp-src/src/screens/Profile.tsx
@@ -430,13 +430,8 @@ function ReferralCard() {
     shareText: string
     invitedCount: number
     activatedCount: number
-    bonusLabel: string
-    todayActivated: number
-    dailyLimit: number
-    yearActivated: number
-    yearlyLimit: number
-    trialCapReached: boolean
-    trialLimit: number
+    rules: string[]
+    capReached: boolean
   } | null>(null)
   const [copied, setCopied] = useState(false)
 

--- a/src/Trale/miniapp-src/src/screens/Profile.tsx
+++ b/src/Trale/miniapp-src/src/screens/Profile.tsx
@@ -491,8 +491,7 @@ function ReferralCard() {
       <div className="jewel-tile px-4 py-4">
         <div className="relative z-[1]">
           <div className="font-sans text-[13px] text-jewelInk-mid mb-3 leading-snug">
-            Друг получит 60 дней триала вместо 30. Ты — {data.bonusLabel}, когда он
-            пройдёт первый урок или добавит 5 слов.
+            {data.bonusLabel}
           </div>
           <div className="flex items-center gap-2 mb-3 jewel-tile px-3 py-2">
             <div className="relative z-[1] flex-1 min-w-0 font-sans text-[12px] text-jewelInk truncate">
@@ -519,13 +518,11 @@ function ReferralCard() {
               Пригласил: {data.invitedCount} · активных: {data.activatedCount}
             </div>
           )}
-          <div className="mt-2 font-sans text-[10px] text-jewelInk-hint">
-            {data.trialCapReached
-              ? 'Максимум бонусов получен. Оформи Pro — и получай +30 дней за каждого друга'
-              : data.todayActivated >= data.dailyLimit
-                ? 'Сегодня лимит достигнут, бонусы продолжатся завтра'
-                : `До ${data.dailyLimit} бонусов в день · до ${data.yearlyLimit} в год`}
-          </div>
+          {data.limitsLabel && (
+            <div className="mt-2 font-sans text-[10px] text-jewelInk-hint">
+              {data.limitsLabel}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,7 +46,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TraleBot — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-U9d5ePTg.js"></script>
+    <script type="module" crossorigin src="/assets/index-CeD09F8S.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-B392ZbaR.css">
   </head>
   <body>

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,8 +46,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TraleBot — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-DeS14ARV.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-GjfuzrOz.css">
+    <script type="module" crossorigin src="/assets/index-U9d5ePTg.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-B392ZbaR.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,8 +46,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TraleBot — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-D8xGWwfG.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DJwNESfh.css">
+    <script type="module" crossorigin src="/assets/index-DeS14ARV.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-GjfuzrOz.css">
   </head>
   <body>
     <div id="root"></div>

--- a/tests/Application.UnitTests/DSL/UserBuilder.cs
+++ b/tests/Application.UnitTests/DSL/UserBuilder.cs
@@ -10,11 +10,17 @@ public class UserBuilder
     private Language _currentLanguage = Language.English;
     private bool _initialLanguageSet;
     private DateTime _subscriptionEndDate;
+    private bool _isPro;
+    private SubscriptionPlan? _subscriptionPlan;
 
     public UserBuilder WithPremiumAccountType()
     {
         _accountType = UserAccountType.Premium;
         _subscriptionEndDate = DateTime.UtcNow.AddDays(1);
+        // Premium test users are also Pro in the new Stars model — HasActivePro/HasMiniAppAccess
+        // should return true so mini-app entitlement gates don't reject them.
+        _isPro = true;
+        _subscriptionPlan = SubscriptionPlan.Month;
         return this;
     }
     
@@ -47,7 +53,11 @@ public class UserBuilder
                 UserId = _userId,
                 CurrentLanguage = _currentLanguage
             },
-            SubscribedUntil = _subscriptionEndDate
+            SubscribedUntil = _subscriptionEndDate,
+            IsPro = _isPro,
+            SubscriptionPlan = _subscriptionPlan,
+            // Recent registration so HasActiveTrial defaults to true for free users in tests.
+            RegisteredAtUtc = DateTime.UtcNow
         };
     }
 }

--- a/tests/Application.UnitTests/Tests/ActivateProStarsCommandTests.cs
+++ b/tests/Application.UnitTests/Tests/ActivateProStarsCommandTests.cs
@@ -1,6 +1,7 @@
 using Application.MiniApp.Commands;
 using Application.UnitTests.Common;
 using Application.UnitTests.DSL;
+using Domain.Entities;
 using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
 
@@ -69,6 +70,40 @@ public class ActivateProStarsCommandTests : CommandTestsBase
 
         var unchanged = Context.Users.First(u => u.Id == user.Id);
         unchanged.ProPurchasedAtUtc.ShouldBe(originalDate);
+    }
+
+    [Test]
+    public async Task ShouldStackPlanOnRemainingTrial_WhenUserPurchasesDuringTrial()
+    {
+        var user = await CreateFreeUser();
+        var registeredAt = DateTime.UtcNow.AddDays(-5);
+        user.RegisteredAtUtc = registeredAt;
+        await Context.SaveChangesAsync();
+
+        await _sut.Handle(
+            new ActivateProStars { UserId = user.Id, Payload = "Stars_Pro_Month" },
+            CancellationToken.None);
+
+        var updated = Context.Users.First(u => u.Id == user.Id);
+        updated.SubscribedUntil.ShouldBe(registeredAt.AddDays(User.TrialDays).AddDays(30));
+    }
+
+    [Test]
+    public async Task ShouldNotStackTrial_WhenTrialAlreadyExpired()
+    {
+        var user = await CreateFreeUser();
+        user.RegisteredAtUtc = DateTime.UtcNow.AddDays(-User.TrialDays - 10);
+        await Context.SaveChangesAsync();
+
+        var before = DateTime.UtcNow;
+        await _sut.Handle(
+            new ActivateProStars { UserId = user.Id, Payload = "Stars_Pro_Month" },
+            CancellationToken.None);
+        var after = DateTime.UtcNow;
+
+        var updated = Context.Users.First(u => u.Id == user.Id);
+        updated.SubscribedUntil.ShouldNotBeNull();
+        updated.SubscribedUntil!.Value.ShouldBeInRange(before.AddDays(30), after.AddDays(30));
     }
 
     [Test]

--- a/tests/Application.UnitTests/Tests/ActivateProStarsCommandTests.cs
+++ b/tests/Application.UnitTests/Tests/ActivateProStarsCommandTests.cs
@@ -107,6 +107,50 @@ public class ActivateProStarsCommandTests : CommandTestsBase
     }
 
     [Test]
+    public async Task ShouldRenewSubscription_WhenExpiredProUserPurchasesAgain()
+    {
+        // Subscription lapsed 5 days ago — user clicked Buy from the paywall.
+        var user = await CreateFreeUser();
+        user.RegisteredAtUtc = DateTime.UtcNow.AddDays(-60);
+        user.IsPro = true;
+        user.SubscriptionPlan = SubscriptionPlan.Month;
+        user.SubscribedUntil = DateTime.UtcNow.AddDays(-5);
+        user.TrialBonusDays = 0;
+        await Context.SaveChangesAsync();
+
+        var before = DateTime.UtcNow;
+        await _sut.Handle(
+            new ActivateProStars { UserId = user.Id, Payload = "Stars_Pro_Month" },
+            CancellationToken.None);
+        var after = DateTime.UtcNow;
+
+        var updated = Context.Users.First(u => u.Id == user.Id);
+        // Renewal starts from now (not from the lapsed expiry) — user gets a fresh 30 days.
+        updated.SubscribedUntil!.Value.ShouldBeInRange(before.AddDays(30), after.AddDays(30));
+        updated.HasActivePro().ShouldBeTrue();
+        updated.HasMiniAppAccess().ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task ShouldExtendActiveSubscription_WhenActiveProUserPurchasesAgain()
+    {
+        var user = await CreateFreeUser();
+        user.IsPro = true;
+        user.SubscriptionPlan = SubscriptionPlan.Month;
+        var currentExpiry = DateTime.UtcNow.AddDays(10);
+        user.SubscribedUntil = currentExpiry;
+        await Context.SaveChangesAsync();
+
+        await _sut.Handle(
+            new ActivateProStars { UserId = user.Id, Payload = "Stars_Pro_Month" },
+            CancellationToken.None);
+
+        var updated = Context.Users.First(u => u.Id == user.Id);
+        // Active subs extend from the current expiry, not from now.
+        updated.SubscribedUntil.ShouldBe(currentExpiry.AddDays(30));
+    }
+
+    [Test]
     public async Task ShouldReturnUserNotFound_WhenUserDoesNotExist()
     {
         var result = await _sut.Handle(

--- a/tests/Application.UnitTests/Tests/GetMiniAppProfileQueryTests.cs
+++ b/tests/Application.UnitTests/Tests/GetMiniAppProfileQueryTests.cs
@@ -1,0 +1,119 @@
+using Application.Common.Interfaces.MiniApp;
+using Application.MiniApp.Queries;
+using Application.UnitTests.Common;
+using Domain.Entities;
+using Moq;
+using Shouldly;
+
+namespace Application.UnitTests.Tests;
+
+/// <summary>
+/// Verifies that the /api/miniapp/me payload reflects User-entity entitlement helpers.
+/// Critical for subscription expiry: an ex-Pro user must report isPro=false and
+/// not be granted access just because the stored IsPro flag is still true.
+/// </summary>
+public class GetMiniAppProfileQueryTests : CommandTestsBase
+{
+    private GetMiniAppProfile.Handler _sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var calc = new Mock<IProgressCalculator>();
+        calc.Setup(c => c.SerializeProgress(It.IsAny<MiniAppUserProgress>())).Returns(new object());
+        _sut = new GetMiniAppProfile.Handler(Context, calc.Object);
+    }
+
+    [Test]
+    public async Task ShouldReportIsProTrue_AndAccess_ForActiveProUser()
+    {
+        var user = await CreateFreeUser();
+        user.IsPro = true;
+        user.SubscriptionPlan = SubscriptionPlan.Month;
+        user.SubscribedUntil = DateTime.UtcNow.AddDays(15);
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.Handle(new GetMiniAppProfile { UserId = user.Id }, CancellationToken.None);
+
+        result.Authenticated.ShouldBeTrue();
+        result.IsPro.ShouldBeTrue();
+        result.IsTrialActive.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task ShouldReportIsProFalse_WhenSubscriptionExpired()
+    {
+        // Subscription lapsed → user should NOT be reported as Pro any more.
+        var user = await CreateFreeUser();
+        user.RegisteredAtUtc = DateTime.UtcNow.AddDays(-60);
+        user.IsPro = true;
+        user.SubscriptionPlan = SubscriptionPlan.Month;
+        user.SubscribedUntil = DateTime.UtcNow.AddDays(-3);
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.Handle(new GetMiniAppProfile { UserId = user.Id }, CancellationToken.None);
+
+        result.IsPro.ShouldBeFalse();
+        result.IsTrialActive.ShouldBeFalse();
+        result.TrialDaysLeft.ShouldBe(0);
+    }
+
+    [Test]
+    public async Task ShouldReportTrialDaysLeft_ForNewlyRegisteredUser()
+    {
+        var user = await CreateFreeUser();
+        user.RegisteredAtUtc = DateTime.UtcNow;
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.Handle(new GetMiniAppProfile { UserId = user.Id }, CancellationToken.None);
+
+        result.IsPro.ShouldBeFalse();
+        result.IsTrialActive.ShouldBeTrue();
+        result.TrialDaysLeft.ShouldBe(30);
+    }
+
+    [Test]
+    public async Task ShouldReportZeroTrialDays_WhenTrialAlreadyExpired()
+    {
+        var user = await CreateFreeUser();
+        user.RegisteredAtUtc = DateTime.UtcNow.AddDays(-31);
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.Handle(new GetMiniAppProfile { UserId = user.Id }, CancellationToken.None);
+
+        result.IsPro.ShouldBeFalse();
+        result.IsTrialActive.ShouldBeFalse();
+        result.TrialDaysLeft.ShouldBe(0);
+    }
+
+    [Test]
+    public async Task ShouldReportIsProTrue_ForLifetimeUserWithNullSubscribedUntil()
+    {
+        var user = await CreateFreeUser();
+        user.IsPro = true;
+        user.SubscriptionPlan = SubscriptionPlan.Lifetime;
+        user.SubscribedUntil = null;
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.Handle(new GetMiniAppProfile { UserId = user.Id }, CancellationToken.None);
+
+        result.IsPro.ShouldBeTrue();
+        result.SubscriptionPlan.ShouldBe("Lifetime");
+        result.SubscribedUntil.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task ShouldReflectTrialBonusDays_InTrialDaysLeft()
+    {
+        // Registered 20 days ago + 14 bonus days = 24 trial days left.
+        var user = await CreateFreeUser();
+        user.RegisteredAtUtc = DateTime.UtcNow.AddDays(-20);
+        user.TrialBonusDays = 14;
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.Handle(new GetMiniAppProfile { UserId = user.Id }, CancellationToken.None);
+
+        result.IsTrialActive.ShouldBeTrue();
+        result.TrialDaysLeft.ShouldBe(24);
+    }
+}

--- a/tests/Application.UnitTests/Tests/RecordReferralLinkServiceTests.cs
+++ b/tests/Application.UnitTests/Tests/RecordReferralLinkServiceTests.cs
@@ -1,0 +1,105 @@
+using Application.MiniApp.Commands;
+using Application.UnitTests.Common;
+using Domain.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace Application.UnitTests.Tests;
+
+public class RecordReferralLinkServiceTests : CommandTestsBase
+{
+    private RecordReferralLinkService _sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _sut = new RecordReferralLinkService(Context, NullLoggerFactory.Instance);
+    }
+
+    [Test]
+    public async Task ShouldGiveReferee60DaysOfTrial_WhenLinkRecorded()
+    {
+        var referrer = await CreateFreeUser();
+        var newUser = await CreateFreeUser();
+        var registeredAt = DateTime.UtcNow;
+        newUser.RegisteredAtUtc = registeredAt;
+        newUser.TrialBonusDays = 0;
+        referrer.TelegramId = 555;
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.ExecuteAsync(newUser.Id, 555, CancellationToken.None);
+
+        result.ShouldBe(RecordReferralLinkResult.Recorded);
+        var updated = Context.Users.First(u => u.Id == newUser.Id);
+        // Bonus accumulates into TrialBonusDays; registration date is untouched.
+        updated.RegisteredAtUtc.ShouldBe(registeredAt);
+        updated.TrialBonusDays.ShouldBe(RecordReferralLinkService.RefereeTrialBonusDays);
+        updated.TrialEndsAtUtc.ShouldBe(registeredAt.AddDays(User.TrialDays + RecordReferralLinkService.RefereeTrialBonusDays));
+    }
+
+    [Test]
+    public async Task ShouldCreateReferralRow_WithCorrectBonusFields()
+    {
+        var referrer = await CreateFreeUser();
+        var newUser = await CreateFreeUser();
+        referrer.TelegramId = 777;
+        await Context.SaveChangesAsync();
+
+        await _sut.ExecuteAsync(newUser.Id, 777, CancellationToken.None);
+
+        var row = Context.Referrals.Single();
+        row.ReferrerUserId.ShouldBe(referrer.Id);
+        row.RefereeUserId.ShouldBe(newUser.Id);
+        row.ActivatedAtUtc.ShouldBeNull();
+        row.BonusRefereeDays.ShouldBe(RecordReferralLinkService.RefereeTrialBonusDays);
+        row.BonusReferrerDays.ShouldBe(0);
+    }
+
+    [Test]
+    public async Task ShouldRejectSelfReferral()
+    {
+        var user = await CreateFreeUser();
+        user.TelegramId = 999;
+        user.TrialBonusDays = 0;
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.ExecuteAsync(user.Id, 999, CancellationToken.None);
+
+        result.ShouldBe(RecordReferralLinkResult.SelfReferral);
+        Context.Users.First(u => u.Id == user.Id).TrialBonusDays.ShouldBe(0);
+        Context.Referrals.Count().ShouldBe(0);
+    }
+
+    [Test]
+    public async Task ShouldRejectDuplicateReferralForSameReferee()
+    {
+        var firstReferrer = await CreateFreeUser();
+        var secondReferrer = await CreateFreeUser();
+        var newUser = await CreateFreeUser();
+        firstReferrer.TelegramId = 111;
+        secondReferrer.TelegramId = 222;
+        newUser.TrialBonusDays = 0;
+        await Context.SaveChangesAsync();
+
+        await _sut.ExecuteAsync(newUser.Id, 111, CancellationToken.None);
+        var bonusAfterFirst = Context.Users.First(u => u.Id == newUser.Id).TrialBonusDays;
+
+        var second = await _sut.ExecuteAsync(newUser.Id, 222, CancellationToken.None);
+
+        second.ShouldBe(RecordReferralLinkResult.AlreadyReferred);
+        // No second bonus applied.
+        Context.Users.First(u => u.Id == newUser.Id).TrialBonusDays.ShouldBe(bonusAfterFirst);
+        Context.Referrals.Count().ShouldBe(1);
+    }
+
+    [Test]
+    public async Task ShouldReturnReferrerNotFound_WhenReferrerTelegramIdUnknown()
+    {
+        var newUser = await CreateFreeUser();
+
+        var result = await _sut.ExecuteAsync(newUser.Id, 424242, CancellationToken.None);
+
+        result.ShouldBe(RecordReferralLinkResult.ReferrerNotFound);
+        Context.Referrals.Count().ShouldBe(0);
+    }
+}

--- a/tests/Application.UnitTests/Tests/ReferralLifecycleTests.cs
+++ b/tests/Application.UnitTests/Tests/ReferralLifecycleTests.cs
@@ -1,0 +1,177 @@
+using Application.MiniApp;
+using Application.MiniApp.Commands;
+using Application.UnitTests.Common;
+using Domain.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace Application.UnitTests.Tests;
+
+/// <summary>
+/// End-to-end coverage of the buy ↔ invite ↔ activate flow. These chain together
+/// ActivateProStars (purchase) and TryActivateReferralService (friend activation)
+/// to verify the entitlement helpers on User produce the right totals across
+/// realistic sequences. Use these to answer "if I bought a sub and then invited
+/// a friend, does my subscription extend?" with concrete numbers.
+/// </summary>
+public class ReferralLifecycleTests : CommandTestsBase
+{
+    private ActivateProStars.Handler _purchase = null!;
+    private TryActivateReferralService _activator = null!;
+    private RecordReferralLinkService _record = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _purchase = new ActivateProStars.Handler(Context, NullLoggerFactory.Instance);
+        _activator = new TryActivateReferralService(Context, NullLoggerFactory.Instance);
+        _record = new RecordReferralLinkService(Context, NullLoggerFactory.Instance);
+    }
+
+    private async Task<Referral> Invite(User referrer)
+    {
+        var newUser = await CreateFreeUser();
+        newUser.RegisteredAtUtc = DateTime.UtcNow;
+        await Context.SaveChangesAsync();
+        await _record.ExecuteAsync(newUser.Id, referrer.TelegramId, CancellationToken.None);
+        var row = Context.Referrals.First(r => r.RefereeUserId == newUser.Id);
+        // Backdate creation past the 1-hour anti-fraud window.
+        row.CreatedAtUtc = DateTime.UtcNow.AddHours(-2);
+        await Context.SaveChangesAsync();
+        return row;
+    }
+
+    [Test]
+    public async Task ProUserInvitesFriend_SubscriptionExtendsBy30Days()
+    {
+        // Bought a Month plan; sub ends in 20 days.
+        var user = await CreateFreeUser();
+        user.TelegramId = 100;
+        user.RegisteredAtUtc = DateTime.UtcNow.AddDays(-2);
+        await Context.SaveChangesAsync();
+        await _purchase.Handle(
+            new ActivateProStars { UserId = user.Id, Payload = "Stars_Pro_Month" },
+            CancellationToken.None);
+        var beforeInvite = Context.Users.First(u => u.Id == user.Id).SubscribedUntil!.Value;
+
+        var referral = await Invite(Context.Users.First(u => u.Id == user.Id));
+        var result = await _activator.ExecuteAsync(referral, "first_lesson", CancellationToken.None);
+
+        result.ShouldBe(TryActivateReferralResult.Activated);
+        var updated = Context.Users.First(u => u.Id == user.Id);
+        updated.SubscribedUntil.ShouldBe(beforeInvite.AddDays(TryActivateReferralService.ReferrerProBonusDays));
+        updated.HasActivePro().ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task TrialUserInvitesFriend_TrialBonusDaysGrows_AndPersistsThroughPurchase()
+    {
+        // Trial user, registered today. Invites & activates one friend.
+        var user = await CreateFreeUser();
+        user.TelegramId = 101;
+        user.RegisteredAtUtc = DateTime.UtcNow;
+        user.TrialBonusDays = 0;
+        await Context.SaveChangesAsync();
+
+        var referral = await Invite(Context.Users.First(u => u.Id == user.Id));
+        await _activator.ExecuteAsync(referral, "first_lesson", CancellationToken.None);
+
+        var afterInvite = Context.Users.First(u => u.Id == user.Id);
+        afterInvite.TrialBonusDays.ShouldBe(TryActivateReferralService.ReferrerTrialBonusDays);
+        afterInvite.HasActiveTrial().ShouldBeTrue();
+
+        // Now buys Month plan — purchase should stack on the bonus-extended trial.
+        await _purchase.Handle(
+            new ActivateProStars { UserId = user.Id, Payload = "Stars_Pro_Month" },
+            CancellationToken.None);
+
+        var afterPurchase = Context.Users.First(u => u.Id == user.Id);
+        afterPurchase.HasActivePro().ShouldBeTrue();
+        // SubscribedUntil ≈ (RegisteredAt + 30 + 7) + 30 = RegisteredAt + 67 days.
+        var expected = user.RegisteredAtUtc.AddDays(User.TrialDays + TryActivateReferralService.ReferrerTrialBonusDays + 30);
+        afterPurchase.SubscribedUntil!.Value.ShouldBe(expected, TimeSpan.FromSeconds(2));
+    }
+
+    [Test]
+    public async Task MultipleInvitesWhilePro_StackUntilDailyCap()
+    {
+        var user = await CreateFreeUser();
+        user.TelegramId = 102;
+        user.RegisteredAtUtc = DateTime.UtcNow.AddDays(-1);
+        await Context.SaveChangesAsync();
+        await _purchase.Handle(
+            new ActivateProStars { UserId = user.Id, Payload = "Stars_Pro_Month" },
+            CancellationToken.None);
+        var initialSubscribedUntil = Context.Users.First(u => u.Id == user.Id).SubscribedUntil!.Value;
+
+        // Invite & activate 5 friends today — that's the daily cap exactly.
+        for (var i = 0; i < TryActivateReferralService.DailyActivationCap; i++)
+        {
+            var referral = await Invite(Context.Users.First(u => u.Id == user.Id));
+            var r = await _activator.ExecuteAsync(referral, "first_lesson", CancellationToken.None);
+            r.ShouldBe(TryActivateReferralResult.Activated);
+        }
+        // Sixth attempt today hits the cap.
+        var sixth = await Invite(Context.Users.First(u => u.Id == user.Id));
+        var capped = await _activator.ExecuteAsync(sixth, "first_lesson", CancellationToken.None);
+
+        capped.ShouldBe(TryActivateReferralResult.DailyCapReached);
+        var final = Context.Users.First(u => u.Id == user.Id);
+        var expected = initialSubscribedUntil.AddDays(
+            TryActivateReferralService.DailyActivationCap * TryActivateReferralService.ReferrerProBonusDays);
+        final.SubscribedUntil.ShouldBe(expected);
+    }
+
+    [Test]
+    public async Task ExpiredProUserInvitesFriend_FallsBackToTrialBonus()
+    {
+        // Edge case to document: user paid for Pro, sub lapsed, then a friend activates.
+        // Current behaviour: TrialBonusDays += 7 (entitlement helper picks trial-style
+        // because HasActivePro is false). The 7 days are absorbed but don't translate to
+        // access until the user buys again — they remain in the renewal-prompt audience.
+        var user = await CreateFreeUser();
+        user.TelegramId = 103;
+        user.RegisteredAtUtc = DateTime.UtcNow.AddDays(-60);
+        user.IsPro = true;
+        user.SubscriptionPlan = SubscriptionPlan.Month;
+        user.SubscribedUntil = DateTime.UtcNow.AddDays(-2);
+        user.TrialBonusDays = 0;
+        await Context.SaveChangesAsync();
+
+        var referral = await Invite(Context.Users.First(u => u.Id == user.Id));
+        var result = await _activator.ExecuteAsync(referral, "first_lesson", CancellationToken.None);
+
+        result.ShouldBe(TryActivateReferralResult.Activated);
+        var updated = Context.Users.First(u => u.Id == user.Id);
+        updated.HasExpiredPro().ShouldBeTrue();
+        updated.TrialBonusDays.ShouldBe(TryActivateReferralService.ReferrerTrialBonusDays);
+        // Critically: TrialBonusDays did NOT grant access (IsPro stored flag stays true).
+        updated.HasActiveTrial().ShouldBeFalse();
+        updated.HasMiniAppAccess().ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task LifetimeUserInvitesFriend_NoBonusButCounterIncrements()
+    {
+        var user = await CreateFreeUser();
+        user.TelegramId = 104;
+        user.RegisteredAtUtc = DateTime.UtcNow.AddDays(-30);
+        user.IsPro = true;
+        user.SubscriptionPlan = SubscriptionPlan.Lifetime;
+        user.SubscribedUntil = null;
+        await Context.SaveChangesAsync();
+
+        var referral = await Invite(Context.Users.First(u => u.Id == user.Id));
+        var result = await _activator.ExecuteAsync(referral, "first_lesson", CancellationToken.None);
+
+        result.ShouldBe(TryActivateReferralResult.Activated);
+        var updated = Context.Users.First(u => u.Id == user.Id);
+        updated.SubscribedUntil.ShouldBeNull();
+        updated.TrialBonusDays.ShouldBe(0);
+        updated.IsLifetime.ShouldBeTrue();
+        // Counter via Referrals row.
+        var row = Context.Referrals.First(r => r.Id == referral.Id);
+        row.ActivatedAtUtc.ShouldNotBeNull();
+        row.BonusReferrerDays.ShouldBe(0);
+    }
+}

--- a/tests/Application.UnitTests/Tests/ReferralLifecycleTests.cs
+++ b/tests/Application.UnitTests/Tests/ReferralLifecycleTests.cs
@@ -123,12 +123,10 @@ public class ReferralLifecycleTests : CommandTestsBase
     }
 
     [Test]
-    public async Task ExpiredProUserInvitesFriend_FallsBackToTrialBonus()
+    public async Task ExpiredProUserInvitesFriend_ReactivatesSubscriptionForProBonus()
     {
-        // Edge case to document: user paid for Pro, sub lapsed, then a friend activates.
-        // Current behaviour: TrialBonusDays += 7 (entitlement helper picks trial-style
-        // because HasActivePro is false). The 7 days are absorbed but don't translate to
-        // access until the user buys again — they remain in the renewal-prompt audience.
+        // User paid for Pro, sub lapsed, then a friend activates.
+        // Expected: Pro reactivates for ReferrerProBonusDays starting from now.
         var user = await CreateFreeUser();
         user.TelegramId = 103;
         user.RegisteredAtUtc = DateTime.UtcNow.AddDays(-60);
@@ -138,16 +136,48 @@ public class ReferralLifecycleTests : CommandTestsBase
         user.TrialBonusDays = 0;
         await Context.SaveChangesAsync();
 
+        var before = DateTime.UtcNow;
         var referral = await Invite(Context.Users.First(u => u.Id == user.Id));
         var result = await _activator.ExecuteAsync(referral, "first_lesson", CancellationToken.None);
+        var after = DateTime.UtcNow;
 
         result.ShouldBe(TryActivateReferralResult.Activated);
         var updated = Context.Users.First(u => u.Id == user.Id);
-        updated.HasExpiredPro().ShouldBeTrue();
-        updated.TrialBonusDays.ShouldBe(TryActivateReferralService.ReferrerTrialBonusDays);
-        // Critically: TrialBonusDays did NOT grant access (IsPro stored flag stays true).
-        updated.HasActiveTrial().ShouldBeFalse();
-        updated.HasMiniAppAccess().ShouldBeFalse();
+        updated.SubscribedUntil.ShouldNotBeNull();
+        updated.SubscribedUntil!.Value.ShouldBeInRange(
+            before.AddDays(TryActivateReferralService.ReferrerProBonusDays),
+            after.AddDays(TryActivateReferralService.ReferrerProBonusDays));
+        updated.HasActivePro().ShouldBeTrue();
+        updated.HasMiniAppAccess().ShouldBeTrue();
+        // Trial-bonus path was NOT taken — the user's TrialBonusDays stays untouched.
+        updated.TrialBonusDays.ShouldBe(0);
+    }
+
+    [Test]
+    public async Task ExpiredProUserActivatesMultipleFriends_BonusStacksFromReactivation()
+    {
+        var user = await CreateFreeUser();
+        user.TelegramId = 113;
+        user.RegisteredAtUtc = DateTime.UtcNow.AddDays(-60);
+        user.IsPro = true;
+        user.SubscriptionPlan = SubscriptionPlan.Month;
+        user.SubscribedUntil = DateTime.UtcNow.AddDays(-2);
+        await Context.SaveChangesAsync();
+
+        var before = DateTime.UtcNow;
+        var r1 = await Invite(Context.Users.First(u => u.Id == user.Id));
+        await _activator.ExecuteAsync(r1, "first_lesson", CancellationToken.None);
+        var r2 = await Invite(Context.Users.First(u => u.Id == user.Id));
+        await _activator.ExecuteAsync(r2, "vocab_5", CancellationToken.None);
+        var after = DateTime.UtcNow;
+
+        var updated = Context.Users.First(u => u.Id == user.Id);
+        // First activation: starts from now (sub expired) → now+30.
+        // Second activation: starts from previous SubscribedUntil (future) → +30 more.
+        updated.SubscribedUntil!.Value.ShouldBeInRange(
+            before.AddDays(2 * TryActivateReferralService.ReferrerProBonusDays),
+            after.AddDays(2 * TryActivateReferralService.ReferrerProBonusDays));
+        updated.HasActivePro().ShouldBeTrue();
     }
 
     [Test]

--- a/tests/Application.UnitTests/Tests/TranslateAndCreateVocabularyEntryCommandTests.cs
+++ b/tests/Application.UnitTests/Tests/TranslateAndCreateVocabularyEntryCommandTests.cs
@@ -97,6 +97,73 @@ a paucity of useful answers to the problem of traffic congestion at rush hour
     }
     
     [Test]
+    public async Task ShouldReturnSubscriptionRequired_WhenUserHasNoActiveProOrTrial()
+    {
+        // Lapsed Pro: registered ages ago, paid once, sub expired.
+        var lapsedUser = Create.User().WithCurrentLanguage(Language.English).Build();
+        lapsedUser.RegisteredAtUtc = DateTime.UtcNow.AddDays(-90);
+        lapsedUser.IsPro = true;
+        lapsedUser.SubscriptionPlan = SubscriptionPlan.Month;
+        lapsedUser.SubscribedUntil = DateTime.UtcNow.AddDays(-3);
+        Context.Users.Add(lapsedUser);
+        await Context.SaveChangesAsync();
+
+        var result = await _createVocabularyEntryCommandHandler.Handle(new TranslateAndCreateVocabularyEntry
+        {
+            UserId = lapsedUser.Id,
+            Word = "paucity"
+        }, CancellationToken.None);
+
+        result.ShouldBeOfType<CreateVocabularyEntryResult.SubscriptionRequired>();
+        Context.VocabularyEntries.Count(v => v.UserId == lapsedUser.Id).ShouldBe(0);
+        _languageTranslatorMock.Verify(
+            s => s.Translate(It.IsAny<string>(), It.IsAny<Language>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "translator must not be called when the user is not entitled");
+    }
+
+    [Test]
+    public async Task ShouldTranslate_WhenUserIsOnActiveTrial()
+    {
+        // Newly registered user (no payment) — has 30-day free trial, must be able to translate.
+        var trialUser = Create.User().WithCurrentLanguage(Language.English).Build();
+        trialUser.RegisteredAtUtc = DateTime.UtcNow;
+        trialUser.IsPro = false;
+        trialUser.TrialBonusDays = 0;
+        Context.Users.Add(trialUser);
+        await Context.SaveChangesAsync();
+        _languageTranslatorMock
+            .Setup(s => s.Translate("paucity", Language.English, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranslationResult.Success("недостаточность", "недостаточность", "ex"));
+
+        var result = await _createVocabularyEntryCommandHandler.Handle(new TranslateAndCreateVocabularyEntry
+        {
+            UserId = trialUser.Id,
+            Word = "paucity"
+        }, CancellationToken.None);
+
+        result.ShouldBeOfType<CreateVocabularyEntryResult.TranslationSuccess>();
+    }
+
+    [Test]
+    public async Task ShouldReturnSubscriptionRequired_WhenTrialAlsoExpired()
+    {
+        var staleUser = Create.User().WithCurrentLanguage(Language.English).Build();
+        staleUser.RegisteredAtUtc = DateTime.UtcNow.AddDays(-31);
+        staleUser.IsPro = false;
+        Context.Users.Add(staleUser);
+        await Context.SaveChangesAsync();
+
+        var result = await _createVocabularyEntryCommandHandler.Handle(new TranslateAndCreateVocabularyEntry
+        {
+            UserId = staleUser.Id,
+            Word = "paucity"
+        }, CancellationToken.None);
+
+        result.ShouldBeOfType<CreateVocabularyEntryResult.SubscriptionRequired>();
+    }
+
+    [Test]
     public async Task ShouldTranslateEnglishWordEvenIfCurrentLanguageIsGeorgian()
     {
         var userWithCurrentLanguageGeorgian = Create.User().WithPremiumAccountType().WithCurrentLanguage(Language.Georgian).Build();

--- a/tests/Application.UnitTests/Tests/TryActivateReferralServiceTests.cs
+++ b/tests/Application.UnitTests/Tests/TryActivateReferralServiceTests.cs
@@ -1,0 +1,280 @@
+using Application.MiniApp;
+using Application.MiniApp.Commands;
+using Application.UnitTests.Common;
+using Domain.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace Application.UnitTests.Tests;
+
+public class TryActivateReferralServiceTests : CommandTestsBase
+{
+    private TryActivateReferralService _sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _sut = new TryActivateReferralService(Context, NullLoggerFactory.Instance);
+    }
+
+    private async Task<Referral> AddPendingReferral(Guid referrerId, DateTime? createdAt = null)
+    {
+        // Default: created 2 hours ago so the 1-hour anti-fraud window has passed.
+        var created = createdAt ?? DateTime.UtcNow.AddHours(-2);
+        var refereeId = Guid.NewGuid();
+        var row = new Referral
+        {
+            Id = Guid.NewGuid(),
+            ReferrerUserId = referrerId,
+            RefereeUserId = refereeId,
+            CreatedAtUtc = created,
+            ActivatedAtUtc = null,
+            ActivationTrigger = null,
+            BonusReferrerDays = 0,
+            BonusRefereeDays = RecordReferralLinkService.RefereeTrialBonusDays
+        };
+        Context.Referrals.Add(row);
+        await Context.SaveChangesAsync();
+        return row;
+    }
+
+    [Test]
+    public async Task ShouldExtendTrialBy7Days_WhenReferrerIsOnActiveTrial()
+    {
+        var referrer = await CreateFreeUser();
+        referrer.RegisteredAtUtc = DateTime.UtcNow.AddDays(-5);
+        referrer.TrialBonusDays = 0;
+        await Context.SaveChangesAsync();
+        var referral = await AddPendingReferral(referrer.Id);
+
+        var result = await _sut.ExecuteAsync(referral, "first_lesson", CancellationToken.None);
+
+        result.ShouldBe(TryActivateReferralResult.Activated);
+        var updated = Context.Users.First(u => u.Id == referrer.Id);
+        updated.TrialBonusDays.ShouldBe(TryActivateReferralService.ReferrerTrialBonusDays);
+        var trialDaysLeft = (updated.TrialEndsAtUtc - DateTime.UtcNow).TotalDays;
+        // Was 25 days left (30-5), now should be ~32.
+        trialDaysLeft.ShouldBeInRange(31, 33);
+    }
+
+    [Test]
+    public async Task ShouldStackTrialBonus_WhenMultipleFriendsActivate()
+    {
+        var referrer = await CreateFreeUser();
+        referrer.RegisteredAtUtc = DateTime.UtcNow.AddDays(-2);
+        referrer.TrialBonusDays = 0;
+        await Context.SaveChangesAsync();
+
+        var r1 = await AddPendingReferral(referrer.Id);
+        var r2 = await AddPendingReferral(referrer.Id);
+        var r3 = await AddPendingReferral(referrer.Id);
+
+        await _sut.ExecuteAsync(r1, "first_lesson", CancellationToken.None);
+        await _sut.ExecuteAsync(r2, "vocab_5", CancellationToken.None);
+        await _sut.ExecuteAsync(r3, "purchase", CancellationToken.None);
+
+        var updated = Context.Users.First(u => u.Id == referrer.Id);
+        updated.TrialBonusDays.ShouldBe(3 * TryActivateReferralService.ReferrerTrialBonusDays);
+    }
+
+    [Test]
+    public async Task ShouldGrantBonus_EvenWhenTrialAlreadyExpired()
+    {
+        // Registered 35 days ago: base trial ended 5 days ago.
+        var referrer = await CreateFreeUser();
+        referrer.RegisteredAtUtc = DateTime.UtcNow.AddDays(-35);
+        referrer.TrialBonusDays = 0;
+        await Context.SaveChangesAsync();
+        referrer.TrialEndsAtUtc.ShouldBeLessThan(DateTime.UtcNow);
+
+        var referral = await AddPendingReferral(referrer.Id);
+        await _sut.ExecuteAsync(referral, "first_lesson", CancellationToken.None);
+
+        var updated = Context.Users.First(u => u.Id == referrer.Id);
+        // The bonus is recorded into TrialBonusDays even though the +7 days isn't
+        // enough to revive an expired trial in this case (35-day-old user, 5 days
+        // overdue, +7 → trial would end 2 days in the future). It DOES revive.
+        updated.TrialBonusDays.ShouldBe(TryActivateReferralService.ReferrerTrialBonusDays);
+        updated.TrialEndsAtUtc.ShouldBeGreaterThan(DateTime.UtcNow);
+    }
+
+    [Test]
+    public async Task ShouldExtendProSubscriptionBy30Days_WhenReferrerIsPro()
+    {
+        var referrer = await CreateFreeUser();
+        referrer.IsPro = true;
+        referrer.SubscriptionPlan = SubscriptionPlan.Month;
+        var subscribedUntil = DateTime.UtcNow.AddDays(20);
+        referrer.SubscribedUntil = subscribedUntil;
+        await Context.SaveChangesAsync();
+        var referral = await AddPendingReferral(referrer.Id);
+
+        var result = await _sut.ExecuteAsync(referral, "first_lesson", CancellationToken.None);
+
+        result.ShouldBe(TryActivateReferralResult.Activated);
+        var updated = Context.Users.First(u => u.Id == referrer.Id);
+        updated.SubscribedUntil.ShouldBe(subscribedUntil.AddDays(TryActivateReferralService.ReferrerProBonusDays));
+    }
+
+    [Test]
+    public async Task ShouldStackProBonus_WhenMultipleFriendsActivate()
+    {
+        var referrer = await CreateFreeUser();
+        referrer.IsPro = true;
+        referrer.SubscriptionPlan = SubscriptionPlan.Month;
+        var subscribedUntil = DateTime.UtcNow.AddDays(15);
+        referrer.SubscribedUntil = subscribedUntil;
+        await Context.SaveChangesAsync();
+
+        var r1 = await AddPendingReferral(referrer.Id);
+        var r2 = await AddPendingReferral(referrer.Id);
+
+        await _sut.ExecuteAsync(r1, "first_lesson", CancellationToken.None);
+        await _sut.ExecuteAsync(r2, "vocab_5", CancellationToken.None);
+
+        var updated = Context.Users.First(u => u.Id == referrer.Id);
+        updated.SubscribedUntil.ShouldBe(subscribedUntil.AddDays(2 * TryActivateReferralService.ReferrerProBonusDays));
+    }
+
+    [Test]
+    public async Task ShouldNotChangeAnything_WhenReferrerIsLifetime()
+    {
+        var referrer = await CreateFreeUser();
+        referrer.IsPro = true;
+        referrer.SubscriptionPlan = SubscriptionPlan.Lifetime;
+        referrer.SubscribedUntil = null;
+        referrer.RegisteredAtUtc = DateTime.UtcNow.AddDays(-10);
+        referrer.TrialBonusDays = 0;
+        await Context.SaveChangesAsync();
+        var referral = await AddPendingReferral(referrer.Id);
+
+        var result = await _sut.ExecuteAsync(referral, "first_lesson", CancellationToken.None);
+
+        result.ShouldBe(TryActivateReferralResult.Activated);
+        var updated = Context.Users.First(u => u.Id == referrer.Id);
+        updated.SubscribedUntil.ShouldBeNull();
+        updated.TrialBonusDays.ShouldBe(0);
+
+        var activated = Context.Referrals.First(r => r.Id == referral.Id);
+        activated.BonusReferrerDays.ShouldBe(0);
+        activated.ActivatedAtUtc.ShouldNotBeNull();
+    }
+
+    [Test]
+    public async Task ShouldReturnTooEarly_WhenWithinAntiFraudWindow()
+    {
+        var referrer = await CreateFreeUser();
+        referrer.RegisteredAtUtc = DateTime.UtcNow.AddDays(-5);
+        referrer.TrialBonusDays = 0;
+        await Context.SaveChangesAsync();
+        var referral = await AddPendingReferral(referrer.Id, DateTime.UtcNow.AddMinutes(-5));
+
+        var result = await _sut.ExecuteAsync(referral, "first_lesson", CancellationToken.None);
+
+        result.ShouldBe(TryActivateReferralResult.TooEarly);
+        Context.Users.First(u => u.Id == referrer.Id).TrialBonusDays.ShouldBe(0);
+        Context.Referrals.First(r => r.Id == referral.Id).ActivatedAtUtc.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task ShouldReturnAlreadyActivated_WhenReferralAlreadyHasActivatedAtUtc()
+    {
+        var referrer = await CreateFreeUser();
+        var referral = await AddPendingReferral(referrer.Id);
+        referral.ActivatedAtUtc = DateTime.UtcNow.AddDays(-1);
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.ExecuteAsync(referral, "first_lesson", CancellationToken.None);
+
+        result.ShouldBe(TryActivateReferralResult.AlreadyActivated);
+    }
+
+    [Test]
+    public async Task ShouldReturnDailyCapReached_WhenReferrerHas5ActivationsToday()
+    {
+        var referrer = await CreateFreeUser();
+        referrer.RegisteredAtUtc = DateTime.UtcNow.AddDays(-1);
+        referrer.TrialBonusDays = 0;
+        await Context.SaveChangesAsync();
+
+        for (var i = 0; i < TryActivateReferralService.DailyActivationCap; i++)
+        {
+            Context.Referrals.Add(new Referral
+            {
+                Id = Guid.NewGuid(),
+                ReferrerUserId = referrer.Id,
+                RefereeUserId = Guid.NewGuid(),
+                CreatedAtUtc = DateTime.UtcNow.AddHours(-3),
+                ActivatedAtUtc = DateTime.UtcNow.AddHours(-1),
+                BonusReferrerDays = TryActivateReferralService.ReferrerTrialBonusDays,
+                BonusRefereeDays = RecordReferralLinkService.RefereeTrialBonusDays
+            });
+        }
+        await Context.SaveChangesAsync();
+        var fresh = await AddPendingReferral(referrer.Id);
+
+        var result = await _sut.ExecuteAsync(fresh, "first_lesson", CancellationToken.None);
+
+        result.ShouldBe(TryActivateReferralResult.DailyCapReached);
+        Context.Users.First(u => u.Id == referrer.Id).TrialBonusDays.ShouldBe(0);
+        Context.Referrals.First(r => r.Id == fresh.Id).ActivatedAtUtc.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task ShouldReturnYearlyCapReached_WhenReferrerHas12ActivationsThisYear()
+    {
+        var referrer = await CreateFreeUser();
+        referrer.RegisteredAtUtc = DateTime.UtcNow.AddDays(-1);
+        referrer.TrialBonusDays = 0;
+        await Context.SaveChangesAsync();
+
+        for (var i = 0; i < TryActivateReferralService.YearlyActivationCap; i++)
+        {
+            var when = DateTime.UtcNow.AddDays(-14 * (i + 1));
+            Context.Referrals.Add(new Referral
+            {
+                Id = Guid.NewGuid(),
+                ReferrerUserId = referrer.Id,
+                RefereeUserId = Guid.NewGuid(),
+                CreatedAtUtc = when.AddHours(-3),
+                ActivatedAtUtc = when,
+                BonusReferrerDays = TryActivateReferralService.ReferrerTrialBonusDays,
+                BonusRefereeDays = RecordReferralLinkService.RefereeTrialBonusDays
+            });
+        }
+        await Context.SaveChangesAsync();
+        var fresh = await AddPendingReferral(referrer.Id);
+
+        var result = await _sut.ExecuteAsync(fresh, "first_lesson", CancellationToken.None);
+
+        result.ShouldBe(TryActivateReferralResult.YearlyCapReached);
+        Context.Referrals.First(r => r.Id == fresh.Id).ActivatedAtUtc.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task ShouldReturnReferrerGone_WhenReferrerWasDeleted()
+    {
+        var orphanReferrerId = Guid.NewGuid();
+        var referral = await AddPendingReferral(orphanReferrerId);
+
+        var result = await _sut.ExecuteAsync(referral, "first_lesson", CancellationToken.None);
+
+        result.ShouldBe(TryActivateReferralResult.ReferrerGone);
+    }
+
+    [Test]
+    public async Task ShouldRecordTriggerAndBonusDays_OnSuccessfulActivation()
+    {
+        var referrer = await CreateFreeUser();
+        referrer.RegisteredAtUtc = DateTime.UtcNow.AddDays(-3);
+        await Context.SaveChangesAsync();
+        var referral = await AddPendingReferral(referrer.Id);
+
+        await _sut.ExecuteAsync(referral, "purchase", CancellationToken.None);
+
+        var activated = Context.Referrals.First(r => r.Id == referral.Id);
+        activated.ActivatedAtUtc.ShouldNotBeNull();
+        activated.ActivationTrigger.ShouldBe("purchase");
+        activated.BonusReferrerDays.ShouldBe(TryActivateReferralService.ReferrerTrialBonusDays);
+    }
+}

--- a/tests/Domain.UnitTests/UserEntitlementTests.cs
+++ b/tests/Domain.UnitTests/UserEntitlementTests.cs
@@ -1,0 +1,414 @@
+using Domain.Entities;
+using Shouldly;
+
+namespace Domain.UnitTests;
+
+/// <summary>
+/// Covers the single-source-of-truth entitlement helpers on User:
+/// HasActivePro, HasActiveTrial, HasMiniAppAccess, TrialDaysLeft,
+/// HasExpiredPro, IsLifetime, TrialEndsAtUtc.
+///
+/// These helpers are how mini-app code answers "is the user paid? on trial?
+/// allowed in?" Everything else (controllers, queries, services) should call
+/// them rather than poking at the underlying flags.
+/// </summary>
+public class UserEntitlementTests
+{
+    private static readonly DateTime Now = new(2026, 5, 14, 12, 0, 0, DateTimeKind.Utc);
+
+    private static User NewUser(Action<User>? configure = null)
+    {
+        var u = new User
+        {
+            InitialLanguageSet = true,
+            RegisteredAtUtc = Now.AddDays(-1),
+            IsPro = false,
+            TrialBonusDays = 0,
+            SubscribedUntil = null,
+            SubscriptionPlan = null
+        };
+        configure?.Invoke(u);
+        return u;
+    }
+
+    // ----- TrialEndsAtUtc -----
+
+    [Test]
+    public void TrialEndsAtUtc_PlainUser_IsRegistrationPlus30()
+    {
+        var registeredAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var user = NewUser(u => u.RegisteredAtUtc = registeredAt);
+
+        user.TrialEndsAtUtc.ShouldBe(registeredAt.AddDays(30));
+    }
+
+    [Test]
+    public void TrialEndsAtUtc_WithBonusDays_IncludesThem()
+    {
+        var registeredAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var user = NewUser(u =>
+        {
+            u.RegisteredAtUtc = registeredAt;
+            u.TrialBonusDays = 25;
+        });
+
+        user.TrialEndsAtUtc.ShouldBe(registeredAt.AddDays(55));
+    }
+
+    // ----- IsLifetime -----
+
+    [Test]
+    public void IsLifetime_ProAndLifetimePlan_ReturnsTrue()
+    {
+        var user = NewUser(u =>
+        {
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Lifetime;
+        });
+
+        user.IsLifetime.ShouldBeTrue();
+    }
+
+    [Test]
+    public void IsLifetime_ProAndMonthPlan_ReturnsFalse()
+    {
+        var user = NewUser(u =>
+        {
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Month;
+        });
+
+        user.IsLifetime.ShouldBeFalse();
+    }
+
+    [Test]
+    public void IsLifetime_LifetimePlanButIsProFalse_ReturnsFalse()
+    {
+        // Refunded Lifetime — IsPro was flipped back but plan field lingered.
+        var user = NewUser(u =>
+        {
+            u.IsPro = false;
+            u.SubscriptionPlan = SubscriptionPlan.Lifetime;
+        });
+
+        user.IsLifetime.ShouldBeFalse();
+    }
+
+    // ----- HasActivePro -----
+
+    [Test]
+    public void HasActivePro_FreshUser_ReturnsFalse()
+    {
+        var user = NewUser();
+
+        user.HasActivePro(Now).ShouldBeFalse();
+    }
+
+    [Test]
+    public void HasActivePro_ProWithFutureExpiry_ReturnsTrue()
+    {
+        var user = NewUser(u =>
+        {
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Month;
+            u.SubscribedUntil = Now.AddDays(15);
+        });
+
+        user.HasActivePro(Now).ShouldBeTrue();
+    }
+
+    [Test]
+    public void HasActivePro_ProWithPastExpiry_ReturnsFalse()
+    {
+        // The renewal-prompt audience.
+        var user = NewUser(u =>
+        {
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Month;
+            u.SubscribedUntil = Now.AddDays(-1);
+        });
+
+        user.HasActivePro(Now).ShouldBeFalse();
+    }
+
+    [Test]
+    public void HasActivePro_Lifetime_ReturnsTrueRegardlessOfSubscribedUntil()
+    {
+        var user = NewUser(u =>
+        {
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Lifetime;
+            u.SubscribedUntil = null;
+        });
+
+        user.HasActivePro(Now).ShouldBeTrue();
+    }
+
+    [Test]
+    public void HasActivePro_NonProEvenWithFutureSubscribedUntil_ReturnsFalse()
+    {
+        // Defensive: paranoid case where IsPro got flipped off but SubscribedUntil lingers.
+        var user = NewUser(u =>
+        {
+            u.IsPro = false;
+            u.SubscribedUntil = Now.AddDays(15);
+        });
+
+        user.HasActivePro(Now).ShouldBeFalse();
+    }
+
+    [Test]
+    public void HasActivePro_ExactlyAtExpiry_ReturnsFalse()
+    {
+        var user = NewUser(u =>
+        {
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Month;
+            u.SubscribedUntil = Now;
+        });
+
+        user.HasActivePro(Now).ShouldBeFalse();
+    }
+
+    // ----- HasExpiredPro -----
+
+    [Test]
+    public void HasExpiredPro_ProWithPastExpiry_ReturnsTrue()
+    {
+        var user = NewUser(u =>
+        {
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Month;
+            u.SubscribedUntil = Now.AddDays(-3);
+        });
+
+        user.HasExpiredPro(Now).ShouldBeTrue();
+    }
+
+    [Test]
+    public void HasExpiredPro_ActivePro_ReturnsFalse()
+    {
+        var user = NewUser(u =>
+        {
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Month;
+            u.SubscribedUntil = Now.AddDays(10);
+        });
+
+        user.HasExpiredPro(Now).ShouldBeFalse();
+    }
+
+    [Test]
+    public void HasExpiredPro_NeverPaidUser_ReturnsFalse()
+    {
+        var user = NewUser();
+
+        user.HasExpiredPro(Now).ShouldBeFalse();
+    }
+
+    [Test]
+    public void HasExpiredPro_Lifetime_ReturnsFalse()
+    {
+        var user = NewUser(u =>
+        {
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Lifetime;
+        });
+
+        user.HasExpiredPro(Now).ShouldBeFalse();
+    }
+
+    // ----- HasActiveTrial -----
+
+    [Test]
+    public void HasActiveTrial_NewlyRegistered_ReturnsTrue()
+    {
+        var user = NewUser(u => u.RegisteredAtUtc = Now.AddDays(-5));
+
+        user.HasActiveTrial(Now).ShouldBeTrue();
+    }
+
+    [Test]
+    public void HasActiveTrial_31DaysAfterRegistration_ReturnsFalse()
+    {
+        var user = NewUser(u => u.RegisteredAtUtc = Now.AddDays(-31));
+
+        user.HasActiveTrial(Now).ShouldBeFalse();
+    }
+
+    [Test]
+    public void HasActiveTrial_TrialExpiredButBonusDaysExtendIt_ReturnsTrue()
+    {
+        var user = NewUser(u =>
+        {
+            u.RegisteredAtUtc = Now.AddDays(-35); // base trial ended 5 days ago
+            u.TrialBonusDays = 10; // bonus pushes end to 5 days in the future
+        });
+
+        user.HasActiveTrial(Now).ShouldBeTrue();
+    }
+
+    [Test]
+    public void HasActiveTrial_UserIsPro_ReturnsFalse()
+    {
+        // Once IsPro=true, trial is considered consumed even if dates suggest otherwise.
+        var user = NewUser(u =>
+        {
+            u.RegisteredAtUtc = Now.AddDays(-5);
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Month;
+            u.SubscribedUntil = Now.AddDays(20);
+        });
+
+        user.HasActiveTrial(Now).ShouldBeFalse();
+    }
+
+    [Test]
+    public void HasActiveTrial_ExpiredProUser_ReturnsFalse()
+    {
+        // Ex-Pro doesn't fall back into trial — they need to renew.
+        var user = NewUser(u =>
+        {
+            u.RegisteredAtUtc = Now.AddDays(-2);
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Month;
+            u.SubscribedUntil = Now.AddDays(-1);
+        });
+
+        user.HasActiveTrial(Now).ShouldBeFalse();
+    }
+
+    // ----- HasMiniAppAccess (the headline check) -----
+
+    [Test]
+    public void HasMiniAppAccess_ActivePro_True()
+    {
+        var user = NewUser(u =>
+        {
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Month;
+            u.SubscribedUntil = Now.AddDays(15);
+        });
+
+        user.HasMiniAppAccess(Now).ShouldBeTrue();
+    }
+
+    [Test]
+    public void HasMiniAppAccess_ActiveTrial_True()
+    {
+        var user = NewUser(u => u.RegisteredAtUtc = Now.AddDays(-2));
+
+        user.HasMiniAppAccess(Now).ShouldBeTrue();
+    }
+
+    [Test]
+    public void HasMiniAppAccess_Lifetime_True()
+    {
+        var user = NewUser(u =>
+        {
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Lifetime;
+        });
+
+        user.HasMiniAppAccess(Now).ShouldBeTrue();
+    }
+
+    [Test]
+    public void HasMiniAppAccess_ExpiredProNoTrialLeft_False()
+    {
+        var user = NewUser(u =>
+        {
+            u.RegisteredAtUtc = Now.AddDays(-60);
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Month;
+            u.SubscribedUntil = Now.AddDays(-2);
+        });
+
+        user.HasMiniAppAccess(Now).ShouldBeFalse();
+    }
+
+    [Test]
+    public void HasMiniAppAccess_ExpiredTrialNeverPaid_False()
+    {
+        var user = NewUser(u => u.RegisteredAtUtc = Now.AddDays(-31));
+
+        user.HasMiniAppAccess(Now).ShouldBeFalse();
+    }
+
+    // ----- TrialDaysLeft -----
+
+    [Test]
+    public void TrialDaysLeft_NewlyRegistered_Returns30()
+    {
+        var user = NewUser(u => u.RegisteredAtUtc = Now);
+
+        user.TrialDaysLeft(Now).ShouldBe(30);
+    }
+
+    [Test]
+    public void TrialDaysLeft_HalfwayThroughTrial_Returns15()
+    {
+        var user = NewUser(u => u.RegisteredAtUtc = Now.AddDays(-15));
+
+        user.TrialDaysLeft(Now).ShouldBe(15);
+    }
+
+    [Test]
+    public void TrialDaysLeft_ExpiredTrial_Returns0()
+    {
+        var user = NewUser(u => u.RegisteredAtUtc = Now.AddDays(-31));
+
+        user.TrialDaysLeft(Now).ShouldBe(0);
+    }
+
+    [Test]
+    public void TrialDaysLeft_ProUser_Returns0()
+    {
+        // Even within base trial window — if they bought Pro, trial is consumed.
+        var user = NewUser(u =>
+        {
+            u.RegisteredAtUtc = Now.AddDays(-2);
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Month;
+            u.SubscribedUntil = Now.AddDays(28);
+        });
+
+        user.TrialDaysLeft(Now).ShouldBe(0);
+    }
+
+    [Test]
+    public void TrialDaysLeft_TrialBonusDays_AddsToRemaining()
+    {
+        var user = NewUser(u =>
+        {
+            u.RegisteredAtUtc = Now.AddDays(-10);
+            u.TrialBonusDays = 14;
+        });
+
+        // 30-10+14 = 34 days remaining (with ceiling rounding for partial day).
+        user.TrialDaysLeft(Now).ShouldBe(34);
+    }
+
+    // ----- HasMiniAppAccess "renewal pain" scenario -----
+
+    [Test]
+    public void RenewalScenario_ExpiredProUserBuysAgain_HasActiveProBecomesTrue()
+    {
+        // Simulates the flow after the Purchase endpoint stops gating on stored IsPro:
+        // an expired-Pro user re-purchases, SubscribedUntil moves into the future,
+        // and HasActivePro flips back to true.
+        var user = NewUser(u =>
+        {
+            u.IsPro = true;
+            u.SubscriptionPlan = SubscriptionPlan.Month;
+            u.SubscribedUntil = Now.AddDays(-2);
+        });
+
+        user.HasActivePro(Now).ShouldBeFalse(); // baseline: lapsed
+
+        user.SubscribedUntil = Now.AddDays(30);
+
+        user.HasActivePro(Now).ShouldBeTrue();
+        user.HasMiniAppAccess(Now).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Two related fixes to the trial/referral surface:

1. **Trial-stacking on purchase** (`feat(subscription)`). Trial-period purchasers were forfeiting their remaining free days: when they bought a plan, `SubscribedUntil` was set to `now + planDuration`, ignoring the active trial. Now the start date is the latest of `now`, current paid expiry, or trial end. Applied uniformly in `ActivateProStars`, `GrantProService`, and the broadcast-gift path in `BroadcastService`.

2. **Referral card copy** (`fix(referral)`). The old card assembled a confusing sentence on the frontend (e.g. "Друг получит 60 дней триала вместо 30. Ты — счётчик друзей (Lifetime — без бонуса), когда он..."). It also showed "До 5 бонусов в день · до 12 в год" to trial users whose actual binding cap was 3 lifetime invites. Replaced with a single self-contained `bonusLabel` and a new state-aware `limitsLabel` from the backend.

Trial constants (`User.TrialDays`, `User.TrialEndsAtUtc`) are now centralized on the entity instead of being recomputed at call sites.

## What changed

- `Domain/Entities/User.cs` — add `TrialDays` const + `TrialEndsAtUtc` computed property.
- `Application/MiniApp/Commands/ActivateProStars.cs` — `startFrom = max(now, SubscribedUntil, TrialEndsAtUtc if !wasAlreadyPro)`.
- `Application/Admin/GrantProService.cs` — same.
- `Application/Admin/BroadcastService.cs` — same (gated by existing `!user.IsPro`).
- `Application/MiniApp/Queries/GetMiniAppProfile.cs` — uses `user.TrialEndsAtUtc`.
- `Application/MiniApp/Queries/GetReferralInfoQuery.cs` — rewrites `bonusLabel`, adds `LimitsLabel`.
- `Trale/Controllers/MiniAppController.cs` + `miniapp-src/src/api.ts` + `miniapp-src/src/screens/Profile.tsx` — wire `limitsLabel` through.

## Test plan

- [x] All existing tests pass (1518 total across Domain/Application/Infrastructure/Integration).
- [x] New `ActivateProStarsCommandTests.ShouldStackPlanOnRemainingTrial_WhenUserPurchasesDuringTrial` covers the stacking path.
- [x] New `ActivateProStarsCommandTests.ShouldNotStackTrial_WhenTrialAlreadyExpired` covers the no-stack path for expired trials.
- [ ] Manual: open mini-app on trial user → buy Month plan → `SubscribedUntil` should be approximately `RegisteredAtUtc + 30 + 30` days (i.e. trial + 30 days).
- [ ] Manual: open Profile → referral card text reads cleanly for trial / Pro / Lifetime states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)