### PR TITLE
fix(agents): make epic-kickoff dispatch actually run

### DIFF
--- a/deploy/agents/scripts/dispatch-by-epic.sh
+++ b/deploy/agents/scripts/dispatch-by-epic.sh
@@ -49,6 +49,14 @@ echo "  Branch: ${BRANCH}"
 echo "  Started: $(date)"
 echo "============================================"
 
+# gh resolves the target GitHub repo from the git remote of the current
+# directory, so we must be inside the repo before any gh call below (the
+# branch is still created later, after the idempotency checks).
+cd "$REPO_DIR" || {
+    echo "Repo dir not found: ${REPO_DIR}"
+    exit 1
+}
+
 # 1. Fetch epic.
 EPIC_JSON=$(gh issue view "$EPIC_NUM" --json title,body,labels 2>&1) || {
     echo "Failed to fetch epic #${EPIC_NUM}: $EPIC_JSON"
@@ -123,6 +131,7 @@ EOF
         --dangerously-skip-permissions \
         --max-turns "${MAX_TURNS_PER_AGENT:-20}" \
         --output-format stream-json \
+        --verbose \
         || echo "[warn] ${agent} exited non-zero (continuing to next agent)"
 }
 


### PR DESCRIPTION
Triggering an epic kickoff from the Dev Tycoon UI (drag epic → Doing) silently failed: `dispatch-by-epic.sh` bailed before any agent did real work.

## Two bugs
1. **`gh` called before `cd` into the repo** — `gh` resolves the target GitHub repo from the git remote of the current directory. The first `gh issue view` ran from a non-repo cwd → `fatal: not a git repository`, immediate exit.
2. **`claude --output-format stream-json` now requires `--verbose`** (CLI update). Without it every agent exited non-zero instantly: `When using --print, --output-format=stream-json requires --verbose`.

## Fix
- `cd "$REPO_DIR"` before the first `gh` call (branch creation still happens later, after the idempotency checks).
- Add `--verbose` to the `claude` invocation.

Verified end-to-end on epic #945: all four agents (product → designer → methodist → tech-lead) now run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)