### PR TITLE
agents: prevent parallel pipeline runs and double-claimed tasks

### DIFF
--- a/deploy/agents/scripts/pick-next-task.sh
+++ b/deploy/agents/scripts/pick-next-task.sh
@@ -23,9 +23,13 @@ set -euo pipefail
 #      `epic-<EPIC>:`. Sorted ascending by issue number — backend (lower
 #      number, created first by breakdown) comes before frontend, then
 #      content, then tests. This is the convention breakdown emits.
-#   4. A task is eligible when it has label `qa-prepared` AND lacks both
-#      `done` (already shipped tonight) and `dev-stuck` (a previous dev
-#      iteration hit max-turns; needs human triage, skip).
+#   4. A task is eligible when it has label `qa-prepared` AND lacks all of
+#      `done` (already shipped tonight), `dev-stuck` (a previous dev iteration
+#      hit max-turns; needs human triage, skip), and `agent:running` (another
+#      agent has already claimed it — don't double-build the same task). The
+#      dev loop sets `agent:running` while working and clears it on return; a
+#      claim left stale by a killed run needs the label removed by hand, same
+#      as `dev-stuck`.
 #   5. The script returns the first eligible task across all epics in
 #      order. If nothing matches → exit empty.
 
@@ -56,6 +60,7 @@ for EPIC in ${EPICS}; do
         | select((.labels // []) | map(.name) | contains(["qa-prepared"]))
         | select((.labels // []) | map(.name) | contains(["done"]) | not)
         | select((.labels // []) | map(.name) | contains(["dev-stuck"]) | not)
+        | select((.labels // []) | map(.name) | contains(["agent:running"]) | not)
         | "\(.number)\t\(.title)"
     ' 2>/dev/null | head -1)
     if [ -n "${PICK}" ]; then

--- a/deploy/agents/scripts/run-pipeline.sh
+++ b/deploy/agents/scripts/run-pipeline.sh
@@ -47,6 +47,21 @@ set -e
 [ -f /etc/environment ] && source /etc/environment
 
 MODE="${1:-auto}"
+
+# Single-instance guard. Two run-pipeline.sh invocations must never run at the
+# same time: in build mode they race on the shared nightly branch and can pick
+# the same task twice; in auto/plan mode the planning phases duplicate epics.
+# This happened in the wild when a cron tick and a manual "run now" overlapped.
+# Take an exclusive, non-blocking flock on a fixed file held for this process's
+# whole lifetime — a second invocation finds the lock taken and exits cleanly
+# instead of stacking. PIPELINE_NO_LOCK=1 escapes the guard for smoke tests.
+if [ "${PIPELINE_NO_LOCK:-0}" != "1" ]; then
+    exec 200>/tmp/run-pipeline.lock
+    if ! flock -n 200; then
+        echo ">>> run-pipeline.sh ($MODE) skipped: another run is already active ($(date))."
+        exit 0
+    fi
+fi
 TODAY=$(date '+%Y-%m-%d')
 HOUR_STAMP=$(date '+%Y-%m-%d_%H-%M')
 BRANCH="${BRANCH_OVERRIDE:-agents/nightly-${TODAY}}"


### PR DESCRIPTION
Two concurrent `run-pipeline.sh` invocations (a cron tick overlapping a manual "run now") were observed planning at the same time — duplicating epic-drafts and able to pick the same task twice.

## Guards
1. **Single-instance flock** at the top of `run-pipeline.sh`: an exclusive non-blocking lock held for the process lifetime; a second invocation finds it held and exits cleanly instead of stacking. `PIPELINE_NO_LOCK=1` escapes it for smoke tests.
2. **Task claim** in `pick-next-task.sh`: skip any task labelled `agent:running`, so a task already claimed by a developer agent is never handed to a second one. The dev loop sets the label while working and clears it on return (a claim left stale by a killed run is cleared by hand, same as `dev-stuck`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)