### PR TITLE
fix(onboarding): spotlight appears after welcome & dismisses for the session

### DIFF
--- a/src/Trale/miniapp-src/e2e/onboarding-spotlight.spec.ts
+++ b/src/Trale/miniapp-src/e2e/onboarding-spotlight.spec.ts
@@ -83,3 +83,43 @@ test('no spotlight is shown when me() returns no hint', async ({ page }) => {
   await expect(page.getByTestId('module-tile-alphabet-progressive')).toBeVisible()
   await expect(page.getByTestId('onboarding-spotlight-first_lesson')).toHaveCount(0)
 })
+
+test('the first-lesson spotlight appears right after the welcome lesson — no reload needed', async ({ page }) => {
+  // me() #1 (on load): a fresh user with a level but no XP and no welcome yet → welcome screen,
+  // and no hint (the gate needs welcome done). me() #2+ (after welcome): hint unlocked.
+  const meFresh = {
+    authenticated: true,
+    level: 'beginner',
+    vocabularyCount: 0,
+    onboardingHint: null,
+    progress: { xp: 0, streak: 0, lastPlayedAtUtc: null, completedLessons: {}, xpSpent: 0, totalTreatsGiven: 0, lastFedAtUtc: null, lastTreatIndex: null },
+  }
+  const meAfterWelcome = {
+    ...meFresh,
+    onboardingHint: 'first_lesson',
+    progress: { ...meFresh.progress, xp: 20, completedLessons: { welcome: [1] } },
+  }
+
+  let meCalls = 0
+  await page.route('**/api/miniapp/content', (route: any) => route.fulfill({ json: catalog }))
+  await page.route('**/api/miniapp/activity-days*', (route: any) => route.fulfill({ json: { dates: [] } }))
+  await page.route('**/api/miniapp/me', (route: any) => {
+    meCalls += 1
+    route.fulfill({ json: meCalls === 1 ? meFresh : meAfterWelcome })
+  })
+  await page.route('**/api/miniapp/progress/lesson-complete', (route: any) =>
+    route.fulfill({ json: { xpEarned: 15, progress: meAfterWelcome.progress } })
+  )
+  await page.route('**/api/miniapp/onboarding/hint-seen', (route: any) => route.fulfill({ json: { ok: true } }))
+
+  await page.goto('/?playwright=1')
+
+  // Walk the welcome mini-lesson.
+  await page.getByRole('button', { name: /дальше/i }).click()
+  await page.getByTestId('welcome-listen-а').click()
+  await page.getByTestId('welcome-name-ани').click()
+  await page.getByRole('button', { name: /открыть приложение/i }).click()
+
+  // Spotlight is there immediately on the dashboard — without any reload.
+  await expect(page.getByTestId('onboarding-spotlight-first_lesson')).toBeVisible()
+})

--- a/src/Trale/miniapp-src/src/App.tsx
+++ b/src/Trale/miniapp-src/src/App.tsx
@@ -291,9 +291,14 @@ export default function App() {
             // awards the first XP (flipping the entry gate to the dashboard) without
             // touching the real alphabet progression. Navigate regardless of the API
             // result so a transient failure doesn't trap the user on the welcome screen.
+            // Re-fetch me() afterwards: completing welcome unlocks the first onboarding
+            // hint, but the initial me() (taken before welcome) returned none — without a
+            // refresh the dashboard spotlight only appears after a manual reload.
             api
               .completeLesson({ moduleId: 'welcome', lessonId: 1, correct: 1, total: 1 })
               .then((res) => setProgress(progressFromDto(res.progress)))
+              .then(() => api.me())
+              .then((meData) => setOnboardingHint((meData as any).onboardingHint ?? null))
               .catch(() => {})
               .finally(() => navigate({ kind: 'dashboard' }))
           }}
@@ -329,6 +334,7 @@ export default function App() {
             shouldShowReferralExtensionCta={shouldShowReferralExtensionCta}
             onboardingHint={onboardingHint}
             onHintSeen={(h) => api.markOnboardingHintSeen(h).catch(() => {})}
+            onHintDismiss={() => setOnboardingHint(null)}
             onPurchaseSuccess={handleProPurchaseSuccess}
             onProgressUpdate={(patch) => setProgress((p) => ({ ...p, ...patch }))}
             navigate={navigate}

--- a/src/Trale/miniapp-src/src/screens/Dashboard.tsx
+++ b/src/Trale/miniapp-src/src/screens/Dashboard.tsx
@@ -28,6 +28,8 @@ interface Props {
   onboardingHint?: string | null
   /** Reports the nudge as shown so the backend doesn't surface it again. */
   onHintSeen?: (hint: string) => void
+  /** Clears the active hint for the rest of the session (acted on or dismissed). */
+  onHintDismiss?: () => void
   onPurchaseSuccess: () => void
   onProgressUpdate?: (patch: Partial<ProgressState>) => void
   navigate: (s: Screen) => void
@@ -81,7 +83,7 @@ function isSectionUnlocked(
  * module icons use meaningful Georgian letters that tie into what's taught,
  * product signature is a tiny kilim strip at the top.
  */
-export default function Dashboard({ catalog, progress, todayLessons, userLevel, isPro, isTrialActive = false, trialDaysLeft = 0, shouldShowReferralExtensionCta = false, onboardingHint = null, onHintSeen, onPurchaseSuccess, onProgressUpdate, navigate }: Props) {
+export default function Dashboard({ catalog, progress, todayLessons, userLevel, isPro, isTrialActive = false, trialDaysLeft = 0, shouldShowReferralExtensionCta = false, onboardingHint = null, onHintSeen, onHintDismiss, onPurchaseSuccess, onProgressUpdate, navigate }: Props) {
   const isBeginner = userLevel === 'beginner'
   const hasAccess = isPro || isTrialActive
   const [paywall, setPaywall] = useState<{ trigger: PaywallTrigger } | null>(null)
@@ -132,9 +134,6 @@ export default function Dashboard({ catalog, progress, todayLessons, userLevel, 
   // Milestone banner — shown when XP or streak crosses a threshold for the first time
   const [milestone, setMilestone] = useState<{ type: 'xp' | 'streak'; value: number } | null>(null)
   const prevProgressRef = useRef<ProgressState | null>(null)
-
-  // Contextual onboarding nudge — dismissed for the rest of this session once closed/acted on.
-  const [nudgeDismissed, setNudgeDismissed] = useState(false)
 
   // Treat shop state
   const [treatShopOpen, setTreatShopOpen] = useState(false)
@@ -219,11 +218,11 @@ export default function Dashboard({ catalog, progress, todayLessons, userLevel, 
 
       {/* ══ Contextual onboarding spotlight (one at a time, time-spread by the backend).
             Highlights the real element to tap so the user learns the actual gesture. ══ */}
-      {onboardingHint && !nudgeDismissed && (
+      {onboardingHint && (
         <OnboardingSpotlight
           hint={onboardingHint}
           onShown={(h) => onHintSeen?.(h)}
-          onDismiss={() => setNudgeDismissed(true)}
+          onDismiss={() => onHintDismiss?.()}
         />
       )}
 


### PR DESCRIPTION
Два follow-up бага из спотлайта (#988), найдены при ручном тесте:

### 1. Фонарик не появлялся после welcome (только после релоада)
`App` берёт `onboardingHint` из первого `me()` — а он снимается **до** welcome, когда гейт ещё возвращает null. Завершение welcome через `lesson-complete` хинт не обновляло. Теперь после welcome `App` перезапрашивает `me()` → первый фонарик всплывает сразу, без перезагрузки.

### 2. Фонарик возвращался после действия
Флаг «закрыт» жил в `Dashboard`, который перемонтируется при навигации и сбрасывал его, а `onboardingHint` оставался. Поднял закрытие в `App` (`onHintDismiss` обнуляет хинт) — после тапа/крестика фонарик гаснет на всю сессию.

### Тесты
- e2e: добавлен «фонарик появляется сразу после welcome, без релоада».
- Локально: vitest 28/28, e2e 6/6 (spotlight 3 + gate 3).

wwwroot не коммичу — собирается в Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)