### PR TITLE
Agent pipeline: self-heal stale claims, model routing, finish-epic engine

### DIFF
--- a/deploy/agents/docker-compose.yml
+++ b/deploy/agents/docker-compose.yml
@@ -18,13 +18,15 @@ services:
       - TZ=Asia/Tbilisi
       # Limits
       - MAX_TURNS=${MAX_TURNS:-30}
+      # Per-role model routing (see scripts/model-utils.sh). Empty = script
+      # defaults: heavy=opus (developer/tech-lead), light=sonnet (the rest).
+      # Override e.g. PIPELINE_MODEL_HEAVY=sonnet to run the whole pipeline cheap.
+      - PIPELINE_MODEL_HEAVY=${PIPELINE_MODEL_HEAVY:-}
+      - PIPELINE_MODEL_LIGHT=${PIPELINE_MODEL_LIGHT:-}
       # Testcontainers: run sibling containers on the host Docker daemon.
-      # RYUK_DISABLED — socket proxy can't look up ryuk by id after creation
-      # (returns 404), so disable the resource reaper.
       # HOST_OVERRIDE=host.docker.internal — test client inside this container
       # must connect to test Postgres via the host's docker-desktop bridge,
       # not via `localhost` (which points back to bombora-agents itself).
-      - TESTCONTAINERS_RYUK_DISABLED=true
       - TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal
     volumes:
       - agent-logs:/logs

--- a/deploy/agents/scripts/claim-utils.sh
+++ b/deploy/agents/scripts/claim-utils.sh
@@ -1,0 +1,82 @@
+# claim-utils.sh — shared helpers for the `agent:running` claim label.
+#
+# A claim marks «an agent is actively building this issue right now». The
+# dispatch wrapper (dispatch-by-stage.sh / the dev loop) adds the label at the
+# start of a run and clears it from an EXIT trap. That trap covers a clean exit
+# AND a normal non-zero exit — but it does NOT fire when the run is hard-killed:
+# OOM (the container exited 137 on 2026-05-31), `docker stop`, or a host reboot.
+# A killed run therefore leaves `agent:running` stuck, and every later picker
+# pass skips the task forever — until a human removes the label by hand.
+#
+# These helpers let the picker and the dispatcher detect such dead claims by
+# age and reclaim them automatically, so a crash mid-build self-heals on the
+# next run instead of silently stalling the whole epic.
+#
+# Sourced — defines functions and (overridable) config, runs nothing on its own.
+
+RUNNING_LABEL="${RUNNING_LABEL:-agent:running}"
+
+# A claim older than this many minutes with no live run behind it is treated as
+# dead. A single dispatch is capped at --max-turns 30, which tops out around a
+# few tens of minutes even on Opus; 90 min is a safe ceiling that never reclaims
+# a genuinely running agent. Override via env if dispatches ever run longer.
+STALE_CLAIM_MINUTES="${STALE_CLAIM_MINUTES:-90}"
+
+# _claims_repo → prints owner/name for the current repo, or empty.
+# gh resolves the default repo from the cwd git remote (same as the bare
+# `gh issue list` calls elsewhere); GH_REPO overrides it when set.
+_claims_repo() {
+    if [ -n "${GH_REPO:-}" ]; then
+        echo "${GH_REPO}"
+        return
+    fi
+    gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true
+}
+
+# claim_age_minutes <issue> → whole minutes since the CURRENT `agent:running`
+# label was applied, or empty string if it can't be determined. Reads the
+# issue's event log (`labeled` events, newest matching one wins). per_page=100
+# pulls the whole history of a task issue in a single call (oldest-first), so
+# the most recent claim is always present.
+claim_age_minutes() {
+    local issue="$1" repo ts then_epoch now_epoch
+    repo="$(_claims_repo)"
+    [ -z "${repo}" ] && { echo ""; return; }
+
+    ts=$(gh api "repos/${repo}/issues/${issue}/events?per_page=100" 2>/dev/null \
+        | jq -r --arg L "${RUNNING_LABEL}" \
+            '[.[] | select(.event == "labeled" and .label.name == $L) | .created_at] | last // empty' \
+            2>/dev/null)
+    [ -z "${ts}" ] && { echo ""; return; }
+
+    # Parse the ISO-8601 `created_at` to epoch seconds. GNU date (the Linux
+    # container) handles `-d` directly; the BSD-date and python fallbacks keep
+    # the helper usable on a macOS host for local testing.
+    then_epoch=$(date -d "${ts}" +%s 2>/dev/null \
+        || date -j -f "%Y-%m-%dT%H:%M:%SZ" "${ts}" +%s 2>/dev/null \
+        || python3 -c 'import sys,calendar,time; print(calendar.timegm(time.strptime(sys.argv[1],"%Y-%m-%dT%H:%M:%SZ")))' "${ts}" 2>/dev/null)
+    [ -z "${then_epoch}" ] && { echo ""; return; }
+    now_epoch=$(date +%s)
+    echo $(( (now_epoch - then_epoch) / 60 ))
+}
+
+# reclaim_if_stale <issue> → if the claim is older than STALE_CLAIM_MINUTES,
+# remove `agent:running`, drop a breadcrumb comment, and return 0 (reclaimed).
+# Returns 1 when the claim is still live OR its age can't be determined — in
+# both cases we leave the label alone, erring toward never killing a real run.
+reclaim_if_stale() {
+    local issue="$1" age
+    age="$(claim_age_minutes "${issue}")"
+    [ -z "${age}" ] && return 1
+    [ "${age}" -lt "${STALE_CLAIM_MINUTES}" ] && return 1
+
+    # Body is a plain double-quoted string (no heredoc) so the file parses
+    # cleanly under any bash; backticks are escaped to stay literal in markdown.
+    local body
+    body="♻️ **Авто-восстановление claim'а.** Лейбл \`${RUNNING_LABEL}\` висел ${age} мин (порог ${STALE_CLAIM_MINUTES} мин) без живого прогона — предыдущий агент, похоже, был убит (OOM / рестарт контейнера / ребут), и EXIT-trap не успел снять claim. Снимаю лейбл и возвращаю задачу в очередь на разработку.
+
+_(Dev Tycoon · self-heal)_"
+    gh issue edit "${issue}" --remove-label "${RUNNING_LABEL}" >/dev/null 2>&1 || true
+    gh issue comment "${issue}" --body "${body}" >/dev/null 2>&1 || true
+    return 0
+}

--- a/deploy/agents/scripts/dispatch-by-epic.sh
+++ b/deploy/agents/scripts/dispatch-by-epic.sh
@@ -22,16 +22,26 @@ set -e
 # Args:
 #   $1 — GitHub issue number of the epic
 #
-# Idempotency: skip if the epic already has `agent:running`. Label is
-# set at the start and cleared in the EXIT trap.
+# Idempotency: skip if the epic already has a LIVE `agent:running` claim.
+# Label is set at the start and cleared in the EXIT trap; a claim stranded by
+# a hard-killed run is auto-reclaimed once stale (see claim-utils.sh).
 
 [ -f /etc/environment ] && source /etc/environment
+
+# Shared claim-label helpers (stale `agent:running` reclaim).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+source "${SCRIPT_DIR}/claim-utils.sh"
 
 EPIC_NUM="$1"
 if [[ -z "$EPIC_NUM" ]]; then
     echo "Usage: dispatch-by-epic.sh <epic_number>"
     exit 1
 fi
+
+# Per-role model routing. In this kickoff flow only tech-lead (epic breakdown)
+# runs heavy/Opus; product / designer / methodist are light/Sonnet planning
+# text. Shared with the pipeline via model-utils.sh; override via PIPELINE_MODEL_*.
+source "${SCRIPT_DIR}/model-utils.sh"
 
 TIMESTAMP=$(date '+%Y-%m-%d_%H-%M-%S')
 LOG_FILE="/logs/dispatch_epic_${EPIC_NUM}_${TIMESTAMP}.log"
@@ -72,10 +82,16 @@ if ! echo "$LABELS" | grep -qx "epic"; then
     exit 1
 fi
 
-# 2. Idempotency.
+# 2. Idempotency. Live claim → another dispatch is in flight, skip. A claim
+#    stranded by a hard-killed run (EXIT trap never fired) is reclaimed once
+#    stale so the epic can be kicked off again instead of jamming forever.
 if echo "$LABELS" | grep -qx "$RUNNING_LABEL"; then
-    echo "Epic #${EPIC_NUM} already has '${RUNNING_LABEL}' — another dispatch in flight. Skipping."
-    exit 0
+    if reclaim_if_stale "$EPIC_NUM"; then
+        echo "Epic #${EPIC_NUM} had a STALE '${RUNNING_LABEL}' claim — reclaimed it, continuing."
+    else
+        echo "Epic #${EPIC_NUM} already has '${RUNNING_LABEL}' — another dispatch in flight. Skipping."
+        exit 0
+    fi
 fi
 
 gh label create "$RUNNING_LABEL" --color "fbca04" --description "An agent is actively working on this issue right now" 2>/dev/null || true
@@ -103,7 +119,7 @@ run_agent() {
 
     echo ""
     echo "--------------------------------------------"
-    echo "  → ${agent} (${stage_label})"
+    echo "  → ${agent} (${stage_label}, model=$(resolve_model "${agent}"))"
     echo "--------------------------------------------"
 
     local instruction
@@ -127,6 +143,7 @@ EOF
 )
 
     claude \
+        $(agent_model_args "$agent") \
         -p "$instruction" \
         --dangerously-skip-permissions \
         --max-turns "${MAX_TURNS_PER_AGENT:-20}" \

--- a/deploy/agents/scripts/dispatch-by-stage.sh
+++ b/deploy/agents/scripts/dispatch-by-stage.sh
@@ -25,6 +25,10 @@ set -e
 
 [ -f /etc/environment ] && source /etc/environment
 
+# Shared claim-label helpers (stale `agent:running` reclaim).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+source "${SCRIPT_DIR}/claim-utils.sh"
+
 ISSUE_NUM="$1"
 STAGE="$2"
 
@@ -45,6 +49,10 @@ case "$STAGE" in
         ;;
 esac
 
+# Per-role model routing (heavy=Opus for dev/review, light=Sonnet for spec/qa).
+# Shared with the pipeline via model-utils.sh; override via PIPELINE_MODEL_*.
+source "${SCRIPT_DIR}/model-utils.sh"
+
 TIMESTAMP=$(date '+%Y-%m-%d_%H-%M-%S')
 LOG_FILE="/logs/dispatch_${ISSUE_NUM}_${STAGE}_${TIMESTAMP}.log"
 REPO_DIR="${REPO_DIR:-/workspace/repo}"
@@ -56,7 +64,7 @@ mkdir -p /logs
 exec > >(tee "$LOG_FILE") 2>&1
 
 echo "============================================"
-echo "  Dispatch · issue #${ISSUE_NUM} → ${STAGE} (${AGENT})"
+echo "  Dispatch · issue #${ISSUE_NUM} → ${STAGE} (${AGENT}, model=$(resolve_model "${AGENT}"))"
 echo "  Branch: ${BRANCH}"
 echo "  Started: $(date)"
 echo "============================================"
@@ -78,10 +86,17 @@ TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
 BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""')
 LABELS=$(echo "$ISSUE_JSON" | jq -r '.labels[].name')
 
-# 2. Idempotency check.
+# 2. Idempotency check. A live claim means another dispatch is in flight —
+#    skip. But a claim left behind by a hard-killed run (EXIT trap never fired)
+#    would block this task forever, so reclaim it if it's gone stale and carry
+#    on instead of bailing.
 if echo "$LABELS" | grep -qx "$RUNNING_LABEL"; then
-    echo "Issue #${ISSUE_NUM} already has '${RUNNING_LABEL}' label — another dispatch is in flight. Skipping."
-    exit 0
+    if reclaim_if_stale "$ISSUE_NUM"; then
+        echo "Issue #${ISSUE_NUM} had a STALE '${RUNNING_LABEL}' claim — reclaimed it, continuing."
+    else
+        echo "Issue #${ISSUE_NUM} already has '${RUNNING_LABEL}' label — another dispatch is in flight. Skipping."
+        exit 0
+    fi
 fi
 
 # Ensure the running label exists in the repo (idempotent).
@@ -145,6 +160,7 @@ EOF
 
 # 7. Run the agent.
 claude \
+    $(agent_model_args "$AGENT") \
     -p "$INSTRUCTION" \
     --dangerously-skip-permissions \
     --max-turns "${MAX_TURNS:-30}" \

--- a/deploy/agents/scripts/dispatch-epic-finish.sh
+++ b/deploy/agents/scripts/dispatch-epic-finish.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+set -e
+
+# dispatch-epic-finish.sh — on-demand "finish this epic" flow
+#
+# Triggered from the Dev Tycoon "🚀 Доделать эпик" button. Drives ONE epic to a
+# reviewable PR — it does NOT merge to main and does NOT close the epic; those
+# stay the owner's call (merge the PR, then move the epic to Done in the game).
+#
+# Why this exists: the per-task dispatch (dispatch-by-stage.sh) starts off
+# `main`, so a task whose partial work already lives on the shared nightly
+# branch (e.g. a dev run that hit --max-turns mid-TDD) looks "nothing to do"
+# and never finishes. This flow instead works ON the nightly branch, where that
+# WIP is, finishes each unfinished child task there, and lands the lot as the
+# daily PR with the same CI-gate the morning cron uses.
+#
+# Steps:
+#   1. Resolve child tasks of the epic (label `epic-<N>`).
+#   2. For each OPEN child not yet `done`: run a developer agent on the nightly
+#      branch to finish impl + tests and mark the task `done` (or, if already
+#      fully implemented on the branch, just verify + mark done).
+#   3. Push the nightly branch, open/refresh the daily PR, CI-gate → ready.
+#   4. Comment the epic with a status summary. Stop. (No merge, no epic close.)
+#
+# Args:
+#   $1 — GitHub issue number of the epic
+
+[ -f /etc/environment ] && source /etc/environment
+
+# Shared helpers (stale-claim reclaim, model routing, PR open/CI-gate).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+source "${SCRIPT_DIR}/claim-utils.sh"
+source "${SCRIPT_DIR}/model-utils.sh"
+source "${SCRIPT_DIR}/pr-utils.sh"
+
+EPIC_NUM="$1"
+if [[ -z "$EPIC_NUM" ]]; then
+    echo "Usage: dispatch-epic-finish.sh <epic_number>"
+    exit 1
+fi
+
+TODAY=$(date '+%Y-%m-%d')
+TIMESTAMP=$(date '+%Y-%m-%d_%H-%M-%S')
+LOG_FILE="/logs/epic_finish_${EPIC_NUM}_${TIMESTAMP}.log"
+REPO_DIR="${REPO_DIR:-/workspace/repo}"
+BRANCH="${BRANCH_OVERRIDE:-agents/nightly-${TODAY}}"
+RUNNING_LABEL="agent:running"
+MAX_TURNS_PER_TASK="${MAX_TURNS_PER_TASK:-${MAX_TURNS:-60}}"
+
+mkdir -p /logs
+exec > >(tee "$LOG_FILE") 2>&1
+
+echo "============================================"
+echo "  Epic finish · #${EPIC_NUM} → nightly branch ${BRANCH}"
+echo "  Started: $(date)"
+echo "============================================"
+
+# gh resolves the repo from the cwd remote — be inside the repo for every call.
+cd "$REPO_DIR" || { echo "Repo dir not found: ${REPO_DIR}"; exit 1; }
+
+# 1. Fetch the epic + sanity-check it really is one.
+EPIC_JSON=$(gh issue view "$EPIC_NUM" --json title,body,labels 2>&1) || {
+    echo "Failed to fetch epic #${EPIC_NUM}: $EPIC_JSON"; exit 1
+}
+EPIC_TITLE=$(echo "$EPIC_JSON" | jq -r '.title')
+EPIC_LABELS=$(echo "$EPIC_JSON" | jq -r '.labels[].name')
+if ! echo "$EPIC_LABELS" | grep -qx "epic"; then
+    echo "Issue #${EPIC_NUM} is missing the 'epic' label — refusing to run."; exit 1
+fi
+
+# 2. Idempotency on the epic claim (stale-claim aware, same as the dispatchers).
+if echo "$EPIC_LABELS" | grep -qx "$RUNNING_LABEL"; then
+    if reclaim_if_stale "$EPIC_NUM"; then
+        echo "Epic #${EPIC_NUM} had a STALE claim — reclaimed it, continuing."
+    else
+        echo "Epic #${EPIC_NUM} already has '${RUNNING_LABEL}' — another run in flight. Skipping."
+        exit 0
+    fi
+fi
+gh label create "$RUNNING_LABEL" --color "fbca04" --description "An agent is actively working on this issue right now" 2>/dev/null || true
+gh issue edit "$EPIC_NUM" --add-label "$RUNNING_LABEL" >/dev/null 2>&1 || true
+cleanup() {
+    gh issue edit "$EPIC_NUM" --remove-label "$RUNNING_LABEL" >/dev/null 2>&1 || true
+    echo "Finished at: $(date)"
+}
+trap cleanup EXIT
+
+# 3. Check out the shared nightly branch, seeded from its remote tip if present
+#    (so earlier WIP is here) else freshly off main.
+git fetch origin --quiet || true
+if git rev-parse --verify --quiet "origin/${BRANCH}" >/dev/null; then
+    git checkout -B "$BRANCH" "origin/${BRANCH}"
+else
+    git checkout -B "$BRANCH" "origin/main"
+fi
+
+# 4. Resolve OPEN child tasks of this epic that are not yet `done`.
+CHILDREN_JSON=$(gh issue list --label "epic-${EPIC_NUM}" --label task --state open --limit 100 \
+    --json number,title,labels 2>/dev/null || echo "[]")
+UNFINISHED=$(echo "$CHILDREN_JSON" | jq -r '
+    .[] | select((.labels // []) | map(.name) | contains(["done"]) | not) | .number' 2>/dev/null)
+TOTAL_CHILDREN=$(echo "$CHILDREN_JSON" | jq -r 'length' 2>/dev/null || echo 0)
+
+echo ">>> Epic #${EPIC_NUM} has ${TOTAL_CHILDREN} open child task(s); unfinished: $(echo ${UNFINISHED} | tr '\n' ' ' | sed 's/ $//')"
+
+FINISHED_NOW=""
+STILL_OPEN=""
+
+# 5. Finish each unfinished task on the nightly branch.
+for TASK in ${UNFINISHED}; do
+    echo ""
+    echo "--------------------------------------------"
+    echo "  → finishing task #${TASK} (developer, model=$(resolve_model developer))"
+    echo "--------------------------------------------"
+
+    # A stale claim on the task must not block us; a live one means skip.
+    TASK_LABELS=$(gh issue view "$TASK" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+    if echo "$TASK_LABELS" | grep -qx "$RUNNING_LABEL"; then
+        if ! reclaim_if_stale "$TASK"; then
+            echo "Task #${TASK} has a live '${RUNNING_LABEL}' — another agent is on it. Skipping."
+            STILL_OPEN="${STILL_OPEN} #${TASK}"
+            continue
+        fi
+    fi
+
+    TASK_JSON=$(gh issue view "$TASK" --json title,body 2>/dev/null || echo '{}')
+    TASK_TITLE=$(echo "$TASK_JSON" | jq -r '.title // ""')
+    TASK_BODY=$(echo "$TASK_JSON" | jq -r '.body // ""')
+
+    INSTRUCTION=$(cat <<EOF
+Ты — developer. Прочитай свою роль из .claude/agents/developer.md.
+
+Ты работаешь ПРЯМО на общей ночной ветке '${BRANCH}' (НЕ создавай новую ветку,
+НЕ переключайся на main). На этой ветке уже может лежать частично сделанная
+работа по этой задаче от прошлого прогона, который не доехал — сначала
+осмотрись: 'git log --oneline origin/main..HEAD' и поищи файлы по теме задачи.
+
+Задача #${TASK}: ${TASK_TITLE}
+
+Описание:
+${TASK_BODY}
+
+ЧТО НУЖНО:
+1. Если задача уже полностью реализована на этой ветке и тесты по ней есть —
+   НЕ переписывай, просто прогони 'dotnet test' (или нужный раннер), убедись
+   что зелёно, и переходи к шагу 4.
+2. Если есть частичная работа — доведи её до конца (TDD: красный → зелёный →
+   рефактор). Не начинай с нуля, если уже что-то написано.
+3. Если работы нет — реализуй задачу с тестами.
+4. Закоммить изменения с упоминанием #${TASK} в commit message (это связывает
+   коммит с задачей в Dev Tycoon). НЕ пушь сам и НЕ открывай PR — обёртка
+   сделает это в конце.
+5. ТОЛЬКО когда реализация готова и тесты зелёные — поставь задаче метку done:
+   gh issue edit ${TASK} --add-label done   (НЕ закрывай issue).
+
+Если упёрся в лимит ходов и не успел — это нормально, обёртка увидит. Работай
+только над #${TASK}, чужие задачи не трогай.
+EOF
+)
+
+    claude \
+        $(agent_model_args developer) \
+        -p "$INSTRUCTION" \
+        --dangerously-skip-permissions \
+        --max-turns "${MAX_TURNS_PER_TASK}" \
+        --output-format stream-json \
+        --verbose \
+        || echo "[warn] developer exited non-zero on #${TASK} (continuing)"
+
+    # Commit any leftovers the agent didn't commit itself.
+    if ! git diff --quiet || ! git diff --staged --quiet; then
+        git add -A
+        git commit -m "[developer] finish #${TASK} (epic #${EPIC_NUM}, leftover changes)" || true
+    fi
+
+    # Did the task reach 'done'? (The agent adds it on success.)
+    if gh issue view "$TASK" --json labels --jq '.labels[].name' 2>/dev/null | grep -qx "done"; then
+        echo ">>> #${TASK} is now done."
+        FINISHED_NOW="${FINISHED_NOW} #${TASK}"
+    else
+        echo ">>> #${TASK} still not done (likely hit max-turns) — tagging dev-stuck for owner review."
+        gh issue edit "$TASK" --add-label "dev-stuck" >/dev/null 2>&1 || true
+        STILL_OPEN="${STILL_OPEN} #${TASK}"
+    fi
+done
+
+# 6. Push whatever landed on the nightly branch.
+COMMITS_AHEAD=$(git log --oneline origin/main..HEAD 2>/dev/null | wc -l | tr -d ' ')
+if [ "${COMMITS_AHEAD}" -gt 0 ]; then
+    git push origin "$BRANCH" || echo "[warn] push failed"
+fi
+
+# 7. Recompute child completion after the run.
+CHILDREN_AFTER=$(gh issue list --label "epic-${EPIC_NUM}" --label task --state all --limit 100 \
+    --json number,labels 2>/dev/null || echo "[]")
+DONE_CNT=$(echo "$CHILDREN_AFTER" | jq -r '[.[] | select(((.labels // []) | map(.name) | contains(["done"])) or (.state == "CLOSED"))] | length' 2>/dev/null || echo 0)
+ALL_CNT=$(echo "$CHILDREN_AFTER" | jq -r 'length' 2>/dev/null || echo 0)
+
+# 8. Open / refresh the daily PR with the CI-gate (only if there's something).
+PR_LINE="PR не открывался (нет коммитов впереди main)."
+if [ "${COMMITS_AHEAD}" -gt 0 ]; then
+    PR_BODY=$(cat <<EOF
+## Доделка эпика #${EPIC_NUM} — ${EPIC_TITLE}
+
+Запущено из Dev Tycoon («Доделать эпик»). Агент-разработчик добивал незаконченные
+задачи прямо на ночной ветке \`${BRANCH}\`.
+
+**Дочерние задачи:** ${DONE_CNT}/${ALL_CNT} done
+**Доделаны в этом прогоне:** ${FINISHED_NOW:-—}
+**Ещё открыты:** ${STILL_OPEN:-—}
+
+Когда CI зелёный и PR станет ready — смержи в main и передвинь эпик #${EPIC_NUM}
+в Done на доске.
+
+_(Automated · dispatch-epic-finish)_
+EOF
+)
+    if open_or_refresh_pr "$BRANCH" "Доделка эпика #${EPIC_NUM} · ${TODAY}" "$PR_BODY"; then
+        PR_LINE="PR #${PR_NUMBER} (${PR_CI:-?}) — ${PR_URL}"
+    else
+        PR_LINE="не удалось открыть PR (см. лог ${LOG_FILE##*/})."
+    fi
+fi
+
+# 9. Summary comment on the epic.
+gh issue comment "$EPIC_NUM" --body "$(cat <<EOF
+🚀 **Доделка эпика прогнана** (из Dev Tycoon).
+
+- Дочерние задачи: **${DONE_CNT}/${ALL_CNT} done**
+- Доделаны сейчас: ${FINISHED_NOW:-—}
+- Ещё открыты: ${STILL_OPEN:-—}
+- ${PR_LINE}
+
+Мерж в main и закрытие эпика — за тобой (флоу до этого не доходит специально).
+_(Dev Tycoon · dispatch-epic-finish)_
+EOF
+)" || true
+
+git checkout main 2>/dev/null || true
+echo ""
+echo "Epic finish done. ${DONE_CNT}/${ALL_CNT} child tasks done."

--- a/deploy/agents/scripts/model-utils.sh
+++ b/deploy/agents/scripts/model-utils.sh
@@ -1,0 +1,42 @@
+# model-utils.sh — shared per-role model routing for the agent pipeline.
+#
+# Why: Opus costs roughly 5x Sonnet at API rates. Since the 2026-06-15 billing
+# split, a headless `claude -p` run no longer draws on the subscription's
+# interactive pool — it spends a separate monthly agent credit at API rates.
+# To stretch that credit, the code-heavy roles (write / break down / review)
+# run on Opus, where the extra capability pays for itself, and the planning /
+# pedagogy / text / QA roles run on Sonnet.
+#
+# Routing keys off the role/phase name each script already passes to its agent
+# runner, covering both naming schemes in use:
+#   - run-pipeline.sh phase labels: `developer`, `tech-lead-breakdown`,
+#     `tech-lead-review`, `product`, `methodist`, `native-reviewer`, `qa`
+#   - dispatch / run-agent role names: `developer`, `tech-lead`, `designer`, `qa`, …
+#
+# Overrides (either tier, via env):
+#   PIPELINE_MODEL_HEAVY=sonnet  → run the whole pipeline cheap
+#   PIPELINE_MODEL_LIGHT=opus    → put everything back on Opus
+#
+# Sourced — defines functions and (overridable) config, runs nothing on its own.
+
+HEAVY_MODEL="${PIPELINE_MODEL_HEAVY:-opus}"
+LIGHT_MODEL="${PIPELINE_MODEL_LIGHT:-sonnet}"
+
+# resolve_model <role/phase name> → prints the model alias for that agent.
+# `tech-lead-*` covers the run-pipeline phase variants (breakdown / review);
+# bare `tech-lead` covers the dispatch + legacy role name. Everything else
+# (product / designer / methodist / native-reviewer / qa) is light.
+resolve_model() {
+    case "$1" in
+        developer|tech-lead|tech-lead-*) echo "${HEAVY_MODEL}" ;;
+        *)                               echo "${LIGHT_MODEL}" ;;
+    esac
+}
+
+# agent_model_args <role/phase name> → prints `--model <alias> ` for splicing
+# into a `claude` invocation, or nothing if the model can't be resolved.
+agent_model_args() {
+    local model
+    model="$(resolve_model "$1")"
+    [ -n "${model}" ] && printf -- '--model %s ' "${model}"
+}

--- a/deploy/agents/scripts/pick-next-task.sh
+++ b/deploy/agents/scripts/pick-next-task.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+# Shared claim-label helpers (stale `agent:running` reclaim). Sourced from the
+# script's own dir so host bind-mount edits apply without an image rebuild.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=claim-utils.sh
+source "${SCRIPT_DIR}/claim-utils.sh"
+
 # pick-next-task.sh — deterministic task picker for the dev loop.
 #
 # Walks the active sprint plan's epics in declared order and returns the
@@ -28,9 +34,11 @@ set -euo pipefail
 #      `done` (already shipped tonight), `dev-stuck` (a previous dev iteration
 #      hit max-turns; needs human triage, skip), and `agent:running` (another
 #      agent has already claimed it — don't double-build the same task). The
-#      dev loop sets `agent:running` while working and clears it on return; a
-#      claim left stale by a killed run needs the label removed by hand, same
-#      as `dev-stuck`.
+#      dev loop sets `agent:running` while working and clears it on return. A
+#      claim left stale by a HARD-KILLED run (OOM / container stop / reboot —
+#      the EXIT trap never fired) is reclaimed automatically below once it is
+#      older than STALE_CLAIM_MINUTES, so a crash mid-build self-heals on the
+#      next pass instead of stalling the epic until a human intervenes.
 #   5. The script returns the first eligible task across all epics in
 #      order. If nothing matches → exit empty.
 
@@ -61,6 +69,23 @@ EPICS=$(printf '%s\n%s\n' "${PLAN_EPICS}" "${DOING_EPICS}" | awk 'NF && !seen[$0
 
 # Pre-fetch all open task issues once (cheaper than per-epic queries).
 ALL_TASKS_JSON=$(gh issue list --label task --state open --limit 200 --json number,title,labels 2>/dev/null)
+
+# Self-heal dead claims before selecting. Any open task still wearing
+# `agent:running` from a run that was hard-killed (so its EXIT trap never
+# cleared the label) would otherwise be skipped forever. Reclaim the stale
+# ones, then re-fetch so the eligibility filter below sees the cleared labels.
+RUNNING_NUMS=$(echo "${ALL_TASKS_JSON}" \
+    | jq -r '.[] | select((.labels // []) | map(.name) | contains(["agent:running"])) | .number' 2>/dev/null)
+RECLAIMED_ANY=0
+for N in ${RUNNING_NUMS}; do
+    if reclaim_if_stale "${N}"; then
+        echo "pick-next-task: reclaimed stale ${RUNNING_LABEL} on #${N}" >&2
+        RECLAIMED_ANY=1
+    fi
+done
+if [ "${RECLAIMED_ANY}" -eq 1 ]; then
+    ALL_TASKS_JSON=$(gh issue list --label task --state open --limit 200 --json number,title,labels 2>/dev/null)
+fi
 
 for EPIC in ${EPICS}; do
     # Filter to tasks under this epic, sort ascending, drop done/dev-stuck/non-qa-prepared.

--- a/deploy/agents/scripts/pr-utils.sh
+++ b/deploy/agents/scripts/pr-utils.sh
@@ -1,0 +1,57 @@
+# pr-utils.sh — shared "open / refresh the nightly PR + CI-gate" helper.
+#
+# Factored from the proven block in run-qa.sh so other on-demand flows (the
+# "finish epic" dispatch) can land work as a reviewable PR the same way the
+# morning cron does — without duplicating the REST/CI-gate quirks.
+#
+# open_or_refresh_pr <branch> <title> <body>
+#   - Opens a DRAFT PR (base=main, head=<branch>), or refreshes the body of the
+#     existing open PR via REST PATCH (gh pr edit fails on repos with classic
+#     Projects attached — REST avoids the GraphQL projects enumeration).
+#   - Waits up to CI_GATE_SECONDS for GitHub Actions. Green → promote to "ready
+#     for review". Red/timeout → leave as draft and comment the failing checks.
+#   - Sets globals PR_NUMBER, PR_URL, PR_CI ("green" | "red") for the caller.
+#     Returns 1 (and leaves PR_NUMBER empty) if the PR could not be created.
+#
+# Sourced — defines a function, runs nothing on its own.
+
+CI_GATE_SECONDS="${CI_GATE_SECONDS:-900}"
+
+open_or_refresh_pr() {
+    local branch="$1" title="$2" body="$3"
+    local repo_slug existing
+    PR_NUMBER=""; PR_URL=""; PR_CI=""
+
+    repo_slug=$(git config --get remote.origin.url | sed -E 's#.*github\.com[:/]([^/]+/[^/.]+).*#\1#')
+    existing=$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number' 2>/dev/null || true)
+
+    if [ -n "${existing}" ]; then
+        echo ">>> PR #${existing} already exists for ${branch}. Updating body via REST."
+        gh api "repos/${repo_slug}/pulls/${existing}" --method PATCH -f body="${body}" --jq .html_url >/dev/null 2>&1 || true
+        PR_NUMBER="${existing}"
+    else
+        PR_NUMBER=$(gh pr create --title "${title}" --body "${body}" --base main --head "${branch}" --draft \
+            | grep -oE '/pull/[0-9]+' | grep -oE '[0-9]+' || true)
+    fi
+    [ -z "${PR_NUMBER}" ] && return 1
+    PR_URL="https://github.com/${repo_slug}/pull/${PR_NUMBER}"
+
+    echo ">>> Waiting for CI on PR #${PR_NUMBER} (up to ${CI_GATE_SECONDS}s)..."
+    if timeout "${CI_GATE_SECONDS}" gh pr checks "${PR_NUMBER}" --watch --fail-fast >/dev/null 2>&1; then
+        gh pr ready "${PR_NUMBER}" 2>/dev/null || true
+        echo ">>> CI green → PR #${PR_NUMBER} promoted to ready for review."
+        PR_CI="green"
+    else
+        local failed
+        failed=$(gh pr checks "${PR_NUMBER}" --json name,state,link \
+            --jq '.[] | select(.state != "SUCCESS") | "- " + .name + " (" + .state + ") " + .link' 2>/dev/null || echo "- see Actions tab")
+        gh pr comment "${PR_NUMBER}" --body "🚧 Оставлен в draft — CI не зелёный.
+
+${failed}
+
+Следующему developer-слоту стоит взять это как priority #1." 2>/dev/null || true
+        echo ">>> CI red/timeout → PR #${PR_NUMBER} stays draft."
+        PR_CI="red"
+    fi
+    return 0
+}

--- a/deploy/agents/scripts/run-agent.sh
+++ b/deploy/agents/scripts/run-agent.sh
@@ -4,6 +4,11 @@ set -e
 # Load environment
 source /etc/environment
 
+# Per-role model routing (heavy=Opus for developer/tech-lead, light=Sonnet for
+# product/designer). Shared with the pipeline; override via PIPELINE_MODEL_*.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+source "${SCRIPT_DIR}/model-utils.sh"
+
 AGENT_NAME="$1"
 TIMESTAMP=$(date '+%Y-%m-%d_%H-%M')
 LOG_FILE="/logs/${AGENT_NAME}_${TIMESTAMP}.log"
@@ -55,8 +60,9 @@ BRANCH="${BRANCH_PREFIX}/${TIMESTAMP}"
 git checkout -b "${BRANCH}"
 
 # Run Claude Code
-echo "Running Claude Code for ${AGENT_NAME}..."
+echo "Running Claude Code for ${AGENT_NAME} (model=$(resolve_model "${AGENT_NAME}"))..."
 claude \
+    $(agent_model_args "${AGENT_NAME}") \
     -p "${INSTRUCTION}" \
     --dangerously-skip-permissions \
     --max-turns "${MAX_TURNS:-30}" \

--- a/deploy/agents/scripts/run-pipeline.sh
+++ b/deploy/agents/scripts/run-pipeline.sh
@@ -180,6 +180,12 @@ agent_plugin_args() {
     done
 }
 
+# --- Per-role model selection -------------------------------------------------
+# Heavy (Opus) for code roles, light (Sonnet) for planning / review / text.
+# Shared with the dispatch + legacy runners via model-utils.sh — see it for the
+# full rationale and the PIPELINE_MODEL_HEAVY / PIPELINE_MODEL_LIGHT overrides.
+source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/model-utils.sh"
+
 # --- Shared context (built once per pipeline invocation) ----------------------
 build_shared_context() {
     {
@@ -258,7 +264,7 @@ run_agent() {
     local stderr_file="${LOG_DIR}/${phase_id}.stderr.log"
 
     echo ""
-    echo ">>> [${phase_id}] starting at $(date) (agent=${agent}, max_turns=${max_turns})"
+    echo ">>> [${phase_id}] starting at $(date) (agent=${agent}, model=$(resolve_model "${agent}"), max_turns=${max_turns})"
 
     # Commit any leftover from a previous phase before starting fresh.
     if ! git diff --quiet || ! git diff --staged --quiet || [ -n "$(git ls-files --others --exclude-standard)" ]; then
@@ -272,6 +278,7 @@ run_agent() {
     # shellcheck disable=SC2046
     claude \
         $(agent_plugin_args "${agent}") \
+        $(agent_model_args "${agent}") \
         -p "${instruction}" \
         --dangerously-skip-permissions \
         --max-turns "${max_turns}" \


### PR DESCRIPTION
Commits the agent-pipeline scripts that have been running off the local bind-mount all session but were never in the repo. `deploy/agents` only — no `src/` change, no bot/k8s impact.

- **Self-heal** (`claim-utils.sh`): auto-reclaim stale `agent:running` claims left by a hard-killed run (OOM / container stop — the EXIT trap never fires), so a crash mid-build recovers on the next pass instead of jamming the picker forever. Wired into `pick-next-task.sh` + both dispatchers.
- **Model routing** (`model-utils.sh`): Opus for code roles (developer / tech-lead), Sonnet for the rest; overridable via `PIPELINE_MODEL_HEAVY/LIGHT`.
- **Finish-epic engine** (`pr-utils.sh` + `dispatch-epic-finish.sh`): finishes an epic's unfinished tasks on the nightly branch and opens/refreshes the daily PR (CI-gated). This is the script the new tycoon «Доделать эпик» button calls.

All 9 scripts lint clean under bash 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)