### PR TITLE
Fix deploy: document AddUserNotificationsEnabled migration in FEATURES.md §5

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -272,6 +272,7 @@ Location: `src/Persistence/Migrations/`. Test greps the migration class name (af
 | `AddLastTreatIndex` | Last-treat index for rotation. |
 | `AddSentenceBuilderProgressJson` | Per-user sentence-builder mastery progress (questionId → correct-count map) for L4/L5 progression gate. |
 | `AddTrialBonusDays` | Cumulative referral trial-bonus days on User; lets bonuses stack and survive trial expiry without rewriting RegisteredAtUtc. |
+| `AddUserNotificationsEnabled` | Per-user notifications opt-out flag on User (default on); toggled from the mini-app Profile, honoured by the D1+ return-push dispatch. |
 
 ---
 


### PR DESCRIPTION
The #981 merge failed the deploy on `FeatureCatalogCoverageTests.Every_migration_class_is_listed_in_FEATURES_md` — the repo requires every EF migration to be listed in FEATURES.md §5, and `AddUserNotificationsEnabled` (from #981) wasn't. Adds the missing row so the deploy goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)