### PR TITLE
db-readonly: auto-pick free local port + robust readiness check

### DIFF
--- a/.claude/skills/db-readonly/SKILL.md
+++ b/.claude/skills/db-readonly/SKILL.md
@@ -22,10 +22,11 @@ Read-only канал в продовую Postgres TraleBot для Claude Code а
 ```
 
 Скрипт сам:
-1. Поднимает `kubectl port-forward pod/postgres-0 5433:5432 -n tralebot-prod` под service-account'ом `agent-readonly` (RBAC разрешает port-forward ТОЛЬКО до postgres-0, больше никуда).
-2. Ждёт пока порт начнёт слушать.
-3. Запускает `psql -h localhost -p 5433 -U agent_ro -d tralebot_db -c "<твой SQL>"` — пароль подхватывается из `~/.pgpass` автоматически.
-4. Убивает port-forward в trap'е (любой выход — нормальный или с ошибкой — закрывает туннель).
+1. Находит свободный локальный порт начиная с 5433 (если 5433 занят — например локальным docker-postgres другого проекта — берёт 5434, 5435, …). Это важно: на занятый порт kubectl не забиндится, а psql молча ушёл бы в ЧУЖУЮ базу и упал с `password authentication failed for user agent_ro`.
+2. Поднимает `kubectl port-forward pod/postgres-0 <порт>:5432 -n tralebot-prod` под service-account'ом `agent-readonly` (RBAC разрешает port-forward ТОЛЬКО до postgres-0, больше никуда).
+3. Ждёт строку `Forwarding from …` в логе kubectl — то есть готовности ИМЕННО нашего туннеля (проверка по `nc` ненадёжна: посторонний слушатель на том же порту обманул бы её).
+4. Запускает `psql -h localhost -p <порт> -U agent_ro -d tralebot_db -c "<твой SQL>"` — пароль подхватывается из `~/.pgpass` автоматически.
+5. Убивает port-forward в trap'е (любой выход — нормальный или с ошибкой — закрывает туннель).
 
 Многострочные запросы — заключай в одинарные кавычки. Внутри SQL — двойные кавычки для имён таблиц/колонок в PascalCase (например `"Users"`), потому что они так созданы EF Core'ом и без кавычек Postgres приведёт их к нижнему регистру.
 
@@ -94,8 +95,10 @@ chmod 600 ~/.kube/tralebot-readonly.conf
 
 Пароль `agent_ro` хранится в твоём 1Password как `TraleBot · agent_ro · prod` (или похоже — см. свою заметку «Как сгенерить пароль для read-only юзера agent_ro» в PrivateNotes).
 
+Порт в записи — `*` (а не конкретный 5433), потому что скрипт может выбрать другой свободный порт, и пароль должен подхватываться независимо от него:
+
 ```bash
-echo "localhost:5433:tralebot_db:agent_ro:<ПАРОЛЬ_ИЗ_1PASSWORD>" > ~/.pgpass
+echo "localhost:*:tralebot_db:agent_ro:<ПАРОЛЬ_ИЗ_1PASSWORD>" > ~/.pgpass
 chmod 600 ~/.pgpass
 ```
 
@@ -124,4 +127,4 @@ chmod 600 ~/.pgpass
 - `TRALEBOT_POD` — имя пода (default `postgres-0`)
 - `TRALEBOT_DB` — имя БД (default `tralebot_db`)
 - `TRALEBOT_DB_USER` — имя юзера для psql (default `agent_ro`)
-- `TRALEBOT_LOCAL_PORT` — на каком локальном порту слушать port-forward (default `5433`)
+- `TRALEBOT_LOCAL_PORT` — стартовый локальный порт для port-forward (default `5433`); если занят, скрипт сам инкрементит до первого свободного

--- a/.claude/skills/db-readonly/query.sh
+++ b/.claude/skills/db-readonly/query.sh
@@ -21,6 +21,8 @@ NS="${TRALEBOT_NAMESPACE:-tralebot-prod}"
 POD="${TRALEBOT_POD:-postgres-0}"
 DB="${TRALEBOT_DB:-tralebot_db}"
 DB_USER="${TRALEBOT_DB_USER:-agent_ro}"
+# Стартовый порт. Если занят (например локальный docker-postgres другого
+# проекта), скрипт сам найдёт свободный — see free-port loop ниже.
 LOCAL_PORT="${TRALEBOT_LOCAL_PORT:-5433}"
 LOG="/tmp/tralebot-pgpf.log"
 
@@ -39,6 +41,23 @@ if ! command -v psql >/dev/null 2>&1; then
   exit 1
 fi
 
+# Ищем свободный локальный порт начиная с LOCAL_PORT. КРИТИЧНО: если порт уже
+# кем-то слушается (частый кейс — docker-postgres другого проекта на 5433),
+# kubectl не сможет на него забиндиться, а psql молча уйдёт в ЧУЖУЮ базу. Раньше
+# это давало загадочный "password authentication failed for user agent_ro".
+# Поэтому форвардим только на заведомо свободный порт.
+for _ in $(seq 0 20); do
+  nc -z localhost "$LOCAL_PORT" 2>/dev/null || break
+  LOCAL_PORT=$((LOCAL_PORT + 1))
+done
+if nc -z localhost "$LOCAL_PORT" 2>/dev/null; then
+  echo "ERROR: не нашёл свободный локальный порт в диапазоне." >&2
+  exit 2
+fi
+if [ "$LOCAL_PORT" != "${TRALEBOT_LOCAL_PORT:-5433}" ]; then
+  echo "note: порт $((LOCAL_PORT)) (дефолтный занят), форвардим на него." >&2
+fi
+
 KUBECONFIG="$KUBECONFIG_FILE" \
   kubectl port-forward "pod/${POD}" "${LOCAL_PORT}:5432" -n "$NS" \
   >"$LOG" 2>&1 &
@@ -51,14 +70,18 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-# Ждём пока порт начнёт принимать соединения. Максимум ~6 секунд.
+# Ждём готовности ИМЕННО нашего туннеля: kubectl пишет "Forwarding from
+# 127.0.0.1:PORT" когда забиндился. Проверять по nc недостаточно — посторонний
+# слушатель на том же порту обманул бы проверку (и psql ушёл бы не туда).
 for _ in $(seq 1 20); do
-  nc -z localhost "$LOCAL_PORT" 2>/dev/null && break
+  grep -q "Forwarding from .*:${LOCAL_PORT} " "$LOG" 2>/dev/null && break
+  # Если kubectl уже упал (например порт перехватили в гонке) — не ждём зря.
+  kill -0 "$PF_PID" 2>/dev/null || break
   sleep 0.3
 done
 
-if ! nc -z localhost "$LOCAL_PORT" 2>/dev/null; then
-  echo "ERROR: port-forward не поднялся за 6с. Лог:" >&2
+if ! grep -q "Forwarding from .*:${LOCAL_PORT} " "$LOG" 2>/dev/null; then
+  echo "ERROR: port-forward не поднялся за ~6с. Лог:" >&2
   cat "$LOG" >&2
   exit 2
 fi


### PR DESCRIPTION
## Проблема

Скилл `db-readonly` хардкодил локальный порт 5433 для `kubectl port-forward`. Если 5433 уже занят (типичный кейс — локальный docker-postgres другого проекта, напр. `ekmekbot-db-1`), то:

- kubectl не мог забиндиться на занятый порт;
- проверка готовности по `nc -z localhost 5433` всё равно проходила (порт-то слушается — но это ЧУЖОЙ процесс);
- psql молча коннектился к посторонней базе и падал с загадочным `password authentication failed for user agent_ro`.

То есть в худшем случае запрос мог уйти не в ту БД.

## Что меняет

- **Авто-выбор свободного порта**: начиная с 5433 ищем первый свободный (5434, 5435, …). На занятый порт больше не форвардим.
- **Надёжная проверка готовности**: ждём строку `Forwarding from …` в логе kubectl (готовность именно нашего туннеля), а не `nc` — посторонний слушатель больше не обманет. Плюс ранний выход, если kubectl упал.
- **`.pgpass` порт → `*`**: пароль `agent_ro` подхватывается при любом выбранном порту (в SKILL.md обновлён сетап).

Секретов в дифе нет — только плейсхолдеры.

## Проверка

- `query.sh 'SELECT current_user, current_database()'` → `agent_ro | tralebot_db` (при занятом 5433 перепрыгнул на 5434).
- `UPDATE …` → `cannot execute UPDATE in a read-only transaction` (read-only гарантия цела).

🤖 Generated with [Claude Code](https://claude.com/claude-code)