### PR TITLE
Ночной прогон 2026-05-18

### DIFF
--- a/src/Trale/miniapp-src/src/components/ChipPool.tsx
+++ b/src/Trale/miniapp-src/src/components/ChipPool.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export default function ChipPool({ children }: Props) {
   return (
-    <div className="flex flex-wrap gap-2" data-testid="chip-pool">
+    <div className="grid grid-cols-3 gap-2" data-testid="chip-pool">
       {children}
     </div>
   )

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,7 +46,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TraleBot — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-NDgAS7oZ.js"></script>
+    <script type="module" crossorigin src="/assets/index-Bz2N3lSk.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Dnrll3Sg.css">
   </head>
   <body>


### PR DESCRIPTION
## Ночной прогон — 2026-05-18

Пять агентов (methodist → product → tech-lead → developer → qa) работали последовательно каждый час на ветке `agents/nightly-2026-05-18`. Интеграционный QA каждый час, GitHub issues — источник правды по задачам.

**Итого:** 1 коммитов · 2 файлов · +2 / -2 строк

---

## 🧪 Как протестировать (тап-за-тапом)

_Тест-сценарии не сгенерированы (phase_test_scenarios не отработал или этой ночью ничего не закрыли)._

---

## Что сделали этой ночью



---

### Задачи

**Закрытые:** —
**Упомянутые:** —

<details>
<summary>QA Report (hourly integration)</summary>

_QA-отчёт не сгенерирован_

</details>

<details>
<summary>Все коммиты</summary>

```
7b64808 refactor(sentence-builder): ChipPool → 3-column CSS grid (§81 no-scroll layout)
```

</details>

<details>
<summary>Изменённые файлы</summary>

```
 src/Trale/miniapp-src/src/components/ChipPool.tsx | 2 +-
 src/Trale/wwwroot/index.html                      | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```

</details>

---
*Automated by Bombora Nightly Pipeline — 2026-05-18*