### PR TITLE
fix(notifications): stop daily-return double-send via atomic claim

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -274,6 +274,7 @@ Location: `src/Persistence/Migrations/`. Test greps the migration class name (af
 | `AddTrialBonusDays` | Cumulative referral trial-bonus days on User; lets bonuses stack and survive trial expiry without rewriting RegisteredAtUtc. |
 | `AddUserNotificationsEnabled` | Per-user notifications opt-out flag on User (default on); toggled from the mini-app Profile, honoured by the D1+ return-push dispatch. |
 | `AddNotificationTriggers` | NotificationTrigger table (per-source last-sent timestamp + variant) backing the 7-day cooldown of the D1+ return-push dispatch. |
+| `MakeNotificationTriggerUnique` | Dedups existing rows and makes the NotificationTrigger (UserId, Source) index unique, so the atomic claim-before-send can't double-fire the return push across overlapping dispatch runs (incident 2026-06-17). |
 
 ---
 

--- a/src/Application/Common/ITraleDbContext.cs
+++ b/src/Application/Common/ITraleDbContext.cs
@@ -26,4 +26,15 @@ public interface ITraleDbContext
     EntityEntry Entry(object entity);
 
     Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically claims the notification slot for (<paramref name="userId"/>, <paramref name="source"/>):
+    /// inserts the trigger, or refreshes it only if the previous send is older than
+    /// <paramref name="cutoff"/> (cooldown elapsed). Returns <c>true</c> if THIS caller won the
+    /// claim and should therefore send the push; <c>false</c> if a fresh trigger already exists
+    /// (another concurrent run holds it). Backed by a unique (UserId, Source) index so overlapping
+    /// dispatch runs collapse to a single send — see the 2026-06-17 double-send incident.
+    /// </summary>
+    Task<bool> TryClaimNotificationTriggerAsync(
+        long userId, string source, string? variant, DateTime now, DateTime cutoff, CancellationToken cancellationToken);
 }

--- a/src/Application/Notifications/DailyReturnNotificationService.cs
+++ b/src/Application/Notifications/DailyReturnNotificationService.cs
@@ -48,28 +48,12 @@ public class DailyReturnNotificationService(
         if (users.Count == 0) return;
 
         var userMap = users.ToDictionary(u => u.Id);
-        var telegramIds = users.Select(u => u.TelegramId).ToList();
-
-        var triggers = await db.NotificationTriggers
-            .Where(t => telegramIds.Contains(t.UserId) && t.Source == Source)
-            .ToListAsync(ct);
-        var triggerMap = triggers.ToDictionary(t => t.UserId);
+        var cooldownCutoff = now - CooldownPeriod;
 
         foreach (var progress in progressList)
         {
             if (!userMap.TryGetValue(progress.UserId, out var user))
                 continue;
-
-            triggerMap.TryGetValue(user.TelegramId, out var trigger);
-
-            // Cooldown: skip if pinged within the last 7 days.
-            if (trigger != null && trigger.LastSentAt > now - CooldownPeriod)
-            {
-                _logger.LogInformation(
-                    "User {TelegramId} skipped — daily-return cooldown (lastSentAt={LastSentAt})",
-                    user.TelegramId, trigger.LastSentAt);
-                continue;
-            }
 
             var completedLessons = ParseCompletedLessons(progress.CompletedLessonsJson);
             var validModules = completedLessons
@@ -88,27 +72,22 @@ public class DailyReturnNotificationService(
             var availableXp = Math.Max(0, progress.Xp - progress.XpSpent);
             var variant = availableXp >= CheapestTreatXp ? "feed" : "earn";
 
+            // Claim the slot BEFORE sending: the cooldown check and the trigger write are now a
+            // single atomic step, so two overlapping dispatch runs can't both pass the check and
+            // both send (the 2026-06-17 double-send). Losing the claim means another run already
+            // sent it, or the 7-day cooldown is still active — either way, skip.
+            var claimed = await db.TryClaimNotificationTriggerAsync(
+                user.TelegramId, Source, variant, DateTime.UtcNow, cooldownCutoff, ct);
+            if (!claimed)
+            {
+                _logger.LogInformation(
+                    "User {TelegramId} skipped — daily-return already claimed (cooldown or concurrent run)",
+                    user.TelegramId);
+                continue;
+            }
+
             await notificationService.SendDailyReturnPushAsync(
                 user, moduleId, moduleId, nextLessonId, variant, availableXp, ct);
-
-            var sentAt = DateTime.UtcNow;
-            if (trigger != null)
-            {
-                trigger.LastSentAt = sentAt;
-                trigger.Variant = variant;
-            }
-            else
-            {
-                db.NotificationTriggers.Add(new NotificationTrigger
-                {
-                    Id = Guid.NewGuid(),
-                    UserId = user.TelegramId,
-                    Source = Source,
-                    LastSentAt = sentAt,
-                    Variant = variant
-                });
-            }
-            await db.SaveChangesAsync(ct);
         }
     }
 

--- a/src/Persistence/Configurations/NotificationTriggerConfiguration.cs
+++ b/src/Persistence/Configurations/NotificationTriggerConfiguration.cs
@@ -18,6 +18,10 @@ public class NotificationTriggerConfiguration : IEntityTypeConfiguration<Notific
         // UserId stores the Telegram ID (long), not the User PK (Guid). No FK relationship:
         // HasPrincipalKey(TelegramId) would promote TelegramId to an alternate key, breaking
         // EF identity tracking in tests that share TelegramId values.
-        builder.HasIndex(x => new { x.UserId, x.Source });
+        //
+        // Unique: one trigger row per (user, source). This is the backstop that lets
+        // TryClaimNotificationTriggerAsync use INSERT … ON CONFLICT so concurrent/overlapping
+        // dispatch runs can't each insert a row and double-send (incident 2026-06-17).
+        builder.HasIndex(x => new { x.UserId, x.Source }).IsUnique();
     }
 }

--- a/src/Persistence/Migrations/20260618105646_MakeNotificationTriggerUnique.Designer.cs
+++ b/src/Persistence/Migrations/20260618105646_MakeNotificationTriggerUnique.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Persistence;
@@ -11,9 +12,11 @@ using Persistence;
 namespace Persistence.Migrations
 {
     [DbContext(typeof(TraleDbContext))]
-    partial class TraleDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618105646_MakeNotificationTriggerUnique")]
+    partial class MakeNotificationTriggerUnique
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/Migrations/20260618105646_MakeNotificationTriggerUnique.cs
+++ b/src/Persistence/Migrations/20260618105646_MakeNotificationTriggerUnique.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeNotificationTriggerUnique : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_NotificationTriggers_UserId_Source",
+                table: "NotificationTriggers");
+
+            // Collapse pre-existing duplicate (UserId, Source) rows before the unique index is
+            // added — otherwise creation fails. The double-send bug (2026-06-17) left 129 such
+            // duplicate trigger rows in prod. Keep the most recent send per (user, source)
+            // (greatest LastSentAt, Id as a deterministic tie-breaker) and delete the rest.
+            migrationBuilder.Sql(
+                """
+                DELETE FROM "NotificationTriggers" a
+                USING "NotificationTriggers" b
+                WHERE a."UserId" = b."UserId"
+                  AND a."Source" = b."Source"
+                  AND (a."LastSentAt" < b."LastSentAt"
+                       OR (a."LastSentAt" = b."LastSentAt" AND a."Id" < b."Id"));
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationTriggers_UserId_Source",
+                table: "NotificationTriggers",
+                columns: new[] { "UserId", "Source" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_NotificationTriggers_UserId_Source",
+                table: "NotificationTriggers");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationTriggers_UserId_Source",
+                table: "NotificationTriggers",
+                columns: new[] { "UserId", "Source" });
+        }
+    }
+}

--- a/src/Persistence/TraleDbContext.cs
+++ b/src/Persistence/TraleDbContext.cs
@@ -35,6 +35,51 @@ public class TraleDbContext : DbContext, ITraleDbContext
     {
         return await Database.BeginTransactionAsync(cancellationToken);
     }
+
+    public async Task<bool> TryClaimNotificationTriggerAsync(
+        long userId, string source, string? variant, DateTime now, DateTime cutoff, CancellationToken cancellationToken)
+    {
+        if (Database.IsNpgsql())
+        {
+            // Single-statement atomic claim. The unique (UserId, Source) index turns the
+            // second concurrent caller into an ON CONFLICT: it refreshes the row only when the
+            // previous send is older than the cooldown cutoff, otherwise it touches nothing.
+            // Affected-row count is 1 exactly when THIS caller inserted or refreshed the slot,
+            // and 0 when a fresh trigger already exists — so concurrent runs can't both "win".
+            var affected = await Database.ExecuteSqlInterpolatedAsync($"""
+                INSERT INTO "NotificationTriggers" ("Id", "UserId", "Source", "LastSentAt", "Variant")
+                VALUES ({Guid.NewGuid()}, {userId}, {source}, {now}, {variant})
+                ON CONFLICT ("UserId", "Source") DO UPDATE
+                    SET "LastSentAt" = EXCLUDED."LastSentAt", "Variant" = EXCLUDED."Variant"
+                    WHERE "NotificationTriggers"."LastSentAt" <= {cutoff}
+                """, cancellationToken);
+            return affected > 0;
+        }
+
+        // Non-relational providers (EF in-memory unit tests) can't run the raw upsert and don't
+        // enforce the unique index. Emulate the claim with tracked entities; these tests are
+        // single-threaded, so atomicity isn't needed — only the same win/lose decision.
+        var existing = await NotificationTriggers
+            .FirstOrDefaultAsync(t => t.UserId == userId && t.Source == source, cancellationToken);
+        if (existing is null)
+        {
+            NotificationTriggers.Add(new NotificationTrigger
+            {
+                Id = Guid.NewGuid(), UserId = userId, Source = source, LastSentAt = now, Variant = variant
+            });
+            await SaveChangesAsync(cancellationToken);
+            return true;
+        }
+        if (existing.LastSentAt <= cutoff)
+        {
+            existing.LastSentAt = now;
+            existing.Variant = variant;
+            await SaveChangesAsync(cancellationToken);
+            return true;
+        }
+        return false;
+    }
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfiguration(new UserConfiguration());

--- a/tests/IntegrationTests/Notifications/DailyReturnDoubleSendTests.cs
+++ b/tests/IntegrationTests/Notifications/DailyReturnDoubleSendTests.cs
@@ -1,0 +1,73 @@
+using Application.Common;
+using Application.Common.Interfaces;
+using Domain.Entities;
+using FluentAssertions;
+using IntegrationTests.DSL;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace IntegrationTests.Notifications;
+
+/// <summary>
+/// Regression for the prod incident (2026-06-17): 129 users received the daily-return
+/// push twice because two dispatch runs overlapped (replica/rolling-deploy), each loaded
+/// the cooldown state once and neither saw the other's writes. The fix claims the
+/// NotificationTrigger slot atomically (unique index + INSERT … ON CONFLICT) BEFORE
+/// sending, so concurrent runs collapse to a single push per (user, source).
+/// </summary>
+public class DailyReturnDoubleSendTests : TestBase
+{
+    private const long EligibleTelegramId = 770001L;
+
+    [Test]
+    public async Task DispatchAsync_RunConcurrently_RecordsExactlyOneTriggerPerUser()
+    {
+        await SeedEligibleUserAsync(EligibleTelegramId);
+
+        // Fire several dispatch cycles at once, each in its own DI scope (its own
+        // DbContext) — this reproduces two app instances dispatching in parallel.
+        var concurrentRuns = Enumerable.Range(0, 6).Select(_ => Task.Run(async () =>
+        {
+            await using var scope = _testServer.Services.CreateAsyncScope();
+            var dispatcher = scope.ServiceProvider.GetRequiredService<IDailyReturnNotificationService>();
+            await dispatcher.DispatchAsync(CancellationToken.None);
+        }));
+
+        await Task.WhenAll(concurrentRuns);
+
+        await using var verifyScope = _testServer.Services.CreateAsyncScope();
+        var db = verifyScope.ServiceProvider.GetRequiredService<ITraleDbContext>();
+        var triggerCount = await db.NotificationTriggers
+            .CountAsync(t => t.UserId == EligibleTelegramId && t.Source == "daily_return");
+
+        triggerCount.Should().Be(1,
+            because: "concurrent dispatch runs must collapse to a single daily-return trigger (and thus a single push)");
+    }
+
+    private async Task SeedEligibleUserAsync(long telegramId)
+    {
+        await using var scope = _testServer.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ITraleDbContext>();
+
+        var user = Create.User(telegramId, "ReturnTest");
+        user.NotificationsEnabled = true;
+        db.Users.Add(user);
+        await db.SaveChangesAsync(CancellationToken.None);
+
+        db.MiniAppUserProgresses.Add(new MiniAppUserProgress
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            LastPlayedAtUtc = DateTime.UtcNow.AddDays(-2),
+            CompletedLessonsJson = """{"alphabet-progressive":[1,2,3]}""",
+            Xp = 0,
+            XpSpent = 0,
+            Streak = 0,
+            Hearts = 0,
+            MaxHearts = 0,
+            CreatedAtUtc = DateTime.UtcNow.AddDays(-2),
+            UpdatedAtUtc = DateTime.UtcNow.AddDays(-2)
+        });
+        await db.SaveChangesAsync(CancellationToken.None);
+    }
+}


### PR DESCRIPTION
## Инцидент

2026-06-17 ~10:00 UTC **129 пользователей** получили daily-return пуш дважды (один и тот же «покорми Бомбору», но с разными фактами). Пруфы из прод-базы:

- `NotificationTriggers`: у затронутых юзеров **по 2 строки** `Source=daily_return` с `LastSentAt` в пределах 19–440 мс.
- Дубли у 129 из 248 получателей за прогон → частичное перекрытие двух прогонов.

## Причина

Два перекрывающихся прогона `ReturnPushWorker` (две реплики либо rolling-deploy в окне запуска). Диспатчер:
1. грузил `triggerMap` (кто уже получил) **один раз** в начале,
2. слал пуш,
3. и **только потом** писал триггер.

Параллельный прогон видел тот же устаревший снимок → слал второй раз. Индекс `(UserId, Source)` был **не уникальный**, поэтому БД дубль не блокировала.

## Фикс — atomic claim перед отправкой

Проверка cooldown и запись триггера теперь **один атомарный шаг**, пуш уходит только если слот удалось застолбить:

- `ITraleDbContext.TryClaimNotificationTriggerAsync(...)` — `INSERT … ON CONFLICT (UserId, Source) DO UPDATE … WHERE LastSentAt <= cutoff` на Postgres (EF-фолбэк для in-memory юнит-тестов).
- `DailyReturnNotificationService`: claim → send только при выигранном claim; устаревший `triggerMap` удалён.
- Индекс `(UserId, Source)` → **unique** (бэкстоп на уровне БД).
- Миграция `MakeNotificationTriggerUnique` **дедупит 129 существующих дублей** (оставляет самый свежий) перед созданием unique-индекса — иначе создание упадёт. Прод-дедуп произойдёт на деплое.

Дубль невозможен даже при двух репликах.

## Тесты

- **Интеграционный** (Testcontainers-Postgres), red→green: 6 параллельных `DispatchAsync` давали 6 триггеров → теперь ровно **1**.
- Юнит диспатчера 7/7, Application 121/121, Domain 68/68, нотификационные Infrastructure 17/17.

## Трейд-офф

Claim теперь до отправки: если отправка в Telegram упадёт, триггер уже записан → юзер пропускается до конца cooldown (7 дней). Сознательно — лучше пропустить, чем спамить.

🤖 Generated with [Claude Code](https://claude.com/claude-code)