### PR TITLE
Доделка эпика #940 · 2026-06-15

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -220,6 +220,7 @@ Location: `src/Trale/HostedServices/`.
 | `CreateWebhook` | `StartAsync` | Register webhook, set chat menu button to mini-app, publish bot command list. |
 | `PendingReferralsWorker` | Every 60s | Activate referrals once the referee crosses the engagement threshold. |
 | `IdempotencyCleanupService` | Every 6h | Purge expired `ProcessedUpdate` rows. |
+| `ReturnPushWorker` | Daily at 10:00 UTC | Dispatch D1+ return push to users who started a lesson but didn't return (#940). |
 
 ---
 

--- a/src/Application/Common/Interfaces/IDailyReturnNotificationService.cs
+++ b/src/Application/Common/Interfaces/IDailyReturnNotificationService.cs
@@ -1,0 +1,11 @@
+namespace Application.Common.Interfaces;
+
+/// <summary>
+/// Dispatches the daily return push to all eligible users (started a lesson, did not return).
+/// Implementation in #951; the <see cref="Trale.HostedServices.ReturnPushWorker"/> in src/Trale
+/// calls this once a day at 10:00 UTC.
+/// </summary>
+public interface IDailyReturnNotificationService
+{
+    Task DispatchAsync(CancellationToken ct);
+}

--- a/src/Application/Common/Interfaces/IUserNotificationService.cs
+++ b/src/Application/Common/Interfaces/IUserNotificationService.cs
@@ -5,4 +5,19 @@ namespace Application.Common.Interfaces;
 public interface IUserNotificationService
 {
     Task NotifyAboutUnlockedAchievementAsync(Achievement achievement, CancellationToken ct);
+
+    /// <summary>
+    /// Send the D1+ retention push to the given user. The button opens the mini-app deep-linked
+    /// to <paramref name="moduleId"/>/<paramref name="lessonId"/>. <paramref name="variant"/> is
+    /// the A/B copy variant chosen upstream (#951). If Telegram returns 403 (user blocked the bot),
+    /// the user is flagged inactive and the exception is swallowed; on 429 the call retries once
+    /// after the server-suggested delay.
+    /// </summary>
+    Task SendDailyReturnPushAsync(
+        User user,
+        string moduleName,
+        string moduleId,
+        int lessonId,
+        string variant,
+        CancellationToken ct);
 }

--- a/src/Infrastructure/Telegram/Services/TelegramNotificationService.cs
+++ b/src/Infrastructure/Telegram/Services/TelegramNotificationService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Telegram.Bot;
 using Telegram.Bot.Exceptions;
+using Telegram.Bot.Types;
 using Telegram.Bot.Types.ReplyMarkups;
 
 namespace Infrastructure.Telegram.Services;
@@ -57,15 +58,65 @@ public class TelegramNotificationService : IUserNotificationService
             cancellationToken: ct);
     }
 
-    public Task SendDailyReturnPushAsync(
-        User user,
+    public async Task SendDailyReturnPushAsync(
+        Domain.Entities.User user,
         string moduleName,
         string moduleId,
         int lessonId,
         string variant,
         CancellationToken ct)
     {
-        // Implemented in the green step of TDD for #952.
-        throw new NotImplementedException();
+        var text = BuildDailyReturnPushText(moduleName, variant);
+        var keyboard = BuildDailyReturnPushKeyboard(moduleId, lessonId);
+
+        try
+        {
+            await _client.SendTextMessageAsync(
+                chatId: user.TelegramId,
+                text: text,
+                replyMarkup: keyboard,
+                cancellationToken: ct);
+        }
+        catch (ApiRequestException ex) when (ex.ErrorCode == 429)
+        {
+            var retryAfterSeconds = ex.Parameters?.RetryAfter ?? 1;
+            _logger.LogInformation(
+                "Daily return push for {TelegramId} hit rate limit; retrying after {RetryAfter}s",
+                user.TelegramId, retryAfterSeconds);
+            await Task.Delay(TimeSpan.FromSeconds(retryAfterSeconds), ct);
+            await _client.SendTextMessageAsync(
+                chatId: user.TelegramId,
+                text: text,
+                replyMarkup: keyboard,
+                cancellationToken: ct);
+        }
+        catch (ApiRequestException ex) when (ex.ErrorCode == 403)
+        {
+            _logger.LogInformation(
+                "Daily return push for {TelegramId} blocked (403); marking user inactive",
+                user.TelegramId);
+            user.IsActive = false;
+            return;
+        }
+
+        await Task.Delay(BulkSendDelay, ct);
+    }
+
+    internal static string BuildDailyReturnPushText(string moduleName, string variant)
+        => variant == "B"
+            ? $"{moduleName} ждёт продолжения 📖 Вернёшься?"
+            : $"Бомбора по тебе скучает 🐶 Продолжишь {moduleName} сегодня?";
+
+    private InlineKeyboardMarkup BuildDailyReturnPushKeyboard(string moduleId, int lessonId)
+    {
+        var host = _botConfig.NormalizedHost();
+        var url = $"{host}/?moduleId={moduleId}&lessonId={lessonId}";
+        return new InlineKeyboardMarkup(new[]
+        {
+            new[]
+            {
+                InlineKeyboardButton.WithWebApp("Продолжить урок", new WebAppInfo { Url = url })
+            }
+        });
     }
 }

--- a/src/Infrastructure/Telegram/Services/TelegramNotificationService.cs
+++ b/src/Infrastructure/Telegram/Services/TelegramNotificationService.cs
@@ -1,34 +1,47 @@
 using Application.Common.Interfaces;
 using Domain.Entities;
 using Infrastructure.Telegram.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Telegram.Bot;
+using Telegram.Bot.Exceptions;
 using Telegram.Bot.Types.ReplyMarkups;
 
 namespace Infrastructure.Telegram.Services;
 
-public class TelegramNotificationService: IUserNotificationService
+public class TelegramNotificationService : IUserNotificationService
 {
-    private readonly ITelegramBotClient _client;
+    /// <summary>Pause between bulk sends. Telegram allows ~30 msg/s globally; 50 ms = 20 msg/s leaves headroom.</summary>
+    internal static readonly TimeSpan BulkSendDelay = TimeSpan.FromMilliseconds(50);
 
-    public TelegramNotificationService(ITelegramBotClient client)
+    private readonly ITelegramBotClient _client;
+    private readonly BotConfiguration _botConfig;
+    private readonly ILogger<TelegramNotificationService> _logger;
+
+    public TelegramNotificationService(
+        ITelegramBotClient client,
+        BotConfiguration botConfig,
+        ILogger<TelegramNotificationService>? logger = null)
     {
         _client = client;
+        _botConfig = botConfig;
+        _logger = logger ?? NullLogger<TelegramNotificationService>.Instance;
     }
 
     public async Task NotifyAboutUnlockedAchievementAsync(Achievement achievement, CancellationToken ct)
     {
         var userTelegramId = achievement.User.TelegramId;
-        
+
         await _client.SendTextMessageAsync(
             userTelegramId,
             "✅Открыто новое достижение!",
             cancellationToken: ct);
-        
+
         await _client.SendTextMessageAsync(
             userTelegramId,
             achievement.Icon,
             cancellationToken: ct);
-        
+
         var keyboard = new InlineKeyboardMarkup(new[]
         {
             new[]
@@ -36,11 +49,23 @@ public class TelegramNotificationService: IUserNotificationService
                 InlineKeyboardButton.WithCallbackData("📊Посмотреть все достижения", $"{CommandNames.Achievements}")
             }
         });
-        
+
         await _client.SendTextMessageAsync(
             userTelegramId,
             $"{achievement.Icon}{achievement.Name} – {achievement.Description}",
             replyMarkup: keyboard,
             cancellationToken: ct);
+    }
+
+    public Task SendDailyReturnPushAsync(
+        User user,
+        string moduleName,
+        string moduleId,
+        int lessonId,
+        string variant,
+        CancellationToken ct)
+    {
+        // Implemented in the green step of TDD for #952.
+        throw new NotImplementedException();
     }
 }

--- a/src/Trale/HostedServices/ReturnPushWorker.cs
+++ b/src/Trale/HostedServices/ReturnPushWorker.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Trale.HostedServices;
+
+/// <summary>
+/// Fires the D1+ return-push dispatch once a day at 10:00 UTC (14:00 Tbilisi — morning for
+/// most Russian-speaking users). Delegates the eligibility query + actual sending to
+/// <see cref="IDailyReturnNotificationService"/> (see issue #951).
+/// Uses a scoped service because the dispatcher pulls EF DbContext.
+/// </summary>
+public class ReturnPushWorker(
+    IServiceScopeFactory scopeFactory,
+    ILogger<ReturnPushWorker> logger) : BackgroundService
+{
+    /// <summary>Hour-of-day in UTC the worker fires at.</summary>
+    public const int RunHourUtc = 10;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Implemented in the green step of TDD for #952.
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Returns the delay from <paramref name="nowUtc"/> until the next scheduled run.
+    /// If <paramref name="nowUtc"/> is before today's 10:00 UTC, returns the delta to today's slot.
+    /// Otherwise returns the delta to tomorrow's 10:00 UTC.
+    /// </summary>
+    public static TimeSpan ComputeDelayUntilNextRun(DateTime nowUtc)
+    {
+        // Implemented in the green step of TDD for #952.
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Runs a single dispatch cycle (resolves the scoped dispatcher and calls DispatchAsync).
+    /// Public so that tests can verify the worker delegates correctly without running the
+    /// long-running scheduling loop.
+    /// </summary>
+    public async Task RunOnceAsync(CancellationToken ct)
+    {
+        // Implemented in the green step of TDD for #952.
+        await Task.Yield();
+        throw new NotImplementedException();
+    }
+}

--- a/src/Trale/HostedServices/ReturnPushWorker.cs
+++ b/src/Trale/HostedServices/ReturnPushWorker.cs
@@ -23,30 +23,57 @@ public class ReturnPushWorker(
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // Implemented in the green step of TDD for #952.
-        throw new NotImplementedException();
+        logger.LogInformation("ReturnPushWorker started; daily run hour={RunHourUtc} UTC", RunHourUtc);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(ComputeDelayUntilNextRun(DateTime.UtcNow), stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            await RunOnceAsync(stoppingToken);
+        }
+
+        logger.LogInformation("ReturnPushWorker stopped");
     }
 
     /// <summary>
     /// Returns the delay from <paramref name="nowUtc"/> until the next scheduled run.
-    /// If <paramref name="nowUtc"/> is before today's 10:00 UTC, returns the delta to today's slot.
-    /// Otherwise returns the delta to tomorrow's 10:00 UTC.
+    /// If <paramref name="nowUtc"/> is strictly before today's 10:00 UTC, returns the delta
+    /// to today's slot. Otherwise (including exactly at 10:00) returns the delta to tomorrow's
+    /// slot, so the worker doesn't fire twice in the same calendar day.
     /// </summary>
     public static TimeSpan ComputeDelayUntilNextRun(DateTime nowUtc)
     {
-        // Implemented in the green step of TDD for #952.
-        throw new NotImplementedException();
+        var nextRun = nowUtc.Date.AddHours(RunHourUtc);
+        if (nowUtc >= nextRun) nextRun = nextRun.AddDays(1);
+        return nextRun - nowUtc;
     }
 
     /// <summary>
     /// Runs a single dispatch cycle (resolves the scoped dispatcher and calls DispatchAsync).
-    /// Public so that tests can verify the worker delegates correctly without running the
-    /// long-running scheduling loop.
+    /// Exceptions are caught and logged so a transient failure doesn't crash the host.
     /// </summary>
     public async Task RunOnceAsync(CancellationToken ct)
     {
-        // Implemented in the green step of TDD for #952.
-        await Task.Yield();
-        throw new NotImplementedException();
+        try
+        {
+            await using var scope = scopeFactory.CreateAsyncScope();
+            var service = scope.ServiceProvider.GetRequiredService<IDailyReturnNotificationService>();
+            await service.DispatchAsync(ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "ReturnPushWorker dispatch iteration failed");
+        }
     }
 }

--- a/src/Trale/Program.cs
+++ b/src/Trale/Program.cs
@@ -41,6 +41,7 @@ builder.Services.AddScoped<Application.Common.Interfaces.MiniApp.IProgressCalcul
 builder.Services.AddHostedService<CreateWebhook>();
 builder.Services.AddHostedService<IdempotencyCleanupService>();
 builder.Services.AddHostedService<Trale.HostedServices.PendingReferralsWorker>();
+builder.Services.AddHostedService<ReturnPushWorker>();
 
 builder.WebHost.UseUrls("http://*:1402/");
 var app = builder.Build();

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,8 +46,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TraleBot — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-NDgAS7oZ.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-Dnrll3Sg.css">
+    <script type="module" crossorigin src="/assets/index-B5INmJVk.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DaoT9jvO.css">
   </head>
   <body>
     <div id="root"></div>

--- a/tests/Infrastructure.UnitTests/HostedServices/ReturnPushWorkerTests.cs
+++ b/tests/Infrastructure.UnitTests/HostedServices/ReturnPushWorkerTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shouldly;
+using Telegram.Bot;
+using Trale.HostedServices;
+using TgRequest = Telegram.Bot.Requests.Abstractions.IRequest<Telegram.Bot.Types.Message>;
+
+namespace Infrastructure.UnitTests.HostedServices;
+
+/// <summary>
+/// Covers AC from QA test plan on #952:
+/// - Worker schedules next run for the following day after a dispatch.
+/// - Worker resolves IDailyReturnNotificationService from scope and calls DispatchAsync once.
+/// - When the dispatcher does nothing (no eligible users) the worker doesn't reach the Telegram client.
+/// </summary>
+[TestFixture]
+public class ReturnPushWorkerTests
+{
+    private static ReturnPushWorker BuildWorker(IServiceScopeFactory scopeFactory)
+        => new(scopeFactory, NullLogger<ReturnPushWorker>.Instance);
+
+    [Test]
+    public void ComputeDelayUntilNextRun_WhenNowBefore10Utc_ReturnsDelayUntilToday10Utc()
+    {
+        var now = new DateTime(2026, 6, 15, 8, 30, 0, DateTimeKind.Utc);
+
+        var delay = ReturnPushWorker.ComputeDelayUntilNextRun(now);
+
+        delay.ShouldBe(TimeSpan.FromHours(1) + TimeSpan.FromMinutes(30));
+    }
+
+    [Test]
+    public void ComputeDelayUntilNextRun_WhenNowAfter10Utc_ReturnsDelayUntilTomorrow10Utc()
+    {
+        var now = new DateTime(2026, 6, 15, 11, 0, 0, DateTimeKind.Utc);
+
+        var delay = ReturnPushWorker.ComputeDelayUntilNextRun(now);
+
+        // From 11:00 today to 10:00 next day = 23h
+        delay.ShouldBe(TimeSpan.FromHours(23));
+    }
+
+    [Test]
+    public void ComputeDelayUntilNextRun_WhenNowExactlyAt10Utc_SchedulesForTomorrow10Utc()
+    {
+        // Mirrors AC "ReturnPushWorker_SchedulesNextRunForFollowingDay_AfterDispatch":
+        // a fresh dispatch at 10:00 must push the next slot 24h out.
+        var now = new DateTime(2026, 6, 15, 10, 0, 0, DateTimeKind.Utc);
+
+        var delay = ReturnPushWorker.ComputeDelayUntilNextRun(now);
+
+        delay.ShouldBe(TimeSpan.FromHours(24));
+        delay.ShouldBeGreaterThan(TimeSpan.FromHours(23));
+    }
+
+    [Test]
+    public async Task RunOnceAsync_ResolvesDispatcherFromScope_AndCallsDispatchAsync()
+    {
+        var dispatcher = new Mock<IDailyReturnNotificationService>(MockBehavior.Strict);
+        dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var services = new ServiceCollection();
+        services.AddSingleton(dispatcher.Object);
+        var sp = services.BuildServiceProvider();
+        var worker = BuildWorker(sp.GetRequiredService<IServiceScopeFactory>());
+
+        await worker.RunOnceAsync(CancellationToken.None);
+
+        dispatcher.Verify(d => d.DispatchAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task RunOnceAsync_WhenDispatchReturnsEmpty_SendIsNotCalled()
+    {
+        // If the dispatcher decides nobody is eligible (no-op), the worker must NOT side-step
+        // into the Telegram client itself. Worker is a pure scheduler.
+        var dispatcher = new Mock<IDailyReturnNotificationService>();
+        dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var botClient = new Mock<ITelegramBotClient>(MockBehavior.Strict);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(dispatcher.Object);
+        services.AddSingleton(botClient.Object);
+        var sp = services.BuildServiceProvider();
+        var worker = BuildWorker(sp.GetRequiredService<IServiceScopeFactory>());
+
+        await worker.RunOnceAsync(CancellationToken.None);
+
+        botClient.Verify(
+            c => c.MakeRequestAsync(It.IsAny<TgRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task RunOnceAsync_WhenDispatchThrows_LogsAndSwallows()
+    {
+        // The worker is a daemon — a transient dispatch failure must not crash the host.
+        var dispatcher = new Mock<IDailyReturnNotificationService>();
+        dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("DB blip"));
+        var services = new ServiceCollection();
+        services.AddSingleton(dispatcher.Object);
+        var sp = services.BuildServiceProvider();
+        var worker = BuildWorker(sp.GetRequiredService<IServiceScopeFactory>());
+
+        await Should.NotThrowAsync(() => worker.RunOnceAsync(CancellationToken.None));
+    }
+
+    [Test]
+    public void Program_RegistersReturnPushWorkerAsHostedService()
+    {
+        // Static guarantee that wiring is in place. Grep keeps CI honest if someone removes it.
+        var programSource = System.IO.File.ReadAllText(
+            FindProgramCsPath());
+        programSource.ShouldContain("AddHostedService<ReturnPushWorker>");
+    }
+
+    private static string FindProgramCsPath()
+    {
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 10 && dir is not null; i++)
+        {
+            var candidate = System.IO.Path.Combine(dir, "src", "Trale", "Program.cs");
+            if (System.IO.File.Exists(candidate)) return candidate;
+            dir = System.IO.Path.GetDirectoryName(dir);
+        }
+        throw new System.IO.FileNotFoundException("Could not locate src/Trale/Program.cs");
+    }
+}

--- a/tests/Infrastructure.UnitTests/Telegram/TelegramNotificationServiceTests.cs
+++ b/tests/Infrastructure.UnitTests/Telegram/TelegramNotificationServiceTests.cs
@@ -1,0 +1,187 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Application.Common.Interfaces;
+using Infrastructure.Telegram.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shouldly;
+using global::Telegram.Bot;
+using global::Telegram.Bot.Exceptions;
+using global::Telegram.Bot.Types;
+using global::Telegram.Bot.Types.ReplyMarkups;
+using BotConfiguration = global::Infrastructure.Telegram.BotConfiguration;
+using DomainUser = global::Domain.Entities.User;
+using UserAccountType = global::Domain.Entities.UserAccountType;
+using TgRequest = global::Telegram.Bot.Requests.Abstractions.IRequest<global::Telegram.Bot.Types.Message>;
+
+namespace Infrastructure.UnitTests.Telegram;
+
+/// <summary>
+/// Covers AC from QA test plan on #952:
+/// - Scenario 1: WebApp button URL contains ?moduleId=&lessonId=
+/// - 403 → user.IsActive = false, no rethrow
+/// - 429 → retry after server-suggested delay
+/// - Message text contains the module name
+/// </summary>
+[TestFixture]
+public class TelegramNotificationServiceTests
+{
+    private const string TestHost = "https://test.tralebot.com";
+
+    private static BotConfiguration BuildBotConfig() => new()
+    {
+        BotName = "testbot",
+        Token = "test_token",
+        HostAddress = TestHost,
+        WebhookToken = "test_webhook",
+        PaymentProviderToken = "test_payment",
+        MiniAppEnabled = true
+    };
+
+    private static DomainUser BuildUser(long telegramId = 99100) => new()
+    {
+        Id = System.Guid.NewGuid(),
+        TelegramId = telegramId,
+        IsActive = true,
+        InitialLanguageSet = true,
+        AccountType = UserAccountType.Free,
+        RegisteredAtUtc = System.DateTime.UtcNow.AddDays(-2)
+    };
+
+    private static (Mock<ITelegramBotClient> client, List<TgRequest> captured)
+        BuildMockClient(System.Func<TgRequest, int, Message>? perCallResponder = null)
+    {
+        var mock = new Mock<ITelegramBotClient>();
+        var captured = new List<TgRequest>();
+        var calls = 0;
+        mock
+            .Setup(c => c.MakeRequestAsync(It.IsAny<TgRequest>(), It.IsAny<System.Threading.CancellationToken>()))
+            .Returns<TgRequest, System.Threading.CancellationToken>((req, _) =>
+            {
+                captured.Add(req);
+                calls++;
+                if (perCallResponder is not null)
+                    return System.Threading.Tasks.Task.FromResult(perCallResponder(req, calls));
+                return System.Threading.Tasks.Task.FromResult(new Message { MessageId = calls });
+            });
+        return (mock, captured);
+    }
+
+    private static string? ReflectText(TgRequest req)
+        => req.GetType().GetProperty("Text")?.GetValue(req) as string;
+
+    private static InlineKeyboardMarkup? ReflectMarkup(TgRequest req)
+        => req.GetType().GetProperty("ReplyMarkup")?.GetValue(req) as InlineKeyboardMarkup;
+
+    [Test]
+    public async Task SendDailyReturnPushAsync_MessageContainsCorrectDeepLinkUrl()
+    {
+        var (client, captured) = BuildMockClient();
+        var service = new TelegramNotificationService(client.Object, BuildBotConfig(), NullLogger<TelegramNotificationService>.Instance);
+        var user = BuildUser();
+
+        await service.SendDailyReturnPushAsync(user, "Алфавит", "alphabet", 7, "A", default);
+
+        captured.ShouldHaveSingleItem();
+        var markup = ReflectMarkup(captured[0]);
+        markup.ShouldNotBeNull();
+        var button = markup.InlineKeyboard.SelectMany(r => r).Single();
+        button.WebApp.ShouldNotBeNull();
+        button.WebApp.Url.ShouldBe($"{TestHost}/?moduleId=alphabet&lessonId=7");
+    }
+
+    [Test]
+    public async Task SendDailyReturnPushAsync_MessageTextContainsModuleName()
+    {
+        var (client, captured) = BuildMockClient();
+        var service = new TelegramNotificationService(client.Object, BuildBotConfig(), NullLogger<TelegramNotificationService>.Instance);
+
+        await service.SendDailyReturnPushAsync(BuildUser(), "Числа", "numbers", 3, "A", default);
+
+        ReflectText(captured.Single()).ShouldNotBeNull().ShouldContain("Числа");
+    }
+
+    [Test]
+    public async Task SendDailyReturnPushAsync_OnVariantA_UsesVariantACopy()
+    {
+        var (client, captured) = BuildMockClient();
+        var service = new TelegramNotificationService(client.Object, BuildBotConfig(), NullLogger<TelegramNotificationService>.Instance);
+
+        await service.SendDailyReturnPushAsync(BuildUser(), "Падежи", "cases", 2, "A", default);
+
+        var text = ReflectText(captured.Single());
+        text.ShouldNotBeNull();
+        text.ShouldContain("скучает");
+    }
+
+    [Test]
+    public async Task SendDailyReturnPushAsync_OnVariantB_UsesVariantBCopy()
+    {
+        var (client, captured) = BuildMockClient();
+        var service = new TelegramNotificationService(client.Object, BuildBotConfig(), NullLogger<TelegramNotificationService>.Instance);
+
+        await service.SendDailyReturnPushAsync(BuildUser(), "Падежи", "cases", 2, "B", default);
+
+        var text = ReflectText(captured.Single());
+        text.ShouldNotBeNull();
+        text.ShouldContain("ждёт продолжения");
+    }
+
+    [Test]
+    public async Task SendDailyReturnPushAsync_On403_SetsUserIsActiveFalseAndDoesNotThrow()
+    {
+        var mock = new Mock<ITelegramBotClient>();
+        mock
+            .Setup(c => c.MakeRequestAsync(It.IsAny<TgRequest>(), It.IsAny<System.Threading.CancellationToken>()))
+            .ThrowsAsync(new ApiRequestException("Forbidden: bot was blocked by the user", 403));
+        var service = new TelegramNotificationService(mock.Object, BuildBotConfig(), NullLogger<TelegramNotificationService>.Instance);
+        var user = BuildUser();
+
+        await service.SendDailyReturnPushAsync(user, "Алфавит", "alphabet", 1, "A", default);
+
+        user.IsActive.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task SendDailyReturnPushAsync_OnTooManyRequests_RetriesAfterDelay()
+    {
+        var calls = 0;
+        var mock = new Mock<ITelegramBotClient>();
+        mock
+            .Setup(c => c.MakeRequestAsync(It.IsAny<TgRequest>(), It.IsAny<System.Threading.CancellationToken>()))
+            .Returns<TgRequest, System.Threading.CancellationToken>((_, _) =>
+            {
+                calls++;
+                if (calls == 1)
+                    throw new ApiRequestException(
+                        "Too Many Requests: retry after 1",
+                        429,
+                        new ResponseParameters { RetryAfter = 1 });
+                return System.Threading.Tasks.Task.FromResult(new Message { MessageId = calls });
+            });
+        var service = new TelegramNotificationService(mock.Object, BuildBotConfig(), NullLogger<TelegramNotificationService>.Instance);
+
+        var sw = Stopwatch.StartNew();
+        await service.SendDailyReturnPushAsync(BuildUser(), "Алфавит", "alphabet", 1, "A", default);
+        sw.Stop();
+
+        calls.ShouldBe(2);
+        sw.Elapsed.ShouldBeGreaterThanOrEqualTo(System.TimeSpan.FromMilliseconds(900));
+    }
+
+    [Test]
+    public async Task SendDailyReturnPushAsync_UsesWebAppButton_NotPlainUrlButton()
+    {
+        var (client, captured) = BuildMockClient();
+        var service = new TelegramNotificationService(client.Object, BuildBotConfig(), NullLogger<TelegramNotificationService>.Instance);
+
+        await service.SendDailyReturnPushAsync(BuildUser(), "Алфавит", "alphabet", 1, "A", default);
+
+        var markup = ReflectMarkup(captured.Single());
+        markup.ShouldNotBeNull();
+        var button = markup.InlineKeyboard.SelectMany(r => r).Single();
+        button.WebApp.ShouldNotBeNull();
+        button.Url.ShouldBeNull(); // not a plain URL button
+    }
+}


### PR DESCRIPTION
## Доделка эпика #940 — [epic] D1+ push для юзеров начавших урок но не вернувшихся

Запущено из Dev Tycoon («Доделать эпик»). Агент-разработчик добивал незаконченные
задачи прямо на ночной ветке `agents/nightly-2026-06-15`.

**Дочерние задачи:** 4/4 done
**Доделаны в этом прогоне:**  #952
**Ещё открыты:** —

Когда CI зелёный и PR станет ready — смержи в main и передвинь эпик #940
в Done на доске.

_(Automated · dispatch-epic-finish)_