### PR TITLE
feat(admin): registration-date range + Pro-status broadcast filters

### DIFF
--- a/src/Application/Admin/BroadcastService.cs
+++ b/src/Application/Admin/BroadcastService.cs
@@ -142,6 +142,38 @@ public class BroadcastService(
                 db.VocabularyEntries.Count(v => v.UserId == u.Id) >= minVocab);
         }
 
+        // Filter by registration date range — for targeting cohorts (e.g. signups May 1-5).
+        if (segment.RegisteredAfterUtc.HasValue)
+        {
+            var since = segment.RegisteredAfterUtc.Value;
+            users = users.Where(u => u.RegisteredAtUtc >= since);
+        }
+        if (segment.RegisteredBeforeUtc.HasValue)
+        {
+            var until = segment.RegisteredBeforeUtc.Value;
+            users = users.Where(u => u.RegisteredAtUtc < until);
+        }
+
+        // Filter by Pro entitlement. "active" = currently has Pro access (Lifetime or
+        // non-expired SubscribedUntil). "free" = the complement — never paid, in trial,
+        // or lapsed subscriber. Mirrors User.HasActivePro semantics so a renewal push
+        // can target exactly the people who'd benefit from it.
+        var nowUtc = DateTime.UtcNow;
+        if (segment.ProStatus == BroadcastProFilter.ActiveProOnly)
+        {
+            users = users.Where(u =>
+                u.IsPro &&
+                (u.SubscriptionPlan == SubscriptionPlan.Lifetime ||
+                 (u.SubscribedUntil.HasValue && u.SubscribedUntil.Value > nowUtc)));
+        }
+        else if (segment.ProStatus == BroadcastProFilter.NoActiveProOnly)
+        {
+            users = users.Where(u =>
+                !u.IsPro ||
+                (u.SubscriptionPlan != SubscriptionPlan.Lifetime &&
+                 (!u.SubscribedUntil.HasValue || u.SubscribedUntil.Value <= nowUtc)));
+        }
+
         // Filter by activity recency (only when explicitly requested)
         if (segment.ActiveWithinDays.HasValue && segment.ActiveWithinDays.Value > 0)
         {
@@ -171,6 +203,22 @@ public class BroadcastSegment
 
     /// <summary>Optional recency filter — null/0 means no recency filter (waking dormant users).</summary>
     public int? ActiveWithinDays { get; set; }
+
+    /// <summary>Lower bound of the registration date range (inclusive UTC). Null = no lower bound.</summary>
+    public DateTime? RegisteredAfterUtc { get; set; }
+
+    /// <summary>Upper bound of the registration date range (exclusive UTC). Null = no upper bound.</summary>
+    public DateTime? RegisteredBeforeUtc { get; set; }
+
+    /// <summary>Filter by Pro entitlement. Default Any = no filter.</summary>
+    public BroadcastProFilter ProStatus { get; set; } = BroadcastProFilter.Any;
+}
+
+public enum BroadcastProFilter
+{
+    Any,
+    ActiveProOnly,
+    NoActiveProOnly
 }
 
 public interface ITelegramMessageSender

--- a/src/Trale/Controllers/AdminController.cs
+++ b/src/Trale/Controllers/AdminController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Application.Admin;
@@ -138,13 +139,19 @@ public class AdminController : Controller
     public async Task<IActionResult> BroadcastPreview(
         [FromQuery] int? activeWithinDays,
         [FromQuery] int minVocab = 0,
+        [FromQuery] DateTime? registeredAfterUtc = null,
+        [FromQuery] DateTime? registeredBeforeUtc = null,
+        [FromQuery] string? proStatus = null,
         CancellationToken ct = default)
     {
         if (!await IsOwnerAsync(ct)) return NotFound();
         var segment = new BroadcastSegment
         {
             ActiveWithinDays = activeWithinDays,
-            MinVocabularyCount = minVocab
+            MinVocabularyCount = minVocab,
+            RegisteredAfterUtc = registeredAfterUtc,
+            RegisteredBeforeUtc = registeredBeforeUtc,
+            ProStatus = ParseProStatus(proStatus)
         };
         var preview = await _broadcast.PreviewAsync(segment, ct);
         return Ok(preview);
@@ -154,6 +161,9 @@ public class AdminController : Controller
     {
         public int? ActiveWithinDays { get; set; }
         public int MinVocabularyCount { get; set; }
+        public DateTime? RegisteredAfterUtc { get; set; }
+        public DateTime? RegisteredBeforeUtc { get; set; }
+        public string? ProStatus { get; set; }
         public string Message { get; set; } = string.Empty;
         public string? GrantPlan { get; set; }
         public bool DryRun { get; set; } = true;
@@ -167,13 +177,23 @@ public class AdminController : Controller
         var segment = new BroadcastSegment
         {
             ActiveWithinDays = req.ActiveWithinDays,
-            MinVocabularyCount = req.MinVocabularyCount
+            MinVocabularyCount = req.MinVocabularyCount,
+            RegisteredAfterUtc = req.RegisteredAfterUtc,
+            RegisteredBeforeUtc = req.RegisteredBeforeUtc,
+            ProStatus = ParseProStatus(req.ProStatus)
         };
         var result = await _broadcast.ExecuteAsync(
             segment, req.Message, req.GrantPlan, req.DryRun, req.IncludeMiniAppButton, ct);
         if (result.Error != null) return BadRequest(result);
         return Ok(result);
     }
+
+    private static BroadcastProFilter ParseProStatus(string? v) => v switch
+    {
+        "active" => BroadcastProFilter.ActiveProOnly,
+        "free" => BroadcastProFilter.NoActiveProOnly,
+        _ => BroadcastProFilter.Any
+    };
 
     /// <summary>
     /// Returns true ONLY if the request is authenticated via X-Telegram-Init-Data

--- a/src/Trale/miniapp-src/src/api.ts
+++ b/src/Trale/miniapp-src/src/api.ts
@@ -237,10 +237,19 @@ export const api = {
       method: 'POST'
     }),
 
-  adminBroadcastPreview: (opts: { activeWithinDays?: number | null; minVocab?: number }) => {
+  adminBroadcastPreview: (opts: {
+    activeWithinDays?: number | null
+    minVocab?: number
+    registeredAfterUtc?: string | null
+    registeredBeforeUtc?: string | null
+    proStatus?: 'active' | 'free' | null
+  }) => {
     const params = new URLSearchParams()
     if (opts.activeWithinDays != null) params.set('activeWithinDays', String(opts.activeWithinDays))
     if (opts.minVocab) params.set('minVocab', String(opts.minVocab))
+    if (opts.registeredAfterUtc) params.set('registeredAfterUtc', opts.registeredAfterUtc)
+    if (opts.registeredBeforeUtc) params.set('registeredBeforeUtc', opts.registeredBeforeUtc)
+    if (opts.proStatus) params.set('proStatus', opts.proStatus)
     return request<{ totalRecipients: number; sampleTelegramIds: number[] }>(
       `/api/admin/broadcast/preview?${params}`
     )
@@ -248,6 +257,9 @@ export const api = {
   adminBroadcast: (body: {
     activeWithinDays?: number | null
     minVocabularyCount?: number
+    registeredAfterUtc?: string | null
+    registeredBeforeUtc?: string | null
+    proStatus?: 'active' | 'free' | null
     message: string
     grantPlan: string | null
     dryRun: boolean

--- a/src/Trale/miniapp-src/src/screens/AdminScreen.tsx
+++ b/src/Trale/miniapp-src/src/screens/AdminScreen.tsx
@@ -236,17 +236,42 @@ function BroadcastPanel() {
   const [minVocab, setMinVocab] = useState(10)
   const [useActivity, setUseActivity] = useState(false)
   const [days, setDays] = useState(365)
-  const [grantPlan, setGrantPlan] = useState<string>('Lifetime')
+  const [useRegisteredRange, setUseRegisteredRange] = useState(false)
+  const [registeredAfterDate, setRegisteredAfterDate] = useState(() => {
+    const d = new Date()
+    d.setDate(d.getDate() - 1)
+    return d.toISOString().slice(0, 10) // YYYY-MM-DD
+  })
+  const [registeredBeforeDate, setRegisteredBeforeDate] = useState('') // empty = no upper bound
+  const [proStatus, setProStatus] = useState<'any' | 'active' | 'free'>('any')
+  // Default: no Pro grant — broadcast is just a message. Owner picks a plan explicitly.
+  const [grantPlan, setGrantPlan] = useState<string>('')
   const [includeMiniAppButton, setIncludeMiniAppButton] = useState(true)
   const [message, setMessage] = useState('')
   const [preview, setPreview] = useState<{ totalRecipients: number; sampleTelegramIds: number[] } | null>(null)
   const [busy, setBusy] = useState(false)
   const [result, setResult] = useState<string | null>(null)
 
+  // Build UTC midnight ISO strings for the registration range. Empty = no bound.
+  const registeredAfterUtcIso = useRegisteredRange && registeredAfterDate
+    ? new Date(registeredAfterDate + 'T00:00:00Z').toISOString()
+    : null
+  const registeredBeforeUtcIso = useRegisteredRange && registeredBeforeDate
+    ? new Date(registeredBeforeDate + 'T00:00:00Z').toISOString()
+    : null
+  const proStatusParam: 'active' | 'free' | null = proStatus === 'any' ? null : proStatus
+
   function segmentSummary() {
     const parts: string[] = []
     if (minVocab > 0) parts.push(`словарь ≥ ${minVocab}`)
     if (useActivity) parts.push(`активные за ${days}д`)
+    if (useRegisteredRange) {
+      const a = registeredAfterDate || '…'
+      const b = registeredBeforeDate || 'сейчас'
+      parts.push(`зарегались ${a} → ${b}`)
+    }
+    if (proStatus === 'active') parts.push('только с активной подпиской')
+    if (proStatus === 'free') parts.push('только без активной подписки')
     if (parts.length === 0) parts.push('все юзеры')
     return parts.join(' + ')
   }
@@ -255,6 +280,9 @@ function BroadcastPanel() {
     return {
       activeWithinDays: useActivity ? days : null,
       minVocabularyCount: minVocab,
+      registeredAfterUtc: registeredAfterUtcIso,
+      registeredBeforeUtc: registeredBeforeUtcIso,
+      proStatus: proStatusParam,
       message,
       grantPlan: grantPlan || null,
       dryRun,
@@ -268,7 +296,10 @@ function BroadcastPanel() {
     try {
       const p = await api.adminBroadcastPreview({
         activeWithinDays: useActivity ? days : null,
-        minVocab
+        minVocab,
+        registeredAfterUtc: registeredAfterUtcIso,
+        registeredBeforeUtc: registeredBeforeUtcIso,
+        proStatus: proStatusParam
       })
       setPreview(p)
     } catch {
@@ -357,6 +388,51 @@ function BroadcastPanel() {
             />
             <span className="font-sans text-[12px] text-jewelInk-mid">дней</span>
           </label>
+
+          {/* Registration-date range — for cohort targeting (e.g. signups May 1-5). */}
+          <div className="flex flex-col gap-1.5">
+            <label className="flex gap-2 items-center">
+              <input
+                type="checkbox"
+                checked={useRegisteredRange}
+                onChange={(e) => setUseRegisteredRange(e.target.checked)}
+              />
+              <span className="font-sans text-[12px] text-jewelInk-mid">+ зарегались в интервал</span>
+            </label>
+            <div className="flex gap-2 items-center pl-6">
+              <span className="font-sans text-[11px] text-jewelInk-mid">с</span>
+              <input
+                type="date"
+                value={registeredAfterDate}
+                disabled={!useRegisteredRange}
+                onChange={(e) => setRegisteredAfterDate(e.target.value)}
+                className="px-2 py-1 rounded border-[1.5px] border-jewelInk/40 font-sans text-[13px] disabled:opacity-50"
+              />
+              <span className="font-sans text-[11px] text-jewelInk-mid">по</span>
+              <input
+                type="date"
+                value={registeredBeforeDate}
+                disabled={!useRegisteredRange}
+                placeholder="сейчас"
+                onChange={(e) => setRegisteredBeforeDate(e.target.value)}
+                className="px-2 py-1 rounded border-[1.5px] border-jewelInk/40 font-sans text-[13px] disabled:opacity-50"
+              />
+            </div>
+          </div>
+
+          {/* Pro entitlement filter */}
+          <div className="flex gap-2 items-center">
+            <span className="font-sans text-[12px] text-jewelInk-mid">подписка:</span>
+            <select
+              value={proStatus}
+              onChange={(e) => setProStatus(e.target.value as 'any' | 'active' | 'free')}
+              className="px-2 py-1.5 rounded border-[1.5px] border-jewelInk/40 font-sans text-[13px] bg-cream"
+            >
+              <option value="any">не важно</option>
+              <option value="active">только с активной</option>
+              <option value="free">только без активной</option>
+            </select>
+          </div>
 
           <div className="flex justify-between items-center">
             <span className="font-sans text-[11px] text-jewelInk-mid">

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,8 +46,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TraleBot — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-CeD09F8S.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-B392ZbaR.css">
+    <script type="module" crossorigin src="/assets/index-BdL0Fb-f.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-Dnrll3Sg.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

Adds two new filters to the Admin → Broadcast panel so the owner can target cohorts directly from the UI:

- **Registration interval**: from-date and to-date pickers (empty to-date = up to now).
- **Pro status**: any / только с активной подпиской / только без активной подписки. Mirrors User.HasActivePro semantics (IsPro AND (Lifetime OR future SubscribedUntil)).

Use case driving this: after the entitlement fix in #905, we want to send a one-off message to everyone who signed up during the bug window AND doesn't have Pro yet, letting them know their 30-day trial is fully available.

Also defaults the Pro-grant dropdown to empty (was "Lifetime") — a 150-person broadcast accidentally including a Lifetime grant would be very hard to undo.

## Test plan

- [x] dotnet test green (1583 tests).
- [x] Backend builds clean, miniapp builds clean.
- [ ] Manual: in admin panel, toggle range filter with May 13 → May 14, select "только без активной подписки", preview → should show ~150 yesterday signups.
- [ ] Manual: dry-run broadcast → confirm recipient count.
- [ ] Manual: real broadcast with the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)