### PR TITLE
agents: disable background cron (run on-demand only)

### DIFF
--- a/deploy/agents/crontab
+++ b/deploy/agents/crontab
@@ -12,19 +12,21 @@
 # В 18:00 — открытие/обновление ежедневного PR.
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# Дневные прогоны — каждый час с 11:00 до 17:00 в auto-режиме.
-# Один прогон = один час = одна фаза или один кусок dev-loop'а.
-# Время выбрано чтобы пайплайн крутился, пока владелец бодрствует и
-# может смерджить PR в main без гонки с cron'ом — у предыдущей ночной
-# схемы регулярно случался кейс «owner мерджит pre-PR в main в 02:30,
-# а cron уже стартанул в 02:00 на старом main → нечего работать».
-0 11 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-0 12 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-0 13 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-0 14 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-0 15 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-0 16 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-0 17 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
-
-# Вечерний QA — собирает результаты дня и открывает PR
-0 18 * * * su -s /bin/bash agent -c '/scripts/run-qa.sh >> /logs/agents.log 2>&1'
+# ФОНОВЫЙ КРОН ОТКЛЮЧЁН (2026-05-31, по решению владельца).
+# Раньше пайплайн запускался каждый час 11:00–17:00 в auto-режиме + run-qa в
+# 18:00. Это жгло токены в фоне на планирование/рефактор, даже когда работы по
+# тискам не было. Теперь агенты запускаются ТОЛЬКО по требованию — кнопкой
+# «Запустить сейчас» в Dev Tycoon (она делает docker exec run-pipeline.sh build)
+# или вручную. Никаких автоматических прогонов.
+#
+# Чтобы вернуть расписание — раскомментируй нужные строки ниже и пересобери
+# образ (docker compose build).
+#
+# 0 11 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+# 0 12 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+# 0 13 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+# 0 14 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+# 0 15 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+# 0 16 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+# 0 17 * * * su -s /bin/bash agent -c '/scripts/run-pipeline.sh auto >> /logs/agents.log 2>&1'
+# 0 18 * * * su -s /bin/bash agent -c '/scripts/run-qa.sh >> /logs/agents.log 2>&1'


### PR DESCRIPTION
The hourly `auto` runs (11:00–17:00) and the 18:00 `run-qa` kept spending tokens in the background on planning/refactor phases even when there was no task work to do — and none of it showed up as task movement on the Dev Tycoon board.

Comment out **every** cron entry. Agents now run **only on demand**: the "Запустить сейчас" button (which `docker exec`s `run-pipeline.sh build`) or a manual exec. The container can stay stopped and is brought up by the button when needed.

Re-enable by uncommenting the lines and `docker compose build`.

⚠️ This also disables the 18:00 auto-PR (`run-qa.sh`) — open/refresh the daily PR manually when wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)