### PR TITLE
tests: auto-remove Postgres testcontainer (fix leak)

### DIFF
--- a/tests/IntegrationTests/TestBase.cs
+++ b/tests/IntegrationTests/TestBase.cs
@@ -18,9 +18,16 @@ public class TestBase
     [OneTimeSetUp]
     public async Task OneTimeSetUp()
     {
-        // Start PostgreSQL container
+        // Start PostgreSQL container.
+        // WithAutoRemove instead of WithCleanUp: the agent runner mounts the
+        // host Docker socket and spawns Postgres as a sibling container, where
+        // Ryuk (what WithCleanUp relies on) doesn't run reliably — stopped
+        // Postgres containers piled up indefinitely. AutoRemove sets Docker's
+        // `--rm` flag so the daemon deletes the container the moment it stops,
+        // regardless of Ryuk or whether DisposeAsync runs (e.g. if the test
+        // process is killed mid-run). The two options are mutually exclusive.
         _postgresqlContainer = new PostgreSqlBuilder()
-            .WithCleanUp(true)
+            .WithAutoRemove(true)
             .WithImage("postgres:16.1")
             .Build();
 


### PR DESCRIPTION
Integration tests leaked stopped `postgres:16.1` containers — 30+ exited ones had piled up on the host.

**Cause:** `TestBase` used `WithCleanUp(true)`, which relies on **Ryuk**. The agent runner mounts the host Docker socket and runs Postgres as a *sibling* container, a setup where Ryuk doesn't run (no ryuk container ever started). When `DisposeAsync` didn't run (killed test process, daemon restart), nothing removed the containers.

**Fix:** `WithAutoRemove(true)` sets Docker's `--rm` flag, so the **daemon** deletes the container the moment it stops — independent of Ryuk or teardown.

Verified locally: `IdempotencyServiceTests` passes (6/6) and the postgres container is auto-removed within seconds; 0 leaked after the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)