### PR TITLE
Wire the daily-return dispatch (#951) — auto-send goes live

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -273,6 +273,7 @@ Location: `src/Persistence/Migrations/`. Test greps the migration class name (af
 | `AddSentenceBuilderProgressJson` | Per-user sentence-builder mastery progress (questionId → correct-count map) for L4/L5 progression gate. |
 | `AddTrialBonusDays` | Cumulative referral trial-bonus days on User; lets bonuses stack and survive trial expiry without rewriting RegisteredAtUtc. |
 | `AddUserNotificationsEnabled` | Per-user notifications opt-out flag on User (default on); toggled from the mini-app Profile, honoured by the D1+ return-push dispatch. |
+| `AddNotificationTriggers` | NotificationTrigger table (per-source last-sent timestamp + variant) backing the 7-day cooldown of the D1+ return-push dispatch. |
 
 ---
 

--- a/src/Application/Common/ITraleDbContext.cs
+++ b/src/Application/Common/ITraleDbContext.cs
@@ -20,6 +20,7 @@ public interface ITraleDbContext
     DbSet<MiniAppUserProgress> MiniAppUserProgresses { get; }
     DbSet<Payment> Payments { get; }
     DbSet<Referral> Referrals { get; }
+    DbSet<NotificationTrigger> NotificationTriggers { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
     EntityEntry Entry(object entity);

--- a/src/Application/DependencyInjection.cs
+++ b/src/Application/DependencyInjection.cs
@@ -6,6 +6,8 @@ using Application.Common.Interfaces.Achievements;
 using Application.MiniApp.Commands;
 using Application.MiniApp.Queries;
 using Application.MiniApp.Services;
+using Application.Common.Interfaces;
+using Application.Notifications;
 using Application.Quizzes.Services;
 using Application.Translation;
 using Application.Translation.Languages;
@@ -22,6 +24,11 @@ public static class DependencyInjection
 
         services.AddTransient<IQuizCreator, QuizCreator>();
         services.AddTransient<IQuizVocabularyEntriesAdvisor, QuizVocabularyEntriesAdvisor>();
+
+        // Daily-return push targeting (#940). Bound to the interface the worker resolves.
+        services.AddScoped<DailyReturnNotificationService>();
+        services.AddScoped<IDailyReturnNotificationService>(
+            sp => sp.GetRequiredService<DailyReturnNotificationService>());
 
         services.AddTransient<ILanguageTranslator, LanguageTranslator>();
         services.AddScoped<ITranslationModule, EnglishTranslationModule>();

--- a/src/Application/Notifications/DailyReturnNotificationService.cs
+++ b/src/Application/Notifications/DailyReturnNotificationService.cs
@@ -1,0 +1,127 @@
+using System.Text.Json;
+using Application.Common;
+using Application.Common.Interfaces;
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Notifications;
+
+/// <summary>
+/// Targets the D1+ return push (epic #940). Eligible = started at least one lesson,
+/// hasn't played in &gt;30h, is active and opted in — capped to once per 7 days via
+/// <see cref="NotificationTrigger"/>. Picks the least-progressed module, deep-links to
+/// its next lesson, and chooses the copy variant by spendable XP (enough → "feed",
+/// otherwise → "earn"). Resolved as <see cref="IDailyReturnNotificationService"/>;
+/// <c>ReturnPushWorker</c> calls <see cref="DispatchAsync"/> once a day.
+/// </summary>
+public class DailyReturnNotificationService(
+    ITraleDbContext db,
+    IUserNotificationService notificationService,
+    ILoggerFactory loggerFactory) : IDailyReturnNotificationService
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<DailyReturnNotificationService>();
+    private const string Source = "daily_return";
+    private const int CheapestTreatXp = 10; // mirrors FeedTreatService.TreatPrices[0]
+    private static readonly TimeSpan EligibilityThreshold = TimeSpan.FromDays(1) + TimeSpan.FromHours(6);
+    private static readonly TimeSpan CooldownPeriod = TimeSpan.FromDays(7);
+
+    public async Task DispatchAsync(CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var cutoff = now - EligibilityThreshold;
+
+        var progressList = await db.MiniAppUserProgresses
+            .Where(p => p.LastPlayedAtUtc != null
+                     && p.LastPlayedAtUtc < cutoff
+                     && p.CompletedLessonsJson != "{}"
+                     && p.CompletedLessonsJson != "null")
+            .ToListAsync(ct);
+
+        if (progressList.Count == 0) return;
+
+        var userIds = progressList.Select(p => p.UserId).ToList();
+        var users = await db.Users
+            .Where(u => userIds.Contains(u.Id) && u.IsActive && u.NotificationsEnabled)
+            .ToListAsync(ct);
+
+        if (users.Count == 0) return;
+
+        var userMap = users.ToDictionary(u => u.Id);
+        var telegramIds = users.Select(u => u.TelegramId).ToList();
+
+        var triggers = await db.NotificationTriggers
+            .Where(t => telegramIds.Contains(t.UserId) && t.Source == Source)
+            .ToListAsync(ct);
+        var triggerMap = triggers.ToDictionary(t => t.UserId);
+
+        foreach (var progress in progressList)
+        {
+            if (!userMap.TryGetValue(progress.UserId, out var user))
+                continue;
+
+            triggerMap.TryGetValue(user.TelegramId, out var trigger);
+
+            // Cooldown: skip if pinged within the last 7 days.
+            if (trigger != null && trigger.LastSentAt > now - CooldownPeriod)
+            {
+                _logger.LogInformation(
+                    "User {TelegramId} skipped — daily-return cooldown (lastSentAt={LastSentAt})",
+                    user.TelegramId, trigger.LastSentAt);
+                continue;
+            }
+
+            var completedLessons = ParseCompletedLessons(progress.CompletedLessonsJson);
+            var validModules = completedLessons
+                .Where(kv => kv.Value.Count > 0)
+                .OrderBy(kv => kv.Value.Count)
+                .ToList();
+
+            if (validModules.Count == 0) continue;
+
+            var (moduleId, lessonIds) = validModules[0];
+            var nextLessonId = lessonIds.Max() + 1;
+
+            // Variant by mechanic: enough spendable XP → "feed" (you can feed Bombora),
+            // otherwise "earn" (do a lesson to earn XP). moduleName is only rendered for the
+            // "module" variant, which we don't use here, so moduleId stands in safely.
+            var availableXp = Math.Max(0, progress.Xp - progress.XpSpent);
+            var variant = availableXp >= CheapestTreatXp ? "feed" : "earn";
+
+            await notificationService.SendDailyReturnPushAsync(
+                user, moduleId, moduleId, nextLessonId, variant, availableXp, ct);
+
+            var sentAt = DateTime.UtcNow;
+            if (trigger != null)
+            {
+                trigger.LastSentAt = sentAt;
+                trigger.Variant = variant;
+            }
+            else
+            {
+                db.NotificationTriggers.Add(new NotificationTrigger
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = user.TelegramId,
+                    Source = Source,
+                    LastSentAt = sentAt,
+                    Variant = variant
+                });
+            }
+            await db.SaveChangesAsync(ct);
+        }
+    }
+
+    private static Dictionary<string, List<int>> ParseCompletedLessons(string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, List<int>>>(json)
+                   ?? new Dictionary<string, List<int>>();
+        }
+        catch
+        {
+            return new Dictionary<string, List<int>>();
+        }
+    }
+}

--- a/src/Domain/Entities/NotificationTrigger.cs
+++ b/src/Domain/Entities/NotificationTrigger.cs
@@ -1,0 +1,17 @@
+// ReSharper disable PropertyCanBeMadeInitOnly.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+#pragma warning disable CS8618
+namespace Domain.Entities;
+
+/// <summary>
+/// Records the last time a given notification (by <see cref="Source"/>) was sent to a user,
+/// so the dispatch can enforce a cooldown. <see cref="UserId"/> stores the Telegram ID (long).
+/// </summary>
+public class NotificationTrigger
+{
+    public Guid Id { get; set; }
+    public long UserId { get; set; }
+    public string Source { get; set; }
+    public DateTime LastSentAt { get; set; }
+    public string? Variant { get; set; }
+}

--- a/src/Persistence/Configurations/NotificationTriggerConfiguration.cs
+++ b/src/Persistence/Configurations/NotificationTriggerConfiguration.cs
@@ -1,0 +1,23 @@
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Persistence.Configurations;
+
+public class NotificationTriggerConfiguration : IEntityTypeConfiguration<NotificationTrigger>
+{
+    public void Configure(EntityTypeBuilder<NotificationTrigger> builder)
+    {
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).ValueGeneratedOnAdd();
+        builder.Property(x => x.UserId).IsRequired();
+        builder.Property(x => x.Source).IsRequired().HasMaxLength(100);
+        builder.Property(x => x.LastSentAt).IsRequired();
+        builder.Property(x => x.Variant).IsRequired(false).HasMaxLength(10);
+
+        // UserId stores the Telegram ID (long), not the User PK (Guid). No FK relationship:
+        // HasPrincipalKey(TelegramId) would promote TelegramId to an alternate key, breaking
+        // EF identity tracking in tests that share TelegramId values.
+        builder.HasIndex(x => new { x.UserId, x.Source });
+    }
+}

--- a/src/Persistence/Migrations/20260616170534_AddNotificationTriggers.Designer.cs
+++ b/src/Persistence/Migrations/20260616170534_AddNotificationTriggers.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Persistence;
@@ -11,9 +12,11 @@ using Persistence;
 namespace Persistence.Migrations
 {
     [DbContext(typeof(TraleDbContext))]
-    partial class TraleDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616170534_AddNotificationTriggers")]
+    partial class AddNotificationTriggers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/Migrations/20260616170534_AddNotificationTriggers.cs
+++ b/src/Persistence/Migrations/20260616170534_AddNotificationTriggers.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNotificationTriggers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "NotificationTriggers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<long>(type: "bigint", nullable: false),
+                    Source = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    LastSentAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Variant = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NotificationTriggers", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationTriggers_UserId_Source",
+                table: "NotificationTriggers",
+                columns: new[] { "UserId", "Source" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "NotificationTriggers");
+        }
+    }
+}

--- a/src/Persistence/TraleDbContext.cs
+++ b/src/Persistence/TraleDbContext.cs
@@ -29,6 +29,7 @@ public class TraleDbContext : DbContext, ITraleDbContext
     public DbSet<MiniAppUserProgress> MiniAppUserProgresses { get; set; } = null!;
     public DbSet<Payment> Payments { get; set; } = null!;
     public DbSet<Referral> Referrals { get; set; } = null!;
+    public DbSet<NotificationTrigger> NotificationTriggers { get; set; } = null!;
 
     public async Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
     {
@@ -49,6 +50,7 @@ public class TraleDbContext : DbContext, ITraleDbContext
         modelBuilder.ApplyConfiguration(new MiniAppUserProgressConfiguration());
         modelBuilder.ApplyConfiguration(new PaymentConfiguration());
         modelBuilder.ApplyConfiguration(new ReferralConfiguration());
+        modelBuilder.ApplyConfiguration(new NotificationTriggerConfiguration());
     }
     
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/tests/Application.UnitTests/Notifications/DailyReturnNotificationServiceTests.cs
+++ b/tests/Application.UnitTests/Notifications/DailyReturnNotificationServiceTests.cs
@@ -1,0 +1,158 @@
+using Application.Common.Interfaces;
+using Application.Notifications;
+using Application.UnitTests.Common;
+using Application.UnitTests.DSL;
+using Domain.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shouldly;
+
+namespace Application.UnitTests.Notifications;
+
+public class DailyReturnNotificationServiceTests : CommandTestsBase
+{
+    private Mock<IUserNotificationService> _notificationServiceMock = null!;
+    private DailyReturnNotificationService _sut = null!;
+    private const long TestTelegramId = 99001L;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _notificationServiceMock = new Mock<IUserNotificationService>();
+        _notificationServiceMock
+            .Setup(s => s.SendDailyReturnPushAsync(
+                It.IsAny<User>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _sut = new DailyReturnNotificationService(
+            Context,
+            _notificationServiceMock.Object,
+            NullLoggerFactory.Instance);
+    }
+
+    private async Task<User> SeedEligibleUser(
+        string completedLessonsJson = """{"alphabet-progressive":[1,2,3]}""",
+        bool notificationsEnabled = true)
+    {
+        var user = Create.User().Build();
+        user.TelegramId = TestTelegramId;
+        user.NotificationsEnabled = notificationsEnabled;
+        Context.Users.Add(user);
+        await Context.SaveChangesAsync();
+
+        Context.MiniAppUserProgresses.Add(new MiniAppUserProgress
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            LastPlayedAtUtc = DateTime.UtcNow.AddDays(-2),
+            CompletedLessonsJson = completedLessonsJson,
+            Xp = 0, XpSpent = 0, Streak = 0, Hearts = 0, MaxHearts = 0,
+            CreatedAtUtc = DateTime.UtcNow.AddDays(-2),
+            UpdatedAtUtc = DateTime.UtcNow.AddDays(-2)
+        });
+        await Context.SaveChangesAsync();
+        return user;
+    }
+
+    private void VerifyPushSent(Times times) =>
+        _notificationServiceMock.Verify(
+            s => s.SendDailyReturnPushAsync(
+                It.IsAny<User>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            times);
+
+    [Test]
+    public async Task DispatchAsync_EligibleUser_SendsPushAndRecordsTrigger()
+    {
+        await SeedEligibleUser();
+
+        await _sut.DispatchAsync(CancellationToken.None);
+
+        // moduleName falls back to moduleId; lessonId = max(completed) + 1.
+        _notificationServiceMock.Verify(
+            s => s.SendDailyReturnPushAsync(
+                It.Is<User>(u => u.TelegramId == TestTelegramId),
+                "alphabet-progressive", "alphabet-progressive", 4,
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var trigger = Context.NotificationTriggers
+            .FirstOrDefault(t => t.UserId == TestTelegramId && t.Source == "daily_return");
+        trigger.ShouldNotBeNull();
+        trigger.LastSentAt.ShouldBeGreaterThan(DateTime.UtcNow.AddMinutes(-1));
+    }
+
+    [Test]
+    public async Task DispatchAsync_EmptyCompletedLessons_SkipsUser()
+    {
+        await SeedEligibleUser(completedLessonsJson: "{}");
+        await _sut.DispatchAsync(CancellationToken.None);
+        VerifyPushSent(Times.Never());
+    }
+
+    [Test]
+    public async Task DispatchAsync_NullCompletedLessons_SkipsUser()
+    {
+        await SeedEligibleUser(completedLessonsJson: "null");
+        await _sut.DispatchAsync(CancellationToken.None);
+        VerifyPushSent(Times.Never());
+    }
+
+    [Test]
+    public async Task DispatchAsync_WithinSevenDayCooldown_SkipsUser()
+    {
+        await SeedEligibleUser();
+        Context.NotificationTriggers.Add(new NotificationTrigger
+        {
+            Id = Guid.NewGuid(), UserId = TestTelegramId, Source = "daily_return",
+            LastSentAt = DateTime.UtcNow.AddDays(-5)
+        });
+        await Context.SaveChangesAsync();
+
+        await _sut.DispatchAsync(CancellationToken.None);
+        VerifyPushSent(Times.Never());
+    }
+
+    [Test]
+    public async Task DispatchAsync_OutsideSevenDayCooldown_SendsNotification()
+    {
+        await SeedEligibleUser();
+        Context.NotificationTriggers.Add(new NotificationTrigger
+        {
+            Id = Guid.NewGuid(), UserId = TestTelegramId, Source = "daily_return",
+            LastSentAt = DateTime.UtcNow.AddDays(-8)
+        });
+        await Context.SaveChangesAsync();
+
+        await _sut.DispatchAsync(CancellationToken.None);
+        VerifyPushSent(Times.Once());
+    }
+
+    [Test]
+    public async Task DispatchAsync_NotificationsDisabled_SkipsUser()
+    {
+        await SeedEligibleUser(notificationsEnabled: false);
+        await _sut.DispatchAsync(CancellationToken.None);
+        VerifyPushSent(Times.Never());
+    }
+
+    [Test]
+    public async Task DispatchAsync_NoXp_PicksEarnVariant()
+    {
+        await SeedEligibleUser(); // Xp = 0 → not enough to feed → "earn"
+
+        string? capturedVariant = null;
+        _notificationServiceMock
+            .Setup(s => s.SendDailyReturnPushAsync(
+                It.IsAny<User>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<int>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<User, string, string, int, string, int, CancellationToken>(
+                (_, _, _, _, variant, _, _) => capturedVariant = variant)
+            .Returns(Task.CompletedTask);
+
+        await _sut.DispatchAsync(CancellationToken.None);
+
+        capturedVariant.ShouldBe("earn");
+    }
+}


### PR DESCRIPTION
Follow-up to #981. Registers the targeting service `ReturnPushWorker` was missing, so the D1+ return push actually sends on its daily tick instead of logging-and-skipping.

## What's in
- **`DailyReturnNotificationService`** (`Application/Notifications`) implementing `IDailyReturnNotificationService`. Eligible = started ≥1 lesson, idle >30h, active **and** opted-in; capped to once per 7 days via `NotificationTrigger`. Picks the least-progressed module, deep-links to its next lesson, and chooses the copy variant by spendable XP (`feed` if ≥10 XP, else `earn`).
- **`NotificationTrigger`** entity + EF config + `DbSet` + `AddNotificationTriggers` migration (the cooldown store).
- **DI**: bound to `IDailyReturnNotificationService` so `ReturnPushWorker` resolves it.
- **Tests**: ported + adapted `DailyReturnNotificationServiceTests` (7/7 — eligibility, 7-day cooldown in/out, empty/null lessons, opt-out, variant). Migration documented in FEATURES.md §5.

Reconciles the stranded #950 (domain) + #951 (service) onto the current interface + 7-arg sender signature.

## Verified locally
Solution builds; Domain (68) + Application (121, incl. the new 7) green; app boots clean, `AddNotificationTriggers` applies, `NotificationTriggers` table created, worker now resolves the service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)