### PR TITLE
feat(onboarding): contextual, time-spread nudges after the welcome win

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -276,6 +276,7 @@ Location: `src/Persistence/Migrations/`. Test greps the migration class name (af
 | `AddUserNotificationsEnabled` | Per-user notifications opt-out flag on User (default on); toggled from the mini-app Profile, honoured by the D1+ return-push dispatch. |
 | `AddNotificationTriggers` | NotificationTrigger table (per-source last-sent timestamp + variant) backing the 7-day cooldown of the D1+ return-push dispatch. |
 | `MakeNotificationTriggerUnique` | Dedups existing rows and makes the NotificationTrigger (UserId, Source) index unique, so the atomic claim-before-send can't double-fire the return push across overlapping dispatch runs (incident 2026-06-17). |
+| `AddOnboardingHintsJson` | Adds nullable OnboardingHintsJson to MiniAppUserProgress — persisted state (seen hints + lastShownAt) for the contextual, time-spread onboarding nudges. |
 
 ---
 

--- a/src/Application/MiniApp/Commands/MarkOnboardingHintSeen.cs
+++ b/src/Application/MiniApp/Commands/MarkOnboardingHintSeen.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common;
+using Application.Onboarding;
+using MediatR;
+
+namespace Application.MiniApp.Commands;
+
+/// <summary>
+/// Records that the mini-app surfaced an onboarding hint to the user, so it isn't shown again
+/// and the ~20h gate to the next hint starts. Unknown hint keys are rejected.
+/// </summary>
+public class MarkOnboardingHintSeen : IRequest<bool>
+{
+    public required Guid UserId { get; init; }
+    public required string HintKey { get; init; }
+
+    public class Handler(ITraleDbContext dbContext) : IRequestHandler<MarkOnboardingHintSeen, bool>
+    {
+        public async Task<bool> Handle(MarkOnboardingHintSeen request, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(request.HintKey) || !OnboardingHints.Order.Contains(request.HintKey))
+            {
+                return false;
+            }
+
+            var progress = await MiniAppHelpers.LoadOrCreateProgressAsync(dbContext, request.UserId, ct);
+            progress.OnboardingHintsJson =
+                OnboardingState.MarkSeen(progress.OnboardingHintsJson, request.HintKey, DateTime.UtcNow);
+            await dbContext.SaveChangesAsync(ct);
+            return true;
+        }
+    }
+}

--- a/src/Application/MiniApp/Queries/GetMiniAppProfile.cs
+++ b/src/Application/MiniApp/Queries/GetMiniAppProfile.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Application.Common;
 using Application.Common.Interfaces.MiniApp;
+using Application.Onboarding;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -50,6 +51,13 @@ public class GetMiniAppProfile : IRequest<GetMiniAppProfileResult>
             const long ownerTelegramId = 309149393;
             var isOwner = user.TelegramId == ownerTelegramId;
 
+            // Contextual onboarding: the next gentle nudge for this user (or null), time-spread
+            // so only one new hint surfaces per ~20h. The mini-app marks it seen when shown.
+            var onboardingHint = OnboardingHints.ResolveActiveHint(
+                OnboardingState.BuildSignals(progress, vocabCount),
+                OnboardingState.Parse(progress.OnboardingHintsJson),
+                now);
+
             return new GetMiniAppProfileResult
             {
                 Authenticated = true,
@@ -65,7 +73,8 @@ public class GetMiniAppProfile : IRequest<GetMiniAppProfileResult>
                 SubscriptionPlan = user.SubscriptionPlan?.ToString(),
                 SubscribedUntil = user.SubscribedUntil,
                 IsOwner = isOwner,
-                NotificationsEnabled = user.NotificationsEnabled
+                NotificationsEnabled = user.NotificationsEnabled,
+                OnboardingHint = onboardingHint
             };
         }
     }
@@ -88,4 +97,6 @@ public class GetMiniAppProfileResult
     public DateTime? SubscribedUntil { get; init; }
     public bool IsOwner { get; init; }
     public bool NotificationsEnabled { get; init; }
+    /// <summary>Active contextual-onboarding hint key for this user, or null. See Application.Onboarding.</summary>
+    public string? OnboardingHint { get; init; }
 }

--- a/src/Application/Onboarding/OnboardingHints.cs
+++ b/src/Application/Onboarding/OnboardingHints.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+
+namespace Application.Onboarding;
+
+/// <summary>
+/// Progress signals the onboarding engine reasons over. "Real" excludes the
+/// throwaway "welcome" module so the very first nudge is "do a real lesson".
+/// </summary>
+public record OnboardingSignals(
+    int RealLessonsCompleted,
+    int DistinctRealModules,
+    int AvailableXp,
+    int TotalTreatsGiven,
+    int VocabularyCount);
+
+/// <summary>Persisted state: which hints were already surfaced and when the last one was shown.</summary>
+public record OnboardingHintState(IReadOnlySet<string> Seen, DateTime? LastShownAt);
+
+/// <summary>
+/// Contextual, time-spread onboarding. After the welcome win we gently guide the user deeper —
+/// one nudge at a time, each shown once, and at most one new nudge per ~20h so the steps land
+/// across days/sessions instead of all at once. The active hint is the first step that is
+/// eligible (its action not yet done) and not yet seen.
+/// </summary>
+public static class OnboardingHints
+{
+    public const string FirstLesson = "first_lesson";
+    public const string NextLesson = "next_lesson";
+    public const string ExploreModule = "explore_module";
+    public const string FeedBombora = "feed_bombora";
+    public const string AddVocab = "add_vocab";
+
+    /// <summary>Priority order — the active hint is the first eligible, unseen step here.</summary>
+    public static readonly IReadOnlyList<string> Order = new[]
+    {
+        FirstLesson, NextLesson, ExploreModule, FeedBombora, AddVocab,
+    };
+
+    /// <summary>Cheapest treat price — mirrors FeedTreatService.TreatPrices[0].</summary>
+    private const int CheapestTreatXp = 10;
+
+    /// <summary>Don't surface a new hint within this window of the previous one — spreads steps over days.</summary>
+    public static readonly TimeSpan MinGapBetweenHints = TimeSpan.FromHours(20);
+
+    public static string? ResolveActiveHint(OnboardingSignals signals, OnboardingHintState state, DateTime nowUtc)
+    {
+        // One new nudge per window — keeps the onboarding gentle and time-spread.
+        if (state.LastShownAt is { } last && nowUtc - last < MinGapBetweenHints)
+        {
+            return null;
+        }
+
+        foreach (var key in Order)
+        {
+            if (!state.Seen.Contains(key) && IsEligible(key, signals))
+            {
+                return key;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsEligible(string key, OnboardingSignals s) => key switch
+    {
+        // Only the welcome lesson done so far — point them at a real lesson.
+        FirstLesson => s.RealLessonsCompleted == 0,
+        // Got going but not yet into a rhythm — encourage the next lesson.
+        NextLesson => s.RealLessonsCompleted is >= 1 and < 3,
+        // Several lessons but all in one module — nudge toward breadth.
+        ExploreModule => s.RealLessonsCompleted >= 3 && s.DistinctRealModules <= 1,
+        // Earned enough to spend but never fed Bombora — show the treat loop.
+        FeedBombora => s.AvailableXp >= CheapestTreatXp && s.TotalTreatsGiven == 0,
+        // A couple of lessons in but the personal dictionary is still empty.
+        AddVocab => s.RealLessonsCompleted >= 2 && s.VocabularyCount == 0,
+        _ => false,
+    };
+}

--- a/src/Application/Onboarding/OnboardingState.cs
+++ b/src/Application/Onboarding/OnboardingState.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Domain.Entities;
+
+namespace Application.Onboarding;
+
+/// <summary>
+/// (De)serializes the onboarding hint state stored in
+/// <see cref="MiniAppUserProgress.OnboardingHintsJson"/> and builds the
+/// <see cref="OnboardingSignals"/> the engine reasons over.
+/// </summary>
+public static class OnboardingState
+{
+    private const string WelcomeModuleId = "welcome";
+
+    private class StateDto
+    {
+        [JsonPropertyName("seen")] public List<string> Seen { get; set; } = new();
+        [JsonPropertyName("lastShownAt")] public DateTime? LastShownAt { get; set; }
+    }
+
+    public static OnboardingHintState Parse(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new OnboardingHintState(new HashSet<string>(), null);
+        }
+
+        try
+        {
+            var dto = JsonSerializer.Deserialize<StateDto>(json);
+            if (dto == null) return new OnboardingHintState(new HashSet<string>(), null);
+            return new OnboardingHintState(new HashSet<string>(dto.Seen), dto.LastShownAt);
+        }
+        catch
+        {
+            return new OnboardingHintState(new HashSet<string>(), null);
+        }
+    }
+
+    /// <summary>Records <paramref name="hintKey"/> as shown at <paramref name="nowUtc"/>; returns the new JSON.</summary>
+    public static string MarkSeen(string? json, string hintKey, DateTime nowUtc)
+    {
+        var state = Parse(json);
+        var seen = new HashSet<string>(state.Seen) { hintKey };
+        var dto = new StateDto { Seen = seen.ToList(), LastShownAt = nowUtc };
+        return JsonSerializer.Serialize(dto);
+    }
+
+    public static OnboardingSignals BuildSignals(MiniAppUserProgress progress, int vocabularyCount)
+    {
+        var completed = ParseCompletedLessons(progress.CompletedLessonsJson);
+        var realModules = completed
+            .Where(kv => kv.Key != WelcomeModuleId && kv.Value.Count > 0)
+            .ToList();
+
+        var realLessons = realModules.Sum(kv => kv.Value.Count);
+        var distinctModules = realModules.Count;
+        var availableXp = Math.Max(0, progress.Xp - progress.XpSpent);
+
+        return new OnboardingSignals(
+            RealLessonsCompleted: realLessons,
+            DistinctRealModules: distinctModules,
+            AvailableXp: availableXp,
+            TotalTreatsGiven: progress.TotalTreatsGiven,
+            VocabularyCount: vocabularyCount);
+    }
+
+    private static Dictionary<string, List<int>> ParseCompletedLessons(string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, List<int>>>(json)
+                   ?? new Dictionary<string, List<int>>();
+        }
+        catch
+        {
+            return new Dictionary<string, List<int>>();
+        }
+    }
+}

--- a/src/Domain/Entities/MiniAppUserProgress.cs
+++ b/src/Domain/Entities/MiniAppUserProgress.cs
@@ -41,6 +41,13 @@ public class MiniAppUserProgress
     public string SentenceBuilderProgressJson { get; set; } = "{}";
 
     /// <summary>
+    /// JSON state for the contextual onboarding engine: which hint keys were already
+    /// surfaced and when the last one was shown (for the time-spread gating).
+    /// Null until the first hint is shown. See <c>Application.Onboarding</c>.
+    /// </summary>
+    public string? OnboardingHintsJson { get; set; }
+
+    /// <summary>
     /// Total XP spent on treats in the treat shop.
     /// Available XP = Xp - XpSpent.
     /// </summary>

--- a/src/Persistence/Migrations/20260618130926_AddOnboardingHintsJson.Designer.cs
+++ b/src/Persistence/Migrations/20260618130926_AddOnboardingHintsJson.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Persistence;
@@ -11,9 +12,11 @@ using Persistence;
 namespace Persistence.Migrations
 {
     [DbContext(typeof(TraleDbContext))]
-    partial class TraleDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618130926_AddOnboardingHintsJson")]
+    partial class AddOnboardingHintsJson
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/Migrations/20260618130926_AddOnboardingHintsJson.cs
+++ b/src/Persistence/Migrations/20260618130926_AddOnboardingHintsJson.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOnboardingHintsJson : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OnboardingHintsJson",
+                table: "MiniAppUserProgresses",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OnboardingHintsJson",
+                table: "MiniAppUserProgresses");
+        }
+    }
+}

--- a/src/Trale/Controllers/MiniAppController.cs
+++ b/src/Trale/Controllers/MiniAppController.cs
@@ -154,7 +154,8 @@ public class MiniAppController : Controller
             subscriptionPlan = result.SubscriptionPlan,
             subscribedUntil = result.SubscribedUntil,
             hasAccess = result.IsPro || result.IsTrialActive,
-            isOwner = result.IsOwner
+            isOwner = result.IsOwner,
+            onboardingHint = result.OnboardingHint
         });
     }
 
@@ -406,6 +407,29 @@ public class MiniAppController : Controller
             CompleteLessonProgressResult.InvalidRequest => BadRequest(new { error = "invalid_request" }),
             _ => BadRequest(new { error = "unknown" })
         };
+    }
+
+    public class HintSeenRequest
+    {
+        public string HintKey { get; set; } = string.Empty;
+    }
+
+    [HttpPost("onboarding/hint-seen")]
+    public async Task<IActionResult> MarkOnboardingHintSeen([FromBody] HintSeenRequest request, CancellationToken ct)
+    {
+        var user = await ResolveUserAsync(ct);
+        if (user == null)
+        {
+            return Unauthorized(new { error = "not_authenticated" });
+        }
+
+        var ok = await _mediator.Send(new Application.MiniApp.Commands.MarkOnboardingHintSeen
+        {
+            UserId = user.Id,
+            HintKey = request.HintKey
+        }, ct);
+
+        return ok ? Ok(new { ok = true }) : BadRequest(new { error = "invalid_hint" });
     }
 
     [HttpGet("referral")]

--- a/src/Trale/miniapp-src/e2e/onboarding-nudge.spec.ts
+++ b/src/Trale/miniapp-src/e2e/onboarding-nudge.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test'
+
+// The dashboard surfaces the backend-chosen contextual onboarding nudge, and acting on it
+// navigates to the right place. me() decides which hint (if any) is active.
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    ;(window as any).Telegram = {
+      WebApp: {
+        initData: 'user=%7B%22id%22%3A123456%7D',
+        BackButton: { show: () => {}, hide: () => {}, onClick: () => {}, offClick: () => {} },
+        MainButton: { show: () => {}, hide: () => {} },
+        HapticFeedback: { impactOccurred: () => {}, notificationOccurred: () => {} },
+        openTelegramLink: () => {},
+      },
+    }
+  })
+})
+
+const catalog = {
+  botUsername: 'TraleBot',
+  miniAppEnabled: true,
+  modules: [
+    {
+      id: 'alphabet-progressive',
+      title: 'Алфавит',
+      emoji: '🔤',
+      description: 'Грузинский алфавит',
+      lessons: [{ id: 1, title: 'Первый урок', short: 'L1', theory: { title: 'Первый урок', goal: 'g', blocks: [] } }],
+    },
+  ],
+}
+
+const meWithHint = {
+  authenticated: true,
+  level: 'beginner',
+  isPro: false,
+  isTrialActive: false,
+  vocabularyCount: 0,
+  onboardingHint: 'first_lesson',
+  progress: {
+    xp: 20, // past the welcome gate → lands on the dashboard
+    streak: 1,
+    lastPlayedAtUtc: null,
+    completedLessons: { welcome: [1] },
+    xpSpent: 0,
+    totalTreatsGiven: 0,
+    lastFedAtUtc: null,
+    lastTreatIndex: null,
+  },
+}
+
+async function setupApi(page: any, me: typeof meWithHint) {
+  await page.route('**/api/miniapp/content', (route: any) => route.fulfill({ json: catalog }))
+  await page.route('**/api/miniapp/me', (route: any) => route.fulfill({ json: me }))
+  await page.route('**/api/miniapp/activity-days*', (route: any) => route.fulfill({ json: { dates: [] } }))
+}
+
+test('dashboard shows the active onboarding nudge and acting on it opens the lesson', async ({ page }) => {
+  let hintSeen = false
+  await setupApi(page, meWithHint)
+  await page.route('**/api/miniapp/onboarding/hint-seen', (route: any) => {
+    hintSeen = true
+    route.fulfill({ json: { ok: true } })
+  })
+
+  await page.goto('/?playwright=1')
+
+  // The nudge for the active hint is shown...
+  const nudge = page.getByTestId('onboarding-nudge-first_lesson')
+  await expect(nudge).toBeVisible()
+
+  // ...and the app reported it shown (so the backend won't repeat it).
+  await expect.poll(() => hintSeen).toBe(true)
+
+  // Acting on it opens the first lesson.
+  await page.getByTestId('onboarding-nudge-cta').click()
+  await expect(page.getByRole('button', { name: 'к практике →' })).toBeVisible()
+})
+
+test('no nudge is shown when me() returns no hint', async ({ page }) => {
+  await setupApi(page, { ...meWithHint, onboardingHint: null as any })
+  await page.goto('/?playwright=1')
+
+  await expect(page.getByTestId('module-tile-alphabet-progressive')).toBeVisible()
+  await expect(page.getByTestId('onboarding-nudge-first_lesson')).toHaveCount(0)
+})

--- a/src/Trale/miniapp-src/src/App.tsx
+++ b/src/Trale/miniapp-src/src/App.tsx
@@ -91,6 +91,7 @@ export default function App() {
   const [telegramId, setTelegramId] = useState<number | null>(null)
   const [showProSuccessToast, setShowProSuccessToast] = useState(false)
   const [vocabularyCount, setVocabularyCount] = useState<number>(0)
+  const [onboardingHint, setOnboardingHint] = useState<string | null>(null)
 
   // Load catalog + progress from backend on mount
   useEffect(() => {
@@ -114,6 +115,7 @@ export default function App() {
           setIsOwner((meData as any).isOwner ?? false)
           setTelegramId((meData as any).telegramId ?? null)
           setVocabularyCount((meData as any).vocabularyCount ?? 0)
+          setOnboardingHint((meData as any).onboardingHint ?? null)
         }
         const hasLevel = meData?.level === 'beginner' || meData?.level === 'intermediate'
         const deepLink = hasLevel ? parseDeepLink(catalogData) : null
@@ -325,6 +327,8 @@ export default function App() {
             isTrialActive={isTrialActive}
             trialDaysLeft={trialDaysLeft}
             shouldShowReferralExtensionCta={shouldShowReferralExtensionCta}
+            onboardingHint={onboardingHint}
+            onHintSeen={(h) => api.markOnboardingHintSeen(h).catch(() => {})}
             onPurchaseSuccess={handleProPurchaseSuccess}
             onProgressUpdate={(patch) => setProgress((p) => ({ ...p, ...patch }))}
             navigate={navigate}

--- a/src/Trale/miniapp-src/src/api.ts
+++ b/src/Trale/miniapp-src/src/api.ts
@@ -51,6 +51,8 @@ export interface MeResponse {
   subscriptionPlan?: string | null
   subscribedUntil?: string | null
   notificationsEnabled?: boolean
+  /** Active contextual-onboarding hint key (or null/absent). See OnboardingNudge. */
+  onboardingHint?: string | null
 }
 
 export interface LessonCompleteResponse {
@@ -129,6 +131,12 @@ export const api = {
     request<LessonCompleteResponse>('/api/miniapp/progress/lesson-complete', {
       method: 'POST',
       body: JSON.stringify(payload)
+    }),
+
+  markOnboardingHintSeen: (hintKey: string) =>
+    request<{ ok: boolean }>('/api/miniapp/onboarding/hint-seen', {
+      method: 'POST',
+      body: JSON.stringify({ hintKey })
     }),
 
   vocabulary: () => request<VocabularyListResponse>('/api/miniapp/vocabulary'),

--- a/src/Trale/miniapp-src/src/components/OnboardingNudge.test.tsx
+++ b/src/Trale/miniapp-src/src/components/OnboardingNudge.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import OnboardingNudge from './OnboardingNudge'
+import { CatalogDto, ProgressState } from '../types'
+import { defaultProgress } from '../progress'
+
+const catalog: CatalogDto = {
+  botUsername: 'TraleBot',
+  miniAppEnabled: true,
+  modules: [
+    {
+      id: 'alphabet-progressive',
+      title: 'Алфавит',
+      emoji: '🔤',
+      description: '',
+      lessons: [{ id: 1, title: 'L1', short: '', theory: { title: 'L1', goal: '', blocks: [] } }],
+    },
+  ],
+}
+
+function renderNudge(hint: string, overrides: Partial<Parameters<typeof OnboardingNudge>[0]> = {}) {
+  const props = {
+    hint,
+    catalog,
+    progress: defaultProgress as ProgressState,
+    navigate: vi.fn(),
+    onFeed: vi.fn(),
+    onClose: vi.fn(),
+    onShown: vi.fn(),
+    ...overrides,
+  }
+  render(<OnboardingNudge {...props} />)
+  return props
+}
+
+describe('OnboardingNudge', () => {
+  it('reports itself shown once on mount', () => {
+    const onShown = vi.fn()
+    renderNudge('first_lesson', { onShown })
+    expect(onShown).toHaveBeenCalledTimes(1)
+    expect(onShown).toHaveBeenCalledWith('first_lesson')
+  })
+
+  it('renders nothing for an unknown hint key', () => {
+    renderNudge('totally_unknown')
+    expect(screen.queryByTestId('onboarding-nudge-cta')).not.toBeInTheDocument()
+  })
+
+  it('first_lesson CTA navigates to the first lesson and closes', async () => {
+    const user = userEvent.setup()
+    const navigate = vi.fn()
+    const onClose = vi.fn()
+    renderNudge('first_lesson', { navigate, onClose })
+
+    await user.click(screen.getByTestId('onboarding-nudge-cta'))
+
+    expect(navigate).toHaveBeenCalledWith({ kind: 'lesson-theory', moduleId: 'alphabet-progressive', lessonId: 1 })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('feed_bombora CTA opens the treat shop', async () => {
+    const user = userEvent.setup()
+    const onFeed = vi.fn()
+    renderNudge('feed_bombora', { onFeed })
+
+    await user.click(screen.getByTestId('onboarding-nudge-cta'))
+    expect(onFeed).toHaveBeenCalledTimes(1)
+  })
+
+  it('add_vocab CTA navigates to the vocabulary list', async () => {
+    const user = userEvent.setup()
+    const navigate = vi.fn()
+    renderNudge('add_vocab', { navigate })
+
+    await user.click(screen.getByTestId('onboarding-nudge-cta'))
+    expect(navigate).toHaveBeenCalledWith({ kind: 'vocabulary-list' })
+  })
+
+  it('the dismiss button closes the nudge', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    renderNudge('explore_module', { onClose })
+
+    await user.click(screen.getByRole('button', { name: /закрыть подсказку/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/Trale/miniapp-src/src/components/OnboardingNudge.tsx
+++ b/src/Trale/miniapp-src/src/components/OnboardingNudge.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect } from 'react'
+import { CatalogDto, ProgressState, Screen } from '../types'
+import { findFirstLesson } from '../entryFlow'
+
+interface Props {
+  hint: string
+  catalog: CatalogDto
+  progress: ProgressState
+  navigate: (s: Screen) => void
+  onFeed: () => void
+  onClose: () => void
+  /** Called once when the nudge is shown — the app records it so it isn't surfaced again. */
+  onShown: (hint: string) => void
+}
+
+interface NudgeCopy {
+  eyebrow: string
+  title: string
+  cta: string
+}
+
+const COPY: Record<string, NudgeCopy> = {
+  first_lesson: { eyebrow: 'дальше', title: 'Бомбора ждёт первый урок — начнём с алфавита?', cta: 'Начать урок' },
+  next_lesson: { eyebrow: 'не останавливайся', title: 'Хорошо идёт! Ещё один короткий урок?', cta: 'Следующий урок' },
+  explore_module: { eyebrow: 'ты освоился', title: 'Ты уже втянулся — загляни в другую тему', cta: 'Показать модули' },
+  feed_bombora: { eyebrow: 'у тебя есть звёзды', title: 'Накопил опыт ⭐ — потрать его и покорми Бомбору', cta: 'Покормить' },
+  add_vocab: { eyebrow: 'твой словарь', title: 'Сохраняй новые слова в личный словарь и тренируй их', cta: 'Мой словарь' },
+}
+
+/**
+ * Contextual onboarding nudge on the dashboard. The backend decides which single hint is
+ * active (time-spread, one per ~20h); this renders it as a friendly, dismissible banner and
+ * reports it shown so it isn't repeated. Unknown / unmapped keys render nothing.
+ */
+export default function OnboardingNudge({ hint, catalog, progress, navigate, onFeed, onClose, onShown }: Props) {
+  useEffect(() => {
+    onShown(hint)
+  }, [hint])
+
+  const copy = COPY[hint]
+  if (!copy) return null
+
+  function act() {
+    switch (hint) {
+      case 'first_lesson':
+      case 'next_lesson': {
+        const first = findFirstLesson(catalog, progress.completedLessons)
+        if (first) navigate({ kind: 'lesson-theory', moduleId: first.moduleId, lessonId: first.lessonId })
+        break
+      }
+      case 'feed_bombora':
+        onFeed()
+        break
+      case 'add_vocab':
+        navigate({ kind: 'vocabulary-list' })
+        break
+      case 'explore_module':
+      default:
+        // Modules are right below on the dashboard — just dismiss the nudge.
+        break
+    }
+    onClose()
+  }
+
+  return (
+    <div className="px-5 pt-2 pb-1">
+      <div
+        className="jewel-tile px-4 py-3 flex items-center gap-3"
+        data-testid={`onboarding-nudge-${hint}`}
+        style={{ background: '#FBF6EC' }}
+      >
+        <div className="relative z-[1] text-[22px] leading-none shrink-0">🐶</div>
+        <div className="relative z-[1] flex-1 min-w-0">
+          <div className="mn-eyebrow text-ruby mb-0.5">{copy.eyebrow}</div>
+          <div className="font-sans text-[13px] font-extrabold text-jewelInk leading-snug">
+            {copy.title}
+          </div>
+          <button
+            onClick={act}
+            data-testid="onboarding-nudge-cta"
+            className="mt-2 px-3 py-1.5 rounded-lg font-sans text-[12px] font-extrabold"
+            style={{ background: '#F5B820', color: '#15100A', border: '1.5px solid #15100A' }}
+          >
+            {copy.cta} →
+          </button>
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Закрыть подсказку"
+          className="relative z-[1] shrink-0 self-start text-jewelInk-hint font-sans text-[18px] leading-none w-8 h-8 flex items-center justify-center"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/Trale/miniapp-src/src/screens/Dashboard.tsx
+++ b/src/Trale/miniapp-src/src/screens/Dashboard.tsx
@@ -5,6 +5,7 @@ import ProBadge from '../components/ProBadge'
 import ProPaywall, { PaywallTrigger } from '../components/ProPaywall'
 import ReferralExtensionCta from '../components/ReferralExtensionCta'
 import DashboardTopBar from '../components/DashboardTopBar'
+import OnboardingNudge from '../components/OnboardingNudge'
 import MilestoneBanner, { XP_MILESTONES, STREAK_MILESTONES } from '../components/MilestoneBanner'
 import TreatShop from '../components/TreatShop'
 import FeedingAnimation from '../components/FeedingAnimation'
@@ -23,6 +24,10 @@ interface Props {
   isTrialActive?: boolean
   trialDaysLeft?: number
   shouldShowReferralExtensionCta?: boolean
+  /** Active contextual-onboarding hint key (or null) — surfaces a single gentle nudge. */
+  onboardingHint?: string | null
+  /** Reports the nudge as shown so the backend doesn't surface it again. */
+  onHintSeen?: (hint: string) => void
   onPurchaseSuccess: () => void
   onProgressUpdate?: (patch: Partial<ProgressState>) => void
   navigate: (s: Screen) => void
@@ -76,7 +81,7 @@ function isSectionUnlocked(
  * module icons use meaningful Georgian letters that tie into what's taught,
  * product signature is a tiny kilim strip at the top.
  */
-export default function Dashboard({ catalog, progress, todayLessons, userLevel, isPro, isTrialActive = false, trialDaysLeft = 0, shouldShowReferralExtensionCta = false, onPurchaseSuccess, onProgressUpdate, navigate }: Props) {
+export default function Dashboard({ catalog, progress, todayLessons, userLevel, isPro, isTrialActive = false, trialDaysLeft = 0, shouldShowReferralExtensionCta = false, onboardingHint = null, onHintSeen, onPurchaseSuccess, onProgressUpdate, navigate }: Props) {
   const isBeginner = userLevel === 'beginner'
   const hasAccess = isPro || isTrialActive
   const [paywall, setPaywall] = useState<{ trigger: PaywallTrigger } | null>(null)
@@ -127,6 +132,9 @@ export default function Dashboard({ catalog, progress, todayLessons, userLevel, 
   // Milestone banner — shown when XP or streak crosses a threshold for the first time
   const [milestone, setMilestone] = useState<{ type: 'xp' | 'streak'; value: number } | null>(null)
   const prevProgressRef = useRef<ProgressState | null>(null)
+
+  // Contextual onboarding nudge — dismissed for the rest of this session once closed/acted on.
+  const [nudgeDismissed, setNudgeDismissed] = useState(false)
 
   // Treat shop state
   const [treatShopOpen, setTreatShopOpen] = useState(false)
@@ -208,6 +216,19 @@ export default function Dashboard({ catalog, progress, todayLessons, userLevel, 
         onNavigateProfile={() => navigate({ kind: 'profile' })}
         onOpenTreatShop={() => setTreatShopOpen(true)}
       />
+
+      {/* ══ Contextual onboarding nudge (one at a time, time-spread by the backend) ══ */}
+      {onboardingHint && !nudgeDismissed && (
+        <OnboardingNudge
+          hint={onboardingHint}
+          catalog={catalog}
+          progress={progress}
+          navigate={navigate}
+          onFeed={() => setTreatShopOpen(true)}
+          onClose={() => setNudgeDismissed(true)}
+          onShown={(h) => onHintSeen?.(h)}
+        />
+      )}
 
       {/* ══ Hero — Bombora tamagotchi + greeting ══ */}
       <section className="px-5 pt-3 pb-4">

--- a/src/Trale/miniapp-src/src/screens/__tests__/Welcome.test.tsx
+++ b/src/Trale/miniapp-src/src/screens/__tests__/Welcome.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import Welcome from './Welcome'
+import Welcome from '../Welcome'
 
 // Walks the happy path: meet the letter → listening task → name task → win.
 async function playThrough(user: ReturnType<typeof userEvent.setup>) {

--- a/tests/Application.UnitTests/Onboarding/OnboardingHintsTests.cs
+++ b/tests/Application.UnitTests/Onboarding/OnboardingHintsTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using Application.Onboarding;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Application.UnitTests.Onboarding;
+
+[TestFixture]
+public class OnboardingHintsTests
+{
+    private static readonly DateTime Now = new(2026, 6, 18, 10, 0, 0, DateTimeKind.Utc);
+
+    private static OnboardingSignals Signals(
+        int realLessons = 0, int distinctModules = 0, int availableXp = 0,
+        int treatsGiven = 0, int vocab = 0) =>
+        new(realLessons, distinctModules, availableXp, treatsGiven, vocab);
+
+    private static OnboardingHintState State(DateTime? lastShownAt = null, params string[] seen) =>
+        new(new HashSet<string>(seen), lastShownAt);
+
+    [Test]
+    public void Fresh_user_who_only_did_welcome_is_nudged_to_the_first_real_lesson()
+    {
+        OnboardingHints.ResolveActiveHint(Signals(realLessons: 0), State(), Now)
+            .ShouldBe(OnboardingHints.FirstLesson);
+    }
+
+    [Test]
+    public void After_one_lesson_the_nudge_is_to_keep_going()
+    {
+        OnboardingHints.ResolveActiveHint(Signals(realLessons: 1, availableXp: 0), State(), Now)
+            .ShouldBe(OnboardingHints.NextLesson);
+    }
+
+    [Test]
+    public void Three_lessons_in_a_single_module_nudges_to_explore_another_module()
+    {
+        OnboardingHints.ResolveActiveHint(Signals(realLessons: 3, distinctModules: 1), State(), Now)
+            .ShouldBe(OnboardingHints.ExploreModule);
+    }
+
+    [Test]
+    public void Spendable_xp_and_never_fed_nudges_to_feed_bombora()
+    {
+        // Lesson hints already seen; the next eligible step is feeding.
+        OnboardingHints.ResolveActiveHint(
+                Signals(realLessons: 1, availableXp: 20, treatsGiven: 0),
+                State(seen: OnboardingHints.NextLesson),
+                Now)
+            .ShouldBe(OnboardingHints.FeedBombora);
+    }
+
+    [Test]
+    public void Empty_vocabulary_after_a_couple_lessons_nudges_to_add_words()
+    {
+        OnboardingHints.ResolveActiveHint(
+                Signals(realLessons: 2, distinctModules: 1, availableXp: 0, vocab: 0),
+                State(seen: OnboardingHints.NextLesson, lastShownAt: null),
+                Now)
+            .ShouldBe(OnboardingHints.AddVocab);
+    }
+
+    [Test]
+    public void Already_seen_hints_are_not_shown_again()
+    {
+        OnboardingHints.ResolveActiveHint(Signals(realLessons: 0), State(seen: OnboardingHints.FirstLesson), Now)
+            .ShouldBeNull();
+    }
+
+    [Test]
+    public void At_most_one_new_hint_per_cooldown_window()
+    {
+        // A hint was shown 2h ago — too soon to surface the next one.
+        var recent = Now.AddHours(-2);
+        OnboardingHints.ResolveActiveHint(Signals(realLessons: 1), State(lastShownAt: recent), Now)
+            .ShouldBeNull();
+    }
+
+    [Test]
+    public void Next_hint_unlocks_once_the_cooldown_has_passed()
+    {
+        var longAgo = Now.AddHours(-21);
+        OnboardingHints.ResolveActiveHint(Signals(realLessons: 1), State(lastShownAt: longAgo), Now)
+            .ShouldBe(OnboardingHints.NextLesson);
+    }
+
+    [Test]
+    public void Nothing_to_nudge_returns_null()
+    {
+        // Deep into the app: many lessons, multiple modules, fed, has vocabulary.
+        OnboardingHints.ResolveActiveHint(
+                Signals(realLessons: 12, distinctModules: 3, availableXp: 0, treatsGiven: 5, vocab: 9),
+                State(),
+                Now)
+            .ShouldBeNull();
+    }
+}

--- a/tests/Application.UnitTests/Onboarding/OnboardingStateTests.cs
+++ b/tests/Application.UnitTests/Onboarding/OnboardingStateTests.cs
@@ -1,0 +1,91 @@
+using System;
+using Application.Onboarding;
+using Domain.Entities;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Application.UnitTests.Onboarding;
+
+[TestFixture]
+public class OnboardingStateTests
+{
+    [Test]
+    public void Parse_null_or_blank_yields_empty_state()
+    {
+        var s = OnboardingState.Parse(null);
+        s.Seen.ShouldBeEmpty();
+        s.LastShownAt.ShouldBeNull();
+
+        OnboardingState.Parse("   ").Seen.ShouldBeEmpty();
+    }
+
+    [Test]
+    public void Parse_garbage_yields_empty_state_rather_than_throwing()
+    {
+        var s = OnboardingState.Parse("{not valid json");
+        s.Seen.ShouldBeEmpty();
+        s.LastShownAt.ShouldBeNull();
+    }
+
+    [Test]
+    public void MarkSeen_records_the_key_and_timestamp_and_round_trips()
+    {
+        var now = new DateTime(2026, 6, 18, 9, 0, 0, DateTimeKind.Utc);
+
+        var json = OnboardingState.MarkSeen(null, OnboardingHints.FirstLesson, now);
+        var state = OnboardingState.Parse(json);
+
+        state.Seen.ShouldContain(OnboardingHints.FirstLesson);
+        state.LastShownAt!.Value.ShouldBe(now);
+    }
+
+    [Test]
+    public void MarkSeen_accumulates_keys()
+    {
+        var t1 = new DateTime(2026, 6, 18, 9, 0, 0, DateTimeKind.Utc);
+        var t2 = t1.AddDays(1);
+
+        var json = OnboardingState.MarkSeen(null, OnboardingHints.FirstLesson, t1);
+        json = OnboardingState.MarkSeen(json, OnboardingHints.NextLesson, t2);
+
+        var state = OnboardingState.Parse(json);
+        state.Seen.ShouldContain(OnboardingHints.FirstLesson);
+        state.Seen.ShouldContain(OnboardingHints.NextLesson);
+        state.LastShownAt!.Value.ShouldBe(t2);
+    }
+
+    [Test]
+    public void BuildSignals_excludes_the_welcome_module_from_real_progress()
+    {
+        var progress = new MiniAppUserProgress
+        {
+            CompletedLessonsJson = """{"welcome":[1],"alphabet-progressive":[1,2]}""",
+            Xp = 40,
+            XpSpent = 10,
+            TotalTreatsGiven = 2,
+        };
+
+        var signals = OnboardingState.BuildSignals(progress, vocabularyCount: 5);
+
+        signals.RealLessonsCompleted.ShouldBe(2); // welcome's lesson is not counted
+        signals.DistinctRealModules.ShouldBe(1);
+        signals.AvailableXp.ShouldBe(30);
+        signals.TotalTreatsGiven.ShouldBe(2);
+        signals.VocabularyCount.ShouldBe(5);
+    }
+
+    [Test]
+    public void BuildSignals_treats_only_welcome_as_zero_real_lessons()
+    {
+        var progress = new MiniAppUserProgress
+        {
+            CompletedLessonsJson = """{"welcome":[1]}""",
+            Xp = 20,
+        };
+
+        var signals = OnboardingState.BuildSignals(progress, vocabularyCount: 0);
+
+        signals.RealLessonsCompleted.ShouldBe(0);
+        signals.DistinctRealModules.ShouldBe(0);
+    }
+}

--- a/tests/IntegrationTests/Onboarding/OnboardingHintFlowTests.cs
+++ b/tests/IntegrationTests/Onboarding/OnboardingHintFlowTests.cs
@@ -1,0 +1,89 @@
+using Application.Common;
+using Application.MiniApp.Commands;
+using Application.MiniApp.Queries;
+using Application.Onboarding;
+using Domain.Entities;
+using FluentAssertions;
+using IntegrationTests.DSL;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace IntegrationTests.Onboarding;
+
+/// <summary>
+/// End-to-end (against real Postgres) for the contextual onboarding engine: me() surfaces the
+/// active hint, marking it seen persists, and the next me() falls silent (cooldown + seen).
+/// </summary>
+public class OnboardingHintFlowTests : TestBase
+{
+    [Test]
+    public async Task Me_surfaces_the_first_lesson_hint_then_falls_silent_once_marked_seen()
+    {
+        var telegramId = 880011L;
+        var userId = await SeedWelcomedUserAsync(telegramId);
+
+        // me() #1 → the user only finished the welcome lesson, so nudge them to a real lesson.
+        var first = await SendAsync(new GetMiniAppProfile { UserId = userId });
+        first.OnboardingHint.Should().Be(OnboardingHints.FirstLesson);
+
+        // Mark it seen (what the mini-app does when it renders the nudge).
+        var marked = await SendAsync(new MarkOnboardingHintSeen { UserId = userId, HintKey = OnboardingHints.FirstLesson });
+        marked.Should().BeTrue();
+
+        // me() #2 → nothing new within the cooldown window.
+        var second = await SendAsync(new GetMiniAppProfile { UserId = userId });
+        second.OnboardingHint.Should().BeNull();
+
+        // The seen state is persisted on the progress row.
+        await using var scope = _testServer.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ITraleDbContext>();
+        var progress = await db.MiniAppUserProgresses.FirstAsync(p => p.UserId == userId);
+        OnboardingState.Parse(progress.OnboardingHintsJson).Seen.Should().Contain(OnboardingHints.FirstLesson);
+    }
+
+    [Test]
+    public async Task Marking_an_unknown_hint_is_rejected()
+    {
+        var userId = await SeedWelcomedUserAsync(880022L);
+        var ok = await SendAsync(new MarkOnboardingHintSeen { UserId = userId, HintKey = "not_a_real_hint" });
+        ok.Should().BeFalse();
+    }
+
+    private async Task<T> SendAsync<T>(IRequest<T> request)
+    {
+        await using var scope = _testServer.Services.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        return await mediator.Send(request);
+    }
+
+    private async Task<System.Guid> SeedWelcomedUserAsync(long telegramId)
+    {
+        await using var scope = _testServer.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ITraleDbContext>();
+
+        var user = Create.User(telegramId, "OnboardingTest");
+        db.Users.Add(user);
+        await db.SaveChangesAsync(CancellationToken.None);
+
+        db.UsersSettings.Add(new UserSettings
+        {
+            Id = System.Guid.NewGuid(),
+            UserId = user.Id,
+            CurrentLanguage = Language.Georgian,
+        });
+
+        db.MiniAppUserProgresses.Add(new MiniAppUserProgress
+        {
+            Id = System.Guid.NewGuid(),
+            UserId = user.Id,
+            CompletedLessonsJson = """{"welcome":[1]}""",
+            Xp = 20,
+            CreatedAtUtc = System.DateTime.UtcNow,
+            UpdatedAtUtc = System.DateTime.UtcNow,
+        });
+        await db.SaveChangesAsync(CancellationToken.None);
+
+        return user.Id;
+    }
+}


### PR DESCRIPTION
## Зачем

Фаза 2 мягкого онбординга. После welcome-урока (одна буква) нужно **постепенно** углублять пользователя в приложение — по одной дружелюбной подсказке за раз, **разнесённой по времени** (день 1, день 2…), а не вываливать всё сразу.

## Как работает

**Бэкенд (`Application.Onboarding`)**
- `OnboardingHints.ResolveActiveHint` — чистый движок над сигналами прогресса. Активная подсказка = первый подходящий, ещё не показанный шаг по порядку:
  `first_lesson → next_lesson → explore_module → feed_bombora → add_vocab`,
  но **не чаще одной новой за ~20ч** (отсюда разнесённость по дням).
- `OnboardingState` — состояние (`{seen, lastShownAt}`) в новом nullable-поле `MiniAppUserProgress.OnboardingHintsJson`. `BuildSignals` исключает служебный модуль `welcome`.
- `me()` отдаёт активную подсказку; `POST /api/miniapp/onboarding/hint-seen` помечает показанной.
- Миграция `AddOnboardingHintsJson` (nullable-колонка, дедуп не нужен).

**Фронт**
- `OnboardingNudge` — один закрываемый баннер-нудж на дашборде. Маппит ключ → копия + CTA (начать/продолжить урок, заглянуть в модули, покормить Бомбору, открыть словарь) и сообщает «показан», чтобы не повторять.

## Спред по времени

Шаги естественно гейтятся прогрессом (next_lesson доступен только после первого урока и т.д.), а cooldown ~20ч гарантирует **не больше одной новой подсказки за заход/день** — мягко и ненавязчиво. Состояние на бэке → переживает перезапуски и работает многосессионно.

## Тесты

- Юнит: `OnboardingHints` 9, `OnboardingState` 6.
- Интеграционные (реальный Postgres): me() отдаёт подсказку → пометил → молчит; персистентность; невалидный ключ отклоняется (2).
- Фронт: `OnboardingNudge` компонент 6; e2e показ+действие и отсутствие при null (2).

Попутно починен устаревший импорт в `screens/__tests__/Welcome.test.tsx` из #986 (vitest не в CI, поэтому проскочило).

## Заметки

- wwwroot не коммичу — SPA собирается в Docker.
- Дальнейшее (необязательно): сделать копию return-push онбординг-aware (ссылаться на активный шаг) — отдельным PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)