### PR TITLE
Bootstrap agent_ro read-only role + RBAC for port-forward

### DIFF
--- a/.github/workflows/kubernetes_deploy_db.yml
+++ b/.github/workflows/kubernetes_deploy_db.yml
@@ -22,10 +22,31 @@ jobs:
           kubeconfig: ${{ secrets.KUBE_CONFIG_DATA }}
           context: microk8s
 
-      - name: Deploy to Kubernetes
-        run: envsubst < ./deploy/postgres.yml | kubectl apply -n tralebot-prod -f - 
+      - name: Deploy postgres StatefulSet
+        run: envsubst < ./deploy/postgres.yml | kubectl apply -n tralebot-prod -f -
         env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
           POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
           POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+
+      - name: Wait for postgres to be ready
+        run: kubectl wait --for=condition=ready pod/postgres-0 -n tralebot-prod --timeout=180s
+
+      # Job в Кубере иммутабельный — повторный apply того же манифеста упадёт.
+      # Поэтому перед apply явно сносим прошлый Job (если был) и создаём заново.
+      - name: Delete previous bootstrap job (if any)
+        run: kubectl delete job db-bootstrap -n tralebot-prod --ignore-not-found
+
+      - name: Apply bootstrap job (creates agent_ro role)
+        run: envsubst < ./deploy/postgres-bootstrap.yml | kubectl apply -n tralebot-prod -f -
+        env:
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          AGENT_RO_PASSWORD: ${{ secrets.AGENT_RO_PASSWORD }}
+
+      - name: Wait for bootstrap to complete
+        run: kubectl wait --for=condition=complete job/db-bootstrap -n tralebot-prod --timeout=120s
+
+      - name: Apply RBAC for external read-only access
+        run: kubectl apply -n tralebot-prod -f ./deploy/agent-rbac.yml

--- a/deploy/agent-rbac.yml
+++ b/deploy/agent-rbac.yml
@@ -1,0 +1,50 @@
+# RBAC для внешнего read-only доступа к Postgres через kubectl port-forward.
+#
+# Идея: на локальной машине, где бегают Claude Code агенты, лежит отдельный
+# kubeconfig под этот ServiceAccount. Агент может только пробросить порт до
+# pod/postgres-0 и больше ничего. Дальше он подключается через psql под
+# agent_ro (read-only роль в самой БД, см. postgres-bootstrap.yml).
+#
+# Два уровня защиты:
+# 1) RBAC ограничивает что в кластере вообще можно потрогать.
+# 2) agent_ro в БД гарантирует read-only даже если RBAC обойдут.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-readonly
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agent-portforward-postgres
+rules:
+  # list нужен чтобы `kubectl port-forward pod/postgres-0` смог найти под.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+
+  # Главное право — пробросить порт. resourceNames намеренно whitelist'ит
+  # ровно один под, чтобы скомпрометированный kubeconfig не дал доступ
+  # к произвольным подам в namespace.
+  - apiGroups: [""]
+    resources: ["pods/portforward"]
+    verbs: ["create"]
+    resourceNames: ["postgres-0"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-portforward-postgres
+subjects:
+  - kind: ServiceAccount
+    name: agent-readonly
+    namespace: tralebot-prod
+roleRef:
+  kind: Role
+  name: agent-portforward-postgres
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/postgres-bootstrap.yml
+++ b/deploy/postgres-bootstrap.yml
@@ -1,0 +1,85 @@
+# Bootstrap для read-only роли `agent_ro` в Postgres.
+#
+# Запускается отдельным Job'ом после каждого деплоя БД. SQL идемпотентный:
+# роль создаётся если её нет, пароль и гранты переустанавливаются всегда,
+# поэтому ротация пароля = bump секрета AGENT_RO_PASSWORD + re-run workflow.
+#
+# Все $VAR — плейсхолдеры под envsubst в .github/workflows/kubernetes_deploy_db.yml,
+# реальные значения приходят из GitHub Secrets и НИКОГДА не должны попадать в этот файл.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-bootstrap-sql
+data:
+  bootstrap.sql: |
+    -- Создаём роль только если её ещё нет. \gexec выполняет результат SELECT'а
+    -- как SQL — пустой SELECT (ничего не возвращает) если роль уже есть.
+    SELECT 'CREATE ROLE agent_ro LOGIN'
+    WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'agent_ro')\gexec
+
+    -- Дальше всё идемпотентно: пароль и гранты переустанавливаются всегда.
+    -- :'agent_ro_password' и :"db_name" — psql-переменные, передаются через -v.
+    -- :'...' квотит как SQL-литерал, :"..." как идентификатор — защита от инъекции.
+    ALTER ROLE agent_ro WITH LOGIN PASSWORD :'agent_ro_password';
+    GRANT CONNECT ON DATABASE :"db_name" TO agent_ro;
+    GRANT USAGE ON SCHEMA public TO agent_ro;
+    GRANT SELECT ON ALL TABLES IN SCHEMA public TO agent_ro;
+    GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO agent_ro;
+
+    -- ВАЖНО: новые таблицы, которые EF создаст после bootstrap'а, по умолчанию
+    -- не будут видны agent_ro. ALTER DEFAULT PRIVILEGES чинит это для будущих
+    -- объектов, созданных текущим юзером (admin Postgres'а).
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO agent_ro;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON SEQUENCES TO agent_ro;
+
+    -- Hard-stop на запись на уровне сессии: даже если кто-то даст agent_ro INSERT
+    -- по ошибке, любой запрос на запись упадёт с read-only transaction error.
+    ALTER ROLE agent_ro SET default_transaction_read_only = on;
+
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-bootstrap
+spec:
+  # Job сам подметётся через час после Completed — не засоряем кластер.
+  ttlSecondsAfterFinished: 3600
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: psql
+          image: postgres:16-alpine
+          env:
+            # Подключение под админом БД — теми же кредами, что и сам StatefulSet.
+            # Резолвится через DNS headless-сервиса `postgres` в том же namespace.
+            - name: PGHOST
+              value: postgres
+            - name: PGUSER
+              value: $POSTGRES_USER
+            - name: PGPASSWORD
+              value: $POSTGRES_PASSWORD
+            - name: PGDATABASE
+              value: $POSTGRES_DB
+            - name: AGENT_RO_PASSWORD
+              value: $AGENT_RO_PASSWORD
+          command:
+            - psql
+            - -v
+            - ON_ERROR_STOP=1
+            - -v
+            - agent_ro_password=$(AGENT_RO_PASSWORD)
+            - -v
+            - db_name=$(PGDATABASE)
+            - -f
+            - /sql/bootstrap.sql
+          volumeMounts:
+            - name: sql
+              mountPath: /sql
+      volumes:
+        - name: sql
+          configMap:
+            name: db-bootstrap-sql


### PR DESCRIPTION
## Summary

Добавляет автоматическое создание read-only роли `agent_ro` в Postgres и RBAC, который даёт ServiceAccount `agent-readonly` право `kubectl port-forward` ровно до пода `postgres-0` — и ничего больше.

Зачем: чтобы локальная машина с Claude Code агентами могла тыкаться в продовую БД на чтение через port-forward + psql, без риска что-либо записать или дотянуться до других подов кластера.

Два уровня защиты:
1. RBAC ограничивает что вообще можно потрогать в кластере (через kubeconfig от SA `agent-readonly`).
2. `agent_ro` в БД — read-only по `default_transaction_read_only=on` + только `SELECT`-гранты, плюс `ALTER DEFAULT PRIVILEGES` для будущих таблиц.

## Что меняется

- `deploy/postgres-bootstrap.yml` — новый. ConfigMap с идемпотентным SQL + Job на `postgres:16-alpine`, который применяет SQL. Пароль `agent_ro` берётся из нового GH Secret `AGENT_RO_PASSWORD` через envsubst.
- `deploy/agent-rbac.yml` — новый. SA + Role (`pods/portforward` create, ограничено `resourceNames: ["postgres-0"]`) + RoleBinding.
- `.github/workflows/kubernetes_deploy_db.yml` — обновлён. Последовательность: postgres apply → wait ready → delete old bootstrap Job → apply bootstrap → wait complete → apply RBAC.

## SQL внутри Job'а — что делает

Только `CREATE ROLE IF NOT EXISTS` + `ALTER ROLE PASSWORD` + `GRANT SELECT` + `ALTER DEFAULT PRIVILEGES`. Ни одной деструктивной операции (`DROP`/`DELETE`/`TRUNCATE`/`REVOKE`) — данные в БД в безопасности при любом сценарии запуска.

## Перед мержем

Положить новый GH Secret `AGENT_RO_PASSWORD`. Команда для генерации:

```
openssl rand -base64 32 | tr -d '\n' | pbcopy
```

После мержа — дёрнуть workflow `Deploy Database to Kubernetes` через workflow_dispatch.

## Test plan

- [ ] `AGENT_RO_PASSWORD` добавлен в GH Secrets, проверена длина (44 символа для base64, без `\n` в конце)
- [ ] Workflow прогнан в проде, Job `db-bootstrap` завершился со статусом Completed
- [ ] `kubectl logs job/db-bootstrap -n tralebot-prod` — нет ошибок, SQL отработал
- [ ] `kubectl get role,rolebinding,serviceaccount -n tralebot-prod | grep agent` — RBAC создан
- [ ] Локально с kubeconfig'ом от SA `agent-readonly`: `kubectl port-forward pod/postgres-0 5432:5432` + `psql -h localhost -U agent_ro -d <db> -c "SELECT 1"` — отвечает
- [ ] Тот же agent_ro пробует INSERT — падает с `read-only transaction`

🤖 Generated with [Claude Code](https://claude.com/claude-code)