### PR TITLE
Ночной прогон 2026-05-15

### DIFF
--- a/src/Application/MiniApp/Queries/GetMiniAppProfile.cs
+++ b/src/Application/MiniApp/Queries/GetMiniAppProfile.cs
@@ -12,8 +12,7 @@ namespace Application.MiniApp.Queries;
 public class GetMiniAppProfile : IRequest<GetMiniAppProfileResult>
 {
     public required Guid UserId { get; init; }
-    /// <summary>Set to BotConfiguration.OwnerTelegramId so the handler doesn't need
-    /// to depend on Infrastructure. Zero means "no owner configured" → isOwner=false.</summary>
+    // Passed from controller so Application doesn't depend on BotConfiguration; 0 → isOwner=false.
     public long OwnerTelegramId { get; init; }
 
     public class Handler(

--- a/src/Application/MiniApp/Queries/GetMiniAppProfile.cs
+++ b/src/Application/MiniApp/Queries/GetMiniAppProfile.cs
@@ -12,6 +12,9 @@ namespace Application.MiniApp.Queries;
 public class GetMiniAppProfile : IRequest<GetMiniAppProfileResult>
 {
     public required Guid UserId { get; init; }
+    /// <summary>Set to BotConfiguration.OwnerTelegramId so the handler doesn't need
+    /// to depend on Infrastructure. Zero means "no owner configured" → isOwner=false.</summary>
+    public long OwnerTelegramId { get; init; }
 
     public class Handler(
         ITraleDbContext dbContext,
@@ -46,9 +49,7 @@ public class GetMiniAppProfile : IRequest<GetMiniAppProfileResult>
             var trialDaysLeft = user.TrialDaysLeft(now);
             var shouldShowReferralExtensionCta = user.ShouldShowReferralExtensionCta(now);
 
-            // Owner has English fallback and debug tooling
-            const long ownerTelegramId = 309149393;
-            var isOwner = user.TelegramId == ownerTelegramId;
+            var isOwner = request.OwnerTelegramId != 0 && user.TelegramId == request.OwnerTelegramId;
 
             return new GetMiniAppProfileResult
             {

--- a/src/Application/MiniApp/Queries/GetMiniAppProfile.cs
+++ b/src/Application/MiniApp/Queries/GetMiniAppProfile.cs
@@ -74,10 +74,10 @@ public class GetMiniAppProfileResult
 {
     public bool Authenticated { get; init; }
     public long TelegramId { get; init; }
-    public string Language { get; init; }
+    public string? Language { get; init; }
     public int VocabularyCount { get; init; }
-    public string Level { get; init; }
-    public object Progress { get; init; }
+    public string? Level { get; init; }
+    public object? Progress { get; init; }
     public bool IsPro { get; init; }
     public bool IsTrialActive { get; init; }
     public int TrialDaysLeft { get; init; }

--- a/src/Trale/Controllers/AdminController.cs
+++ b/src/Trale/Controllers/AdminController.cs
@@ -16,10 +16,6 @@ public class AdminController : Controller
 {
     private const string InitDataHeader = "X-Telegram-Init-Data";
 
-    // Hardcoded owner Telegram ID for now (matches GetMiniAppProfile.cs).
-    // BotConfiguration.OwnerTelegramId can override via env BOTCONFIGURATION__OWNERTELEGRAMID.
-    private const long DefaultOwnerTelegramId = 309149393;
-
     private readonly ITraleDbContext _dbContext;
     private readonly BotConfiguration _botConfig;
     private readonly GetAdminStatsQuery _statsQuery;
@@ -212,8 +208,7 @@ public class AdminController : Controller
             return false;
         }
 
-        var ownerId = _botConfig.OwnerTelegramId != 0 ? _botConfig.OwnerTelegramId : DefaultOwnerTelegramId;
-        if (telegramId.Value != ownerId)
+        if (_botConfig.OwnerTelegramId == 0 || telegramId.Value != _botConfig.OwnerTelegramId)
         {
             return false;
         }

--- a/src/Trale/Controllers/MiniAppController.cs
+++ b/src/Trale/Controllers/MiniAppController.cs
@@ -33,17 +33,16 @@ public class MiniAppController : Controller
 
     private const int StarsProPrice = 150;
 
+    // Additional tester who gets test pricing alongside the owner.
+    private const long ExtraTestPricingId = 866427565;
+
     /// <summary>
     /// Telegram user IDs that get a symbolic 1-star price on all subscription plans —
     /// used exclusively to validate the end-to-end Stars checkout flow against real
     /// Telegram infrastructure without paying full fare each time. All other users
     /// see the normal <see cref="SubscriptionPlans"/> prices.
     /// </summary>
-    private static readonly HashSet<long> TestPricingTelegramIds = new()
-    {
-        309149393, // owner
-        866427565,
-    };
+    private readonly HashSet<long> _testPricingTelegramIds;
 
     private const int TestPricingStars = 1;
 
@@ -77,6 +76,10 @@ public class MiniAppController : Controller
         _metrics = metrics;
         _logger = logger;
         _feedTreatService = feedTreatService;
+
+        _testPricingTelegramIds = new HashSet<long> { ExtraTestPricingId };
+        if (botConfig.OwnerTelegramId != 0)
+            _testPricingTelegramIds.Add(botConfig.OwnerTelegramId);
     }
 
     [HttpGet("ping")]
@@ -136,7 +139,8 @@ public class MiniAppController : Controller
 
         var result = await _mediator.Send(new GetMiniAppProfile
         {
-            UserId = user.Id
+            UserId = user.Id,
+            OwnerTelegramId = _botConfig.OwnerTelegramId
         }, ct);
 
         return Ok(new
@@ -165,7 +169,7 @@ public class MiniAppController : Controller
         // plan cards, matching what Purchase() will then charge them. Anonymous /
         // unresolved callers fall through to normal SubscriptionPlans prices.
         var user = await ResolveUserAsync(ct);
-        var applyTestPricing = user != null && TestPricingTelegramIds.Contains(user.TelegramId);
+        var applyTestPricing = user != null && _testPricingTelegramIds.Contains(user.TelegramId);
 
         var plans = SubscriptionPlans.All.Select(p => new
         {
@@ -250,7 +254,7 @@ public class MiniAppController : Controller
             return BadRequest(new { error = "invalid_plan" });
         }
 
-        if (TestPricingTelegramIds.Contains(user.TelegramId))
+        if (_testPricingTelegramIds.Contains(user.TelegramId))
         {
             _logger.LogWarning(
                 "Test pricing applied: user {TelegramId} ({UserId}) purchasing {Plan} at {Stars}⭐ instead of {OriginalStars}⭐",

--- a/src/Trale/Controllers/MiniAppController.cs
+++ b/src/Trale/Controllers/MiniAppController.cs
@@ -31,8 +31,6 @@ public class MiniAppController : Controller
 {
     private const string InitDataHeader = "X-Telegram-Init-Data";
 
-    private const int StarsProPrice = 150;
-
     // Additional tester who gets test pricing alongside the owner.
     private const long ExtraTestPricingId = 866427565;
 

--- a/src/Trale/miniapp-src/src/components/ChipPool.tsx
+++ b/src/Trale/miniapp-src/src/components/ChipPool.tsx
@@ -2,11 +2,16 @@ import React from 'react'
 
 interface Props {
   children: React.ReactNode
+  useGrid?: boolean
 }
 
-export default function ChipPool({ children }: Props) {
+export default function ChipPool({ children, useGrid }: Props) {
   return (
-    <div className="flex flex-wrap gap-2" data-testid="chip-pool">
+    <div
+      className={useGrid ? 'grid gap-2' : 'flex flex-wrap gap-2'}
+      style={useGrid ? { gridTemplateColumns: 'repeat(3, 1fr)' } : undefined}
+      data-testid="chip-pool"
+    >
       {children}
     </div>
   )

--- a/src/Trale/miniapp-src/src/components/SentenceBuilderCard.tsx
+++ b/src/Trale/miniapp-src/src/components/SentenceBuilderCard.tsx
@@ -11,6 +11,8 @@ interface Props {
   onAnswer: (isCorrect: boolean) => void
 }
 
+const LONG_SENTENCE_THRESHOLD = 7
+
 export default function SentenceBuilderCard({ question, onAnswer }: Props) {
   const correctOrder = question.correctOrder ?? []
   const chipPoolTokens = question.chipPool ?? []
@@ -130,7 +132,7 @@ export default function SentenceBuilderCard({ question, onAnswer }: Props) {
         <div className="h-px bg-jewelInk/15 mb-2 relative z-[1]" />
         <div
           data-testid="question-text"
-          className={`font-sans font-extrabold text-jewelInk leading-tight relative z-[1] ${correctOrder.length >= 7 ? 'text-[18px]' : 'text-[22px]'}`}
+          className={`font-sans font-extrabold text-jewelInk leading-tight relative z-[1] ${correctOrder.length >= LONG_SENTENCE_THRESHOLD ? 'text-[18px]' : 'text-[22px]'}`}
         >
           {targetRu}
         </div>
@@ -182,7 +184,7 @@ export default function SentenceBuilderCard({ question, onAnswer }: Props) {
       </div>
 
       {/* Chip pool */}
-      <ChipPool useGrid={correctOrder.length >= 7}>
+      <ChipPool useGrid={correctOrder.length >= LONG_SENTENCE_THRESHOLD}>
         {chips.map((chip, i) => {
           if (chip.inSlot) return null
           const chipState =

--- a/src/Trale/miniapp-src/src/components/SentenceBuilderCard.tsx
+++ b/src/Trale/miniapp-src/src/components/SentenceBuilderCard.tsx
@@ -182,7 +182,7 @@ export default function SentenceBuilderCard({ question, onAnswer }: Props) {
       </div>
 
       {/* Chip pool */}
-      <ChipPool>
+      <ChipPool useGrid={correctOrder.length >= 7}>
         {chips.map((chip, i) => {
           if (chip.inSlot) return null
           const chipState =

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,7 +46,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TraleBot — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-CMO90s6e.js"></script>
+    <script type="module" crossorigin src="/assets/index-B6zvaT0o.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Dnrll3Sg.css">
   </head>
   <body>

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,7 +46,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TraleBot — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-NDgAS7oZ.js"></script>
+    <script type="module" crossorigin src="/assets/index-CMO90s6e.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Dnrll3Sg.css">
   </head>
   <body>

--- a/tests/Application.UnitTests/Tests/GetMiniAppProfileQueryTests.cs
+++ b/tests/Application.UnitTests/Tests/GetMiniAppProfileQueryTests.cs
@@ -167,4 +167,46 @@ public class GetMiniAppProfileQueryTests : CommandTestsBase
 
         result.ShouldShowReferralExtensionCta.ShouldBeFalse();
     }
+
+    [Test]
+    public async Task IsOwner_ShouldBeTrue_WhenOwnerTelegramIdMatchesUser()
+    {
+        var user = await CreateFreeUser();
+        user.TelegramId = 12345L;
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.Handle(
+            new GetMiniAppProfile { UserId = user.Id, OwnerTelegramId = 12345L },
+            CancellationToken.None);
+
+        result.IsOwner.ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task IsOwner_ShouldBeFalse_WhenOwnerTelegramIdIsZero()
+    {
+        var user = await CreateFreeUser();
+        user.TelegramId = 12345L;
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.Handle(
+            new GetMiniAppProfile { UserId = user.Id, OwnerTelegramId = 0 },
+            CancellationToken.None);
+
+        result.IsOwner.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task IsOwner_ShouldBeFalse_WhenOwnerTelegramIdDoesNotMatchUser()
+    {
+        var user = await CreateFreeUser();
+        user.TelegramId = 12345L;
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.Handle(
+            new GetMiniAppProfile { UserId = user.Id, OwnerTelegramId = 99999L },
+            CancellationToken.None);
+
+        result.IsOwner.ShouldBeFalse();
+    }
 }


### PR DESCRIPTION
## Ночной прогон — 2026-05-15

Пять агентов (methodist → product → tech-lead → developer → qa) работали последовательно каждый час на ветке `agents/nightly-2026-05-15`. Интеграционный QA каждый час, GitHub issues — источник правды по задачам.

**Итого:** 7 коммитов · 7 файлов · +72 / -26 строк

---

## 🧪 Как протестировать (тап-за-тапом)

_Тест-сценарии не сгенерированы (phase_test_scenarios не отработал или этой ночью ничего не закрыли)._

---

## Что сделали этой ночью

### 🛠 Инфраструктура

- fix(§81): ChipPool switches to 3-column grid for 7+ slot questions

---

### Задачи

**Закрытые:** —
**Упомянутые:** —

<details>
<summary>QA Report (hourly integration)</summary>

_QA-отчёт не сгенерирован_

</details>

<details>
<summary>Все коммиты</summary>

```
929ec97 [refactor] 2026-05-15_17-00
1e7a93c refactor(§81 review): nullable result fields + extract LONG_SENTENCE_THRESHOLD
a92876c refactor(§81 review): compress multi-line XML doc to single comment
b42d686 refactor(§81 review): remove unused StarsProPrice constant
da766de test(§81 refactor): add IsOwner unit tests for GetMiniAppProfile
7217101 fix(§81): ChipPool switches to 3-column grid for 7+ slot questions
04651b8 [refactor] 2026-05-15_11-00
```

</details>

<details>
<summary>Изменённые файлы</summary>

```
 .../MiniApp/Queries/GetMiniAppProfile.cs           | 12 +++----
 src/Trale/Controllers/AdminController.cs           |  7 +---
 src/Trale/Controllers/MiniAppController.cs         | 20 ++++++-----
 src/Trale/miniapp-src/src/components/ChipPool.tsx  |  9 +++--
 .../src/components/SentenceBuilderCard.tsx         |  6 ++--
 src/Trale/wwwroot/index.html                       |  2 +-
 .../Tests/GetMiniAppProfileQueryTests.cs           | 42 ++++++++++++++++++++++
 7 files changed, 72 insertions(+), 26 deletions(-)
```

</details>

---
*Automated by Bombora Nightly Pipeline — 2026-05-15*