### PR TITLE
Add db-readonly skill: agents can query prod Postgres in read-only mode

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(.claude/skills/db-readonly/query.sh:*)",
+      "Bash(kubectl port-forward pod/postgres-0:*)",
+      "Bash(psql -h localhost:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.claude/skills/db-readonly/SKILL.md
+++ b/.claude/skills/db-readonly/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: db-readonly
+description: Read-only access to TraleBot prod Postgres via kubectl port-forward + psql under the agent_ro role. Use this when you need to look up real production data (user counts, achievements, quiz stats, retention etc.) for analytics or debugging. SELECTs only — INSERT/UPDATE/DELETE will fail with a read-only transaction error by design.
+---
+
+# db-readonly
+
+Read-only канал в продовую Postgres TraleBot для Claude Code агентов.
+
+## Когда использовать
+
+- Аналитика: «сколько у нас юзеров», «какие квизы популярны», retention, конверсии, и т.п.
+- Дебаг прода: посмотреть состояние конкретной записи (юзер, ачивка, payment).
+- Любой read-only запрос про реальные данные, который нельзя достоверно ответить из кода или тестов.
+
+НЕ использовать для миграций, обновлений, тестовых вставок — даже если очень хочется. Канал технически блокирует запись.
+
+## Как использовать (после one-time setup, см. ниже)
+
+```bash
+.claude/skills/db-readonly/query.sh 'SELECT count(*) FROM "Users"'
+```
+
+Скрипт сам:
+1. Поднимает `kubectl port-forward pod/postgres-0 5433:5432 -n tralebot-prod` под service-account'ом `agent-readonly` (RBAC разрешает port-forward ТОЛЬКО до postgres-0, больше никуда).
+2. Ждёт пока порт начнёт слушать.
+3. Запускает `psql -h localhost -p 5433 -U agent_ro -d tralebot_db -c "<твой SQL>"` — пароль подхватывается из `~/.pgpass` автоматически.
+4. Убивает port-forward в trap'е (любой выход — нормальный или с ошибкой — закрывает туннель).
+
+Многострочные запросы — заключай в одинарные кавычки. Внутри SQL — двойные кавычки для имён таблиц/колонок в PascalCase (например `"Users"`), потому что они так созданы EF Core'ом и без кавычек Postgres приведёт их к нижнему регистру.
+
+Пример:
+
+```bash
+.claude/skills/db-readonly/query.sh 'SELECT "TelegramId", "Username", "CreatedAt" FROM "Users" ORDER BY "CreatedAt" DESC LIMIT 10'
+```
+
+## Что нельзя
+
+- **Write-операции** (`INSERT`/`UPDATE`/`DELETE`/`TRUNCATE`) — падают с `cannot execute ... in a read-only transaction`. Это by design: роль `agent_ro` имеет `default_transaction_read_only = on`.
+- **Port-forward к другим подам кластера** — RBAC запрещает (`resourceNames: ["postgres-0"]` в Role).
+- **Использовать admin kubeconfig** для этих запросов — он даёт cluster-admin, что и не нужно, и опасно если случайно попадёт в логи/память агента.
+
+## One-time setup на новой машине
+
+Если ты на свежем компе и хочешь чтобы скилл заработал:
+
+### 1. Установить psql клиент
+
+```bash
+brew install libpq
+echo 'export PATH="/usr/local/opt/libpq/bin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
+psql --version  # должна показать 18+
+```
+
+### 2. Получить kubeconfig под agent-readonly
+
+Нужен админский доступ к microk8s кластеру TraleBot (см. в PrivateNotes «Как настроен деплой для тралебота» — там лежит admin kubeconfig). С ним:
+
+```bash
+# Извлекаем токен и CA из Secret который workflow создал
+SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[].cluster.server}')
+CA_B64=$(kubectl get secret agent-readonly-token -n tralebot-prod -o jsonpath='{.data.ca\.crt}')
+TOKEN=$(kubectl get secret agent-readonly-token -n tralebot-prod -o jsonpath='{.data.token}' | base64 -d)
+
+mkdir -p ~/.kube
+cat > ~/.kube/tralebot-readonly.conf <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+  - name: microk8s
+    cluster:
+      server: ${SERVER}
+      certificate-authority-data: ${CA_B64}
+contexts:
+  - name: agent-readonly@microk8s
+    context:
+      cluster: microk8s
+      user: agent-readonly
+      namespace: tralebot-prod
+current-context: agent-readonly@microk8s
+users:
+  - name: agent-readonly
+    user:
+      token: ${TOKEN}
+EOF
+chmod 600 ~/.kube/tralebot-readonly.conf
+```
+
+Если Secret `agent-readonly-token` ещё не создан — workflow `Deploy Database to Kubernetes` должен был его создать. Если нет — см. `deploy/agent-rbac.yml` и `deploy/postgres-bootstrap.yml`.
+
+### 3. Положить пароль в ~/.pgpass
+
+Пароль `agent_ro` хранится в твоём 1Password как `TraleBot · agent_ro · prod` (или похоже — см. свою заметку «Как сгенерить пароль для read-only юзера agent_ro» в PrivateNotes).
+
+```bash
+echo "localhost:5433:tralebot_db:agent_ro:<ПАРОЛЬ_ИЗ_1PASSWORD>" > ~/.pgpass
+chmod 600 ~/.pgpass
+```
+
+### 4. Проверить что всё работает
+
+```bash
+.claude/skills/db-readonly/query.sh 'SELECT current_user, current_database()'
+```
+
+Должно показать `agent_ro | tralebot_db`. Если показало — всё на месте, скилл готов.
+
+## Дебаг
+
+- `cat /tmp/tralebot-pgpf.log` — последний лог port-forward, если что-то не поднимается
+- `KUBECONFIG=~/.kube/tralebot-readonly.conf kubectl auth whoami` — kubeconfig жив?
+- `psql --version` — psql в PATH?
+- `ls -la ~/.pgpass` — права должны быть `-rw-------` (600), иначе psql его проигнорирует
+- `kubectl get secret agent-readonly-token -n tralebot-prod` — Secret в кластере существует?
+
+## Кастомизация
+
+Переменные окружения для переопределения дефолтов (если тебе нужно подключиться к другому кластеру/окружению):
+
+- `TRALEBOT_KUBECONFIG` — путь к kubeconfig (default `~/.kube/tralebot-readonly.conf`)
+- `TRALEBOT_NAMESPACE` — namespace в кластере (default `tralebot-prod`)
+- `TRALEBOT_POD` — имя пода (default `postgres-0`)
+- `TRALEBOT_DB` — имя БД (default `tralebot_db`)
+- `TRALEBOT_DB_USER` — имя юзера для psql (default `agent_ro`)
+- `TRALEBOT_LOCAL_PORT` — на каком локальном порту слушать port-forward (default `5433`)

--- a/.claude/skills/db-readonly/query.sh
+++ b/.claude/skills/db-readonly/query.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Read-only SELECT to TraleBot prod Postgres via port-forward + psql.
+# Usage:
+#   ./query.sh 'SELECT count(*) FROM "Users"'
+#
+# See .claude/skills/db-readonly/SKILL.md for full setup instructions
+# (kubeconfig, .pgpass, psql).
+
+set -euo pipefail
+
+if [ $# -lt 1 ] || [ -z "${1:-}" ]; then
+  echo "Usage: $0 \"<SQL>\"" >&2
+  echo "Example: $0 'SELECT count(*) FROM \"Users\"'" >&2
+  exit 64
+fi
+SQL="$1"
+
+# Overridable defaults (see SKILL.md → Кастомизация).
+KUBECONFIG_FILE="${TRALEBOT_KUBECONFIG:-$HOME/.kube/tralebot-readonly.conf}"
+NS="${TRALEBOT_NAMESPACE:-tralebot-prod}"
+POD="${TRALEBOT_POD:-postgres-0}"
+DB="${TRALEBOT_DB:-tralebot_db}"
+DB_USER="${TRALEBOT_DB_USER:-agent_ro}"
+LOCAL_PORT="${TRALEBOT_LOCAL_PORT:-5433}"
+LOG="/tmp/tralebot-pgpf.log"
+
+if [ ! -f "$KUBECONFIG_FILE" ]; then
+  echo "ERROR: kubeconfig not found: $KUBECONFIG_FILE" >&2
+  echo "See .claude/skills/db-readonly/SKILL.md → One-time setup → step 2." >&2
+  exit 1
+fi
+
+# psql ставится через `brew install libpq` и не попадает в PATH без линковки.
+# Добавляем стандартный путь явно — если уже в PATH, ничего не сломается.
+export PATH="/usr/local/opt/libpq/bin:$PATH"
+if ! command -v psql >/dev/null 2>&1; then
+  echo "ERROR: psql not in PATH. Run: brew install libpq" >&2
+  echo "Then add to PATH: echo 'export PATH=\"/usr/local/opt/libpq/bin:\$PATH\"' >> ~/.zshrc" >&2
+  exit 1
+fi
+
+KUBECONFIG="$KUBECONFIG_FILE" \
+  kubectl port-forward "pod/${POD}" "${LOCAL_PORT}:5432" -n "$NS" \
+  >"$LOG" 2>&1 &
+PF_PID=$!
+
+# Любой выход (нормальный, ошибка, Ctrl+C) гасит port-forward.
+cleanup() {
+  kill "$PF_PID" 2>/dev/null || true
+  wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Ждём пока порт начнёт принимать соединения. Максимум ~6 секунд.
+for _ in $(seq 1 20); do
+  nc -z localhost "$LOCAL_PORT" 2>/dev/null && break
+  sleep 0.3
+done
+
+if ! nc -z localhost "$LOCAL_PORT" 2>/dev/null; then
+  echo "ERROR: port-forward не поднялся за 6с. Лог:" >&2
+  cat "$LOG" >&2
+  exit 2
+fi
+
+# Пароль psql берёт из ~/.pgpass — никаких env-переменных в команде.
+psql -h localhost -p "$LOCAL_PORT" -U "$DB_USER" -d "$DB" -c "$SQL"


### PR DESCRIPTION
## Summary

Финальный кусок read-only пайплайна: skill, который любой Claude Code агент в этом репе может использовать чтобы дёрнуть продовую БД на чтение. Дополняет инфру из PR #933 (agent_ro роль + RBAC + Job).

## Что меняется

- **`.claude/skills/db-readonly/SKILL.md`** — описание скилла для агентов: когда использовать, как использовать, что нельзя, и **полный one-time setup чеклист** для свежей машины (установить psql, собрать kubeconfig, положить пароль в `~/.pgpass`). Это важно: при смене компа всё восстанавливается по инструкции из репы.
- **`.claude/skills/db-readonly/query.sh`** — bash-обёртка: поднимает `kubectl port-forward` в background, ждёт пока порт начнёт слушать, выполняет psql-запрос, в trap'е гасит туннель. Все пути env-overridable (`TRALEBOT_KUBECONFIG`, `TRALEBOT_NAMESPACE`, etc.) — портативно.
- **`.claude/settings.json`** — team-wide allow-list (`Bash(.claude/skills/db-readonly/query.sh:*)`, `Bash(kubectl port-forward pod/postgres-0:*)`, `Bash(psql -h localhost:*)`), чтобы агенты не дёргали оунера на каждое выполнение. Кладу в `settings.json`, а не в `settings.local.json`, чтобы тоже работало после смены компа.

## Где живут секреты

**Намеренно вне репы** (по дефолтным путям, восстанавливаются по чеклисту в SKILL.md):
- `~/.kube/tralebot-readonly.conf` — kubeconfig для SA `agent-readonly`
- `~/.pgpass` — пароль `agent_ro`

Сам пароль продолжает жить в 1Password как единый источник правды.

## Test plan

- [x] `query.sh 'SELECT current_user, current_database()'` → возвращает `agent_ro | tralebot_db` (проверено локально)
- [x] `query.sh 'INSERT INTO "Users" DEFAULT VALUES'` → падает с `cannot execute INSERT in a read-only transaction` (проверено локально)
- [x] port-forward убивается trap'ом при любом выходе скрипта (проверено — после завершения нет висящего process'а)
- [ ] При смене компа: пройти one-time setup из SKILL.md → `query.sh` сразу работает без правки кода

🤖 Generated with [Claude Code](https://claude.com/claude-code)