### PR TITLE
Ночной прогон 2026-05-20

### DIFF
--- a/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
+++ b/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
@@ -35,7 +35,7 @@ public class GetReferralInfoQuery(ITraleDbContext db)
         var now = DateTime.UtcNow;
         var isLifetime = user.IsLifetime;
         // Pro bonus is earned by anyone who ever bought Pro (excl. Lifetime) — including
-        // expired-Pro users, whose +30d will reactivate their subscription.
+        // expired-Pro users, whose referral bonus reactivates their subscription.
         var earnsProBonus = user.IsPro && !isLifetime;
         var inviteeTotalTrial = User.TrialDays + RecordReferralLinkService.RefereeTrialBonusDays;
         var dailyCap = TryActivateReferralService.DailyActivationCap;

--- a/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
+++ b/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
@@ -32,7 +32,6 @@ public class GetReferralInfoQuery(ITraleDbContext db)
                           && r.ActivatedAtUtc != null
                           && r.ActivatedAtUtc >= yearAgo, ct);
 
-        var now = DateTime.UtcNow;
         var isLifetime = user.IsLifetime;
         // Pro bonus is earned by anyone who ever bought Pro (excl. Lifetime) — including
         // expired-Pro users, whose referral bonus reactivates their subscription.

--- a/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
+++ b/src/Application/MiniApp/Queries/GetReferralInfoQuery.cs
@@ -21,16 +21,15 @@ public class GetReferralInfoQuery(ITraleDbContext db)
         var user = await db.Users.FirstOrDefaultAsync(u => u.Id == userId, ct);
         if (user == null) return null;
 
-        var invited = await db.Referrals
-            .CountAsync(r => r.ReferrerUserId == userId, ct);
-        var activated = await db.Referrals
-            .CountAsync(r => r.ReferrerUserId == userId && r.ActivatedAtUtc != null, ct);
-
         var yearAgo = DateTime.UtcNow.AddDays(-365);
-        var yearActivated = await db.Referrals
-            .CountAsync(r => r.ReferrerUserId == userId
-                          && r.ActivatedAtUtc != null
-                          && r.ActivatedAtUtc >= yearAgo, ct);
+        var activatedDates = await db.Referrals
+            .Where(r => r.ReferrerUserId == userId)
+            .Select(r => r.ActivatedAtUtc)
+            .ToListAsync(ct);
+
+        var invited = activatedDates.Count;
+        var activated = activatedDates.Count(a => a != null);
+        var yearActivated = activatedDates.Count(a => a != null && a >= yearAgo);
 
         var isLifetime = user.IsLifetime;
         // Pro bonus is earned by anyone who ever bought Pro (excl. Lifetime) — including

--- a/src/Trale/miniapp-src/src/components/ChipPool.tsx
+++ b/src/Trale/miniapp-src/src/components/ChipPool.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export default function ChipPool({ children }: Props) {
   return (
-    <div className="flex flex-wrap gap-2" data-testid="chip-pool">
+    <div className="grid grid-cols-3 gap-2" data-testid="chip-pool">
       {children}
     </div>
   )

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,7 +46,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TraleBot — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-NDgAS7oZ.js"></script>
+    <script type="module" crossorigin src="/assets/index-Bz2N3lSk.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Dnrll3Sg.css">
   </head>
   <body>

--- a/tests/Application.UnitTests/Tests/GetReferralInfoQueryTests.cs
+++ b/tests/Application.UnitTests/Tests/GetReferralInfoQueryTests.cs
@@ -1,0 +1,226 @@
+using Application.MiniApp.Commands;
+using Application.MiniApp.Queries;
+using Application.UnitTests.Common;
+using Domain.Entities;
+using Shouldly;
+
+namespace Application.UnitTests.Tests;
+
+public class GetReferralInfoQueryTests : CommandTestsBase
+{
+    private GetReferralInfoQuery _sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _sut = new GetReferralInfoQuery(Context);
+    }
+
+    private async Task<User> AddUser(bool isPro = false, bool isLifetime = false)
+    {
+        var settingsId = Guid.NewGuid();
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            TelegramId = Random.Shared.NextInt64(100_000, 999_999),
+            IsPro = isPro || isLifetime,
+            SubscriptionPlan = isLifetime ? SubscriptionPlan.Lifetime
+                : isPro ? SubscriptionPlan.Month
+                : null,
+            SubscribedUntil = isPro && !isLifetime ? DateTime.UtcNow.AddDays(30) : null,
+            RegisteredAtUtc = DateTime.UtcNow,
+            IsActive = true,
+            InitialLanguageSet = false,
+            UserSettingsId = settingsId
+        };
+        user.Settings = new UserSettings { Id = settingsId, UserId = user.Id, CurrentLanguage = Language.English };
+        Context.Users.Add(user);
+        await Context.SaveChangesAsync();
+        return user;
+    }
+
+    private async Task AddReferral(Guid referrerId, DateTime? activatedAt)
+    {
+        Context.Referrals.Add(new Referral
+        {
+            Id = Guid.NewGuid(),
+            ReferrerUserId = referrerId,
+            RefereeUserId = Guid.NewGuid(),
+            CreatedAtUtc = DateTime.UtcNow.AddDays(-1),
+            ActivatedAtUtc = activatedAt,
+            BonusReferrerDays = 0,
+            BonusRefereeDays = 0
+        });
+        await Context.SaveChangesAsync();
+    }
+
+    [Test]
+    public async Task ReturnsNull_WhenUserDoesNotExist()
+    {
+        var result = await _sut.ExecuteAsync(Guid.NewGuid(), CancellationToken.None);
+        result.ShouldBeNull();
+    }
+
+    [Test]
+    public async Task InvitedCount_IncludesNonActivatedReferrals()
+    {
+        var user = await AddUser();
+        await AddReferral(user.Id, activatedAt: null);
+        await AddReferral(user.Id, activatedAt: null);
+        await AddReferral(user.Id, activatedAt: DateTime.UtcNow.AddDays(-10));
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        result!.InvitedCount.ShouldBe(3);
+        result.ActivatedCount.ShouldBe(1);
+    }
+
+    [Test]
+    public async Task ActivatedCount_ExcludesReferralsWithNullActivation()
+    {
+        var user = await AddUser();
+        await AddReferral(user.Id, activatedAt: DateTime.UtcNow.AddDays(-5));
+        await AddReferral(user.Id, activatedAt: null);
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        result!.ActivatedCount.ShouldBe(1);
+        result.InvitedCount.ShouldBe(2);
+    }
+
+    [Test]
+    public async Task CapReached_WhenYearActivatedReachesYearlyCap()
+    {
+        var user = await AddUser(isPro: true);
+        for (var i = 0; i < TryActivateReferralService.YearlyActivationCap; i++)
+            await AddReferral(user.Id, activatedAt: DateTime.UtcNow.AddDays(-i - 1));
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        result!.CapReached.ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task CapReached_IsFalse_WhenBelowYearlyCap()
+    {
+        var user = await AddUser(isPro: true);
+        for (var i = 0; i < TryActivateReferralService.YearlyActivationCap - 1; i++)
+            await AddReferral(user.Id, activatedAt: DateTime.UtcNow.AddDays(-i - 1));
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        result!.CapReached.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task CapReached_IsFalse_ForLifetimeUser_EvenWhenYearlyCapExceeded()
+    {
+        var user = await AddUser(isLifetime: true);
+        for (var i = 0; i <= TryActivateReferralService.YearlyActivationCap; i++)
+            await AddReferral(user.Id, activatedAt: DateTime.UtcNow.AddDays(-i - 1));
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        result!.CapReached.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task YearActivated_ExcludesActivationsOlderThanOneYear()
+    {
+        var user = await AddUser(isPro: true);
+        await AddReferral(user.Id, activatedAt: DateTime.UtcNow.AddDays(-10));   // within year
+        await AddReferral(user.Id, activatedAt: DateTime.UtcNow.AddDays(-400));  // older than year
+        await AddReferral(user.Id, activatedAt: null);                            // not activated
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        // Only 1 activation counts toward yearActivated; cap=6, so not reached.
+        result!.CapReached.ShouldBeFalse();
+        result.ActivatedCount.ShouldBe(2);
+        result.InvitedCount.ShouldBe(3);
+    }
+
+    [Test]
+    public async Task BonusShortLabel_IsProBonus_ForProNonLifetimeUser()
+    {
+        var user = await AddUser(isPro: true);
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        result!.BonusShortLabel.ShouldBe($"+{TryActivateReferralService.ReferrerProBonusDays} дней Pro");
+    }
+
+    [Test]
+    public async Task BonusShortLabel_IsTrialBonus_ForFreeUser()
+    {
+        var user = await AddUser(isPro: false);
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        result!.BonusShortLabel.ShouldBe($"+{TryActivateReferralService.ReferrerTrialBonusDays} дней триала");
+    }
+
+    [Test]
+    public async Task BonusShortLabel_IsEmpty_ForLifetimeUser()
+    {
+        var user = await AddUser(isLifetime: true);
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        result!.BonusShortLabel.ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task Rules_ContainsLifetimeNote_ForLifetimeUser()
+    {
+        var user = await AddUser(isLifetime: true);
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        result!.Rules.ShouldContain(r => r.Contains("Lifetime"));
+    }
+
+    [Test]
+    public async Task Rules_ContainsCapLimits_ForNonLifetimeUser()
+    {
+        var user = await AddUser(isPro: true);
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        result!.Rules.ShouldContain(r => r.Contains(TryActivateReferralService.DailyActivationCap.ToString()));
+        result.Rules.ShouldContain(r => r.Contains(TryActivateReferralService.YearlyActivationCap.ToString()));
+    }
+
+    [Test]
+    public async Task Rules_InviteeTotalTrialDays_MatchesExpectedFormula()
+    {
+        var user = await AddUser();
+        var expectedTotal = User.TrialDays + RecordReferralLinkService.RefereeTrialBonusDays;
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        result!.Rules.ShouldContain(r => r.Contains(expectedTotal.ToString()));
+    }
+
+    [Test]
+    public async Task ReferrerTelegramId_MatchesUser()
+    {
+        var user = await AddUser();
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        result!.ReferrerTelegramId.ShouldBe(user.TelegramId);
+    }
+
+    [Test]
+    public async Task ZeroReferrals_AllCountsAreZero()
+    {
+        var user = await AddUser();
+
+        var result = await _sut.ExecuteAsync(user.Id, CancellationToken.None);
+
+        result!.InvitedCount.ShouldBe(0);
+        result.ActivatedCount.ShouldBe(0);
+        result.CapReached.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Ночной прогон — 2026-05-20

Пять агентов (methodist → product → tech-lead → developer → qa) работали последовательно каждый час на ветке `agents/nightly-2026-05-20`. Интеграционный QA каждый час, GitHub issues — источник правды по задачам.

**Итого:** 4 коммитов · 4 файлов · +237 / -13 строк

---

## 🧪 Как протестировать (тап-за-тапом)

_Тест-сценарии не сгенерированы (phase_test_scenarios не отработал или этой ночью ничего не закрыли)._

---

## Что сделали этой ночью

### 🛠 Инфраструктура

- fix(§81): ChipPool grid layout + stale comment in referral query

---

### Задачи

**Закрытые:** —
**Упомянутые:** —

<details>
<summary>QA Report (hourly integration)</summary>

_QA-отчёт не сгенерирован_

</details>

<details>
<summary>Все коммиты</summary>

```
b110b7b test(§81): add unit tests for GetReferralInfoQuery
82184f5 refactor(§81): batch referral counts into single DB round-trip
a2bbff7 refactor(§81): drop unused `now` variable in GetReferralInfoQuery
ed5db61 fix(§81): ChipPool grid layout + stale comment in referral query
```

</details>

<details>
<summary>Изменённые файлы</summary>

```
 .../MiniApp/Queries/GetReferralInfoQuery.cs        |  20 +-
 src/Trale/miniapp-src/src/components/ChipPool.tsx  |   2 +-
 src/Trale/wwwroot/index.html                       |   2 +-
 .../Tests/GetReferralInfoQueryTests.cs             | 226 +++++++++++++++++++++
 4 files changed, 237 insertions(+), 13 deletions(-)
```

</details>

---
*Automated by Bombora Nightly Pipeline — 2026-05-20*