### PR TITLE
fix(miniapp): activity heatmap reflects every played day, aligned to weekdays

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -277,6 +277,7 @@ Location: `src/Persistence/Migrations/`. Test greps the migration class name (af
 | `AddNotificationTriggers` | NotificationTrigger table (per-source last-sent timestamp + variant) backing the 7-day cooldown of the D1+ return-push dispatch. |
 | `MakeNotificationTriggerUnique` | Dedups existing rows and makes the NotificationTrigger (UserId, Source) index unique, so the atomic claim-before-send can't double-fire the return push across overlapping dispatch runs (incident 2026-06-17). |
 | `AddOnboardingHintsJson` | Adds nullable OnboardingHintsJson to MiniAppUserProgress — persisted state (seen hints + lastShownAt) for the contextual, time-spread onboarding nudges. |
+| `AddActivityDaysJson` | Adds nullable ActivityDaysJson to MiniAppUserProgress — per-day mini-app play log (one UTC timestamp per played day) so the profile activity heatmap lights one cell per played day instead of only the single LastPlayedAtUtc point. |
 
 ---
 

--- a/src/Application/MiniApp/Queries/GetActivityDaysQuery.cs
+++ b/src/Application/MiniApp/Queries/GetActivityDaysQuery.cs
@@ -42,6 +42,15 @@ public class GetActivityDaysQuery(ITraleDbContext db)
             .Select(p => p.LastPlayedAtUtc)
             .ToListAsync(ct);
 
+        // Per-day mini-app play log — the primary source for the heatmap. Without it
+        // daily play contributes only the single LastPlayedAtUtc point above, so a
+        // learner with a long streak would still light up just one cell.
+        var activityDaysJson = await db.MiniAppUserProgresses
+            .Where(p => p.UserId == userId)
+            .Select(p => p.ActivityDaysJson)
+            .FirstOrDefaultAsync(ct);
+        var playDays = ParseActivityDays(activityDaysJson).Where(d => d >= since);
+
         var achievementDates = await db.Achievements
             .Where(a => a.UserId == userId && a.DateAddedUtc >= since)
             .Select(a => a.DateAddedUtc)
@@ -50,6 +59,7 @@ public class GetActivityDaysQuery(ITraleDbContext db)
         var all = vocabDates
             .Concat(quizDates)
             .Concat(lastPlayed.Where(d => d.HasValue).Select(d => d!.Value))
+            .Concat(playDays)
             .Concat(achievementDates);
 
         // Return ISO 8601 timestamps with explicit UTC marker. Frontend converts
@@ -58,5 +68,32 @@ public class GetActivityDaysQuery(ITraleDbContext db)
             .OrderBy(d => d)
             .Select(d => DateTime.SpecifyKind(d, DateTimeKind.Utc).ToString("yyyy-MM-ddTHH:mm:ssZ"))
             .ToList();
+    }
+
+    // ActivityDaysJson is a JSON array of ISO-8601 UTC timestamps written by the
+    // mini-app on each played day. Malformed/empty json yields no dates.
+    private static List<DateTime> ParseActivityDays(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new();
+        try
+        {
+            var raw = System.Text.Json.JsonSerializer.Deserialize<List<string>>(json) ?? new();
+            var result = new List<DateTime>(raw.Count);
+            foreach (var s in raw)
+            {
+                if (DateTime.TryParse(s, null,
+                        System.Globalization.DateTimeStyles.AdjustToUniversal |
+                        System.Globalization.DateTimeStyles.AssumeUniversal,
+                        out var dt))
+                {
+                    result.Add(DateTime.SpecifyKind(dt, DateTimeKind.Utc));
+                }
+            }
+            return result;
+        }
+        catch
+        {
+            return new();
+        }
     }
 }

--- a/src/Domain/Entities/MiniAppUserProgress.cs
+++ b/src/Domain/Entities/MiniAppUserProgress.cs
@@ -48,6 +48,15 @@ public class MiniAppUserProgress
     public string? OnboardingHintsJson { get; set; }
 
     /// <summary>
+    /// JSON array of ISO-8601 UTC timestamps, one per distinct UTC day the user
+    /// played the mini-app. Backs the profile activity heatmap: mini-app plays
+    /// otherwise leave only the single <see cref="LastPlayedAtUtc"/> point, so
+    /// without this log a daily learner would light up just one cell.
+    /// Null until the first play after this column shipped.
+    /// </summary>
+    public string? ActivityDaysJson { get; set; }
+
+    /// <summary>
     /// Total XP spent on treats in the treat shop.
     /// Available XP = Xp - XpSpent.
     /// </summary>

--- a/src/Persistence/Migrations/20260619153512_AddActivityDaysJson.Designer.cs
+++ b/src/Persistence/Migrations/20260619153512_AddActivityDaysJson.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Persistence;
@@ -11,9 +12,11 @@ using Persistence;
 namespace Persistence.Migrations
 {
     [DbContext(typeof(TraleDbContext))]
-    partial class TraleDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619153512_AddActivityDaysJson")]
+    partial class AddActivityDaysJson
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/Migrations/20260619153512_AddActivityDaysJson.cs
+++ b/src/Persistence/Migrations/20260619153512_AddActivityDaysJson.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddActivityDaysJson : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ActivityDaysJson",
+                table: "MiniAppUserProgresses",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ActivityDaysJson",
+                table: "MiniAppUserProgresses");
+        }
+    }
+}

--- a/src/Trale/MiniApp/ProgressCalculator.cs
+++ b/src/Trale/MiniApp/ProgressCalculator.cs
@@ -65,6 +65,7 @@ public class ProgressCalculator : IProgressCalculator
             }
         }
         progress.LastPlayedAtUtc = DateTime.UtcNow;
+        RecordActivityDay(progress, DateTime.UtcNow);
 
         // Record completion — only on 100%, skip "vocabulary" pseudo-module
         var lessonCompleted = false;
@@ -99,6 +100,52 @@ public class ProgressCalculator : IProgressCalculator
             lastFedAtUtc = progress.LastFedAtUtc,
             lastTreatIndex = progress.LastTreatIndex
         };
+    }
+
+    // Append nowUtc to the activity-days log unless this UTC day is already recorded.
+    // Stored as a JSON array of ISO-8601 UTC timestamps (one per played UTC day);
+    // the frontend localizes each to the user's date for the heatmap. Bounded to the
+    // most recent year so the column can't grow without limit.
+    private static void RecordActivityDay(MiniAppUserProgress progress, DateTime nowUtc)
+    {
+        var days = ParseActivityDays(progress.ActivityDaysJson);
+
+        var today = nowUtc.Date;
+        if (days.Exists(d => d.Date == today)) return;
+
+        days.Add(nowUtc);
+        days.Sort();
+        var cutoff = today.AddDays(-366);
+        days.RemoveAll(d => d.Date < cutoff);
+
+        progress.ActivityDaysJson = JsonSerializer.Serialize(
+            days.ConvertAll(d => DateTime.SpecifyKind(d, DateTimeKind.Utc)
+                .ToString("yyyy-MM-ddTHH:mm:ssZ")));
+    }
+
+    private static List<DateTime> ParseActivityDays(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new();
+        try
+        {
+            var raw = JsonSerializer.Deserialize<List<string>>(json) ?? new();
+            var result = new List<DateTime>(raw.Count);
+            foreach (var s in raw)
+            {
+                if (DateTime.TryParse(s, null,
+                        System.Globalization.DateTimeStyles.AdjustToUniversal |
+                        System.Globalization.DateTimeStyles.AssumeUniversal,
+                        out var dt))
+                {
+                    result.Add(DateTime.SpecifyKind(dt, DateTimeKind.Utc));
+                }
+            }
+            return result;
+        }
+        catch
+        {
+            return new();
+        }
     }
 
     private static Dictionary<string, List<int>> ParseCompletedLessons(string json)

--- a/src/Trale/miniapp-src/src/screens/Profile.tsx
+++ b/src/Trale/miniapp-src/src/screens/Profile.tsx
@@ -209,9 +209,12 @@ export default function Profile({ catalog, progress, isPro, isOwner = false, tel
           <div className="relative z-[1]">
             <StreakHeatmap activityDates={activityDates} days={35} />
             <div className="font-sans text-[11px] text-jewelInk-mid text-center mt-2">
-              {activityDates.size > 0
-                ? `${activityDates.size} ${plural(activityDates.size, 'день', 'дня', 'дней')} с активностью`
-                : 'Сделай первый шаг — добавь слово или пройди урок'}
+              {(() => {
+                const activeCount = activeDaysInWindow(activityDates, 35)
+                return activeCount > 0
+                  ? `${activeCount} ${plural(activeCount, 'день', 'дня', 'дней')} с активностью`
+                  : 'Сделай первый шаг — добавь слово или пройди урок'
+              })()}
             </div>
           </div>
         </div>
@@ -601,27 +604,61 @@ function plural(n: number, one: string, two: string, many: string): string {
 // Georgian weekday abbreviations Mon–Sun: ორ/სამ/ოთხ/ხუთ/პარ/შაბ/კვირ
 const WEEKDAY_LABELS = ['ო', 'ს', 'ო', 'ხ', 'პ', 'შ', 'კ']
 
-function StreakHeatmap({ activityDates, days }: { activityDates: Set<string>; days: number }) {
+// Mon-first column index (0=Mon … 6=Sun) for a date — matches WEEKDAY_LABELS order.
+export function mondayFirstColumn(d: Date): number {
+  return (d.getDay() + 6) % 7
+}
+
+// Count of distinct local days with activity inside the last `days` window.
+// Drives the caption so the number always matches the lit cells the user sees.
+export function activeDaysInWindow(activityDates: Set<string>, days: number): number {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  let n = 0
+  for (let i = 0; i < days; i++) {
+    const d = new Date(today)
+    d.setDate(today.getDate() - i)
+    if (activityDates.has(localDateKey(d))) n++
+  }
+  return n
+}
+
+export function StreakHeatmap({ activityDates, days }: { activityDates: Set<string>; days: number }) {
   const today = new Date()
   today.setHours(0, 0, 0, 0)
 
-  // Map getDay() (0=Sun…6=Sat) to Mon-first column index
-  const todayColumnIndex = (today.getDay() + 6) % 7
+  const todayColumnIndex = mondayFirstColumn(today)
 
-  const cells: { date: string; active: boolean; isToday: boolean }[] = []
+  // The `days` calendar days ending today.
+  const dayCells: { date: string; active: boolean; isToday: boolean }[] = []
   for (let i = days - 1; i >= 0; i--) {
     const d = new Date(today)
     d.setDate(today.getDate() - i)
     const key = localDateKey(d)
-    cells.push({
+    dayCells.push({
       date: key,
       active: activityDates.has(key),
       isToday: i === 0
     })
   }
 
-  // Render as 5 rows × 7 columns (oldest top-left, today bottom-right)
-  const rows: typeof cells[] = []
+  // Pad so every column lines up with its weekday label: leading blanks before the
+  // first day's weekday, trailing blanks after today to finish the last week row.
+  // (Previously today was always forced into the last column, so the labels lied
+  // unless today happened to be Sunday.)
+  const firstDay = new Date(today)
+  firstDay.setDate(today.getDate() - (days - 1))
+  const leading = mondayFirstColumn(firstDay)
+  const trailing = 6 - todayColumnIndex
+
+  type Cell = { date: string; active: boolean; isToday: boolean } | null
+  const cells: Cell[] = [
+    ...Array.from<unknown, Cell>({ length: leading }, () => null),
+    ...dayCells,
+    ...Array.from<unknown, Cell>({ length: trailing }, () => null)
+  ]
+
+  const rows: Cell[][] = []
   for (let i = 0; i < cells.length; i += 7) {
     rows.push(cells.slice(i, i + 7))
   }
@@ -646,18 +683,22 @@ function StreakHeatmap({ activityDates, days }: { activityDates: Set<string>; da
       </div>
       {rows.map((row, ri) => (
         <div key={ri} className="flex gap-1.5">
-          {row.map((c) => (
-            <div
-              key={c.date}
-              title={c.date}
-              className="w-6 h-6 rounded border-[1.5px] border-jewelInk"
-              style={{
-                background: c.active ? '#1B5FB0' : 'rgba(21,16,10,0.06)',
-                outline: c.isToday ? '2px solid #F5B820' : 'none',
-                outlineOffset: c.isToday ? '1px' : undefined
-              }}
-            />
-          ))}
+          {row.map((c, ci) =>
+            c === null ? (
+              <div key={`blank-${ri}-${ci}`} className="w-6 h-6" />
+            ) : (
+              <div
+                key={c.date}
+                title={c.date}
+                className="w-6 h-6 rounded border-[1.5px] border-jewelInk"
+                style={{
+                  background: c.active ? '#1B5FB0' : 'rgba(21,16,10,0.06)',
+                  outline: c.isToday ? '2px solid #F5B820' : 'none',
+                  outlineOffset: c.isToday ? '1px' : undefined
+                }}
+              />
+            )
+          )}
         </div>
       ))}
     </div>

--- a/src/Trale/miniapp-src/src/screens/__tests__/ProfileHeatmap.test.tsx
+++ b/src/Trale/miniapp-src/src/screens/__tests__/ProfileHeatmap.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { StreakHeatmap, mondayFirstColumn, activeDaysInWindow } from '../Profile'
+
+// Mirror of Profile's localDateKey (not exported) — yyyy-MM-dd in local time.
+function key(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+describe('mondayFirstColumn', () => {
+  it('maps Monday to column 0 and Sunday to column 6', () => {
+    expect(mondayFirstColumn(new Date(2026, 5, 15))).toBe(0) // Mon 2026-06-15
+    expect(mondayFirstColumn(new Date(2026, 5, 18))).toBe(3) // Thu
+    expect(mondayFirstColumn(new Date(2026, 5, 21))).toBe(6) // Sun
+  })
+})
+
+describe('activeDaysInWindow', () => {
+  it('counts only distinct local days inside the window', () => {
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    const threeAgo = new Date(today)
+    threeAgo.setDate(today.getDate() - 3)
+    const wayBack = new Date(today)
+    wayBack.setDate(today.getDate() - 100)
+
+    const set = new Set([key(today), key(threeAgo), key(wayBack)])
+    expect(activeDaysInWindow(set, 35)).toBe(2) // wayBack is outside the 35-day window
+  })
+
+  it('returns 0 for an empty set', () => {
+    expect(activeDaysInWindow(new Set<string>(), 35)).toBe(0)
+  })
+})
+
+describe('StreakHeatmap weekday alignment', () => {
+  it("places today's cell under the column matching its real weekday", () => {
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    const todayKey = key(today)
+
+    const { container } = render(
+      <StreakHeatmap activityDates={new Set([todayKey])} days={35} />
+    )
+
+    const todayCell = container.querySelector(`[title="${todayKey}"]`)
+    expect(todayCell).not.toBeNull()
+
+    const row = todayCell!.parentElement!
+    const columnIndex = Array.from(row.children).indexOf(todayCell as Element)
+
+    // The bug was today always landing in the last (Sunday) column regardless of
+    // the real weekday. Now it must sit under its actual weekday column.
+    expect(columnIndex).toBe(mondayFirstColumn(today))
+  })
+
+  it('renders a 7-column header and 7-wide rows', () => {
+    const { container } = render(
+      <StreakHeatmap activityDates={new Set<string>()} days={35} />
+    )
+    const flexRows = container.querySelectorAll(':scope > div > div.flex')
+    // header + at least 5 week rows, each exactly 7 cells wide
+    expect(flexRows.length).toBeGreaterThanOrEqual(6)
+    flexRows.forEach((r) => expect(r.children.length).toBe(7))
+  })
+})

--- a/tests/Infrastructure.UnitTests/MiniApp/ProgressCalculatorActivityDaysTests.cs
+++ b/tests/Infrastructure.UnitTests/MiniApp/ProgressCalculatorActivityDaysTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+using Domain.Entities;
+using NUnit.Framework;
+using Shouldly;
+using Trale.MiniApp;
+
+namespace Infrastructure.UnitTests.MiniApp;
+
+// Guards the per-day activity log that backs the profile heatmap: a daily mini-app
+// learner must light up one cell PER played day, not just the single LastPlayedAtUtc.
+[TestFixture]
+public class ProgressCalculatorActivityDaysTests
+{
+    private static MiniAppUserProgress NewProgress(string? activityDaysJson = null) => new()
+    {
+        CompletedLessonsJson = "{}",
+        SentenceBuilderProgressJson = "{}",
+        ActivityDaysJson = activityDaysJson
+    };
+
+    private static List<DateTime> ParseDays(string? json) =>
+        JsonSerializer.Deserialize<List<string>>(json!)!
+            .ConvertAll(s => DateTime.Parse(s, null, DateTimeStyles.AdjustToUniversal).ToUniversalTime());
+
+    [Test]
+    public void Records_today_and_preserves_prior_days()
+    {
+        var calc = new ProgressCalculator();
+        var fiveDaysAgo = DateTime.UtcNow.Date.AddDays(-5).AddHours(9);
+        var progress = NewProgress(JsonSerializer.Serialize(
+            new[] { fiveDaysAgo.ToString("yyyy-MM-ddTHH:mm:ssZ") }));
+
+        calc.CalculateLessonCompletion(progress, "verbs", 1, 3, 3);
+
+        var days = ParseDays(progress.ActivityDaysJson);
+        days.Count.ShouldBe(2); // prior day kept + today appended
+        days.ShouldContain(d => d.Date == DateTime.UtcNow.Date);
+        days.ShouldContain(d => d.Date == fiveDaysAgo.Date);
+    }
+
+    [Test]
+    public void Does_not_duplicate_when_played_twice_same_day()
+    {
+        var calc = new ProgressCalculator();
+        var progress = NewProgress();
+
+        calc.CalculateLessonCompletion(progress, "verbs", 1, 3, 3);
+        calc.CalculateLessonCompletion(progress, "verbs", 2, 3, 3);
+
+        ParseDays(progress.ActivityDaysJson).Count.ShouldBe(1);
+    }
+
+    [Test]
+    public void Starts_log_when_json_is_null()
+    {
+        var calc = new ProgressCalculator();
+        var progress = NewProgress(activityDaysJson: null);
+
+        calc.CalculateLessonCompletion(progress, "verbs", 1, 2, 3);
+
+        progress.ActivityDaysJson.ShouldNotBeNull();
+        ParseDays(progress.ActivityDaysJson).Count.ShouldBe(1);
+    }
+}


### PR DESCRIPTION
## Проблема
Плитка «активность · 35 дней» в профиле занижала активность и врала подписями дней недели.

**Корень:** прохождение урока в мини-аппе только перезаписывало один `LastPlayedAtUtc`, то есть per-day лога занятий не было. Юзер со стриком 15 загорался максимум одной клеткой; у чисто-мини-апп-юзеров навсегда «1 день с активностью». Исторические клетки могли прийти только из старых таблиц словаря/квизов/ачивок, которых у большинства нет.

Пруф с прода: топ-юзер (стрик 15, 3140 XP) — лишь 1 исторический день активности.

## Что сделано
- **Per-day лог занятий** в `MiniAppUserProgress.ActivityDaysJson` — один ISO-UTC таймстамп на каждый сыгранный день (ограничение ~1 год). Пишется при завершении урока рядом с `LastPlayedAtUtc`; `GetActivityDaysQuery` подмешивает его к остальным источникам.
- **Выравнивание сетки** `StreakHeatmap`: ведущие/замыкающие пустые клетки, чтобы каждый столбец соответствовал реальному дню недели. Раньше «сегодня» всегда падало в крайний (воскресный) столбец, и подсветка дня недели в заголовке не совпадала с подсвеченной клеткой, кроме случая, когда сегодня воскресенье.
- **Подпись** теперь считает только дни внутри видимого окна — число всегда совпадает с зажжёнными клетками.

Существующие юзеры стартуют с чистого листа (историю не восстановить); плитка корректно наполняется со следующей игры.

## Тесты
- Фронт: `ProfileHeatmap.test.tsx` — выравнивание по дню недели + хелперы (5 тестов, зелёные).
- Бэк: `ProgressCalculatorActivityDaysTests` — запись дня, дедуп в пределах дня, старт с null (3 теста, зелёные).
- Application.UnitTests: 138/138 зелёные.

Миграция: `AddActivityDaysJson` (один nullable text-столбец).

🤖 Generated with [Claude Code](https://claude.com/claude-code)