### PR TITLE
agents: move task card to Разработка while building (stage:dev)

### DIFF
--- a/deploy/agents/scripts/run-pipeline.sh
+++ b/deploy/agents/scripts/run-pipeline.sh
@@ -804,12 +804,18 @@ phase_dev() {
     echo ">>> [dev] picker selected #${pick_num}: ${pick_title}"
     local phase_id="dev-${pick_num}"
 
-    # Mark the task live so the Dev Tycoon board can highlight it while the
-    # developer agent works (the board reads the agent:running label, same as
-    # the epic-kickoff path). Cleared right after the agent returns, below.
+    # Move the card into the "Разработка" (dev) column and mark it live so the
+    # Dev Tycoon board reflects what's happening. The board derives a task's
+    # column from its `stage:<x>` label; without this the card sits in spec/qa
+    # and only jumps to "Готово" at the end, never travelling through dev.
+    # `agent:running` is the live highlight (cleared after the agent returns).
+    gh label create "stage:dev" --color 1d76db \
+        --description "Task is in development" 2>/dev/null || true
     gh label create agent:running --color fbca04 \
         --description "An agent is actively working on this issue right now" 2>/dev/null || true
-    gh issue edit "${pick_num}" --add-label "agent:running" 2>/dev/null || true
+    gh issue edit "${pick_num}" \
+        --add-label "stage:dev" --add-label "agent:running" \
+        --remove-label "stage:spec" --remove-label "stage:qa" 2>/dev/null || true
 
     local instruction
     instruction="$(context_prefix)Read .claude/agents/developer.md AND ARCHITECTURE.md.


### PR DESCRIPTION
Tasks being built didn't visibly move into the **Разработка** column. The board (`detectDevStage`) derives a task's column from its `stage:<x>` label; the dev loop set `agent:running` and eventually `done` but never `stage:dev`, so a task sat in spec/qa and jumped straight to Готово.

`phase_dev` now adds `stage:dev` (and removes `stage:spec`/`stage:qa`) when it picks a task, so the card travels to Разработка for the duration of the build. The `done` label still takes priority for Готово at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)