### PR TITLE
feat(attribution): capture acquisition source — tell where users come from

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -278,6 +278,7 @@ Location: `src/Persistence/Migrations/`. Test greps the migration class name (af
 | `MakeNotificationTriggerUnique` | Dedups existing rows and makes the NotificationTrigger (UserId, Source) index unique, so the atomic claim-before-send can't double-fire the return push across overlapping dispatch runs (incident 2026-06-17). |
 | `AddOnboardingHintsJson` | Adds nullable OnboardingHintsJson to MiniAppUserProgress — persisted state (seen hints + lastShownAt) for the contextual, time-spread onboarding nudges. |
 | `AddActivityDaysJson` | Adds nullable ActivityDaysJson to MiniAppUserProgress — per-day mini-app play log (one UTC timestamp per played day) so the profile activity heatmap lights one cell per played day instead of only the single LastPlayedAtUtc point. |
+| `AddUserAcquisitionSource` | Adds nullable AcquisitionSource to User — first-touch acquisition tag captured from the /start deep-link payload (e.g. "site") or the mini-app start_param, so registrations can be attributed to landing/channel/post/direct traffic. |
 
 ---
 

--- a/src/Application/DependencyInjection.cs
+++ b/src/Application/DependencyInjection.cs
@@ -55,6 +55,9 @@ public static class DependencyInjection
         services.AddScoped<GetUserVocabularyQuery>();
         services.AddScoped<FeedTreatService>();
 
+        // Acquisition attribution (per ARCHITECTURE.md, no MediatR)
+        services.AddScoped<RecordAcquisitionSourceService>();
+
         // Referral services (per ARCHITECTURE.md, no MediatR)
         services.AddScoped<RecordReferralLinkService>();
         services.AddScoped<TryActivateReferralService>();

--- a/src/Application/MiniApp/Commands/RecordAcquisitionSourceService.cs
+++ b/src/Application/MiniApp/Commands/RecordAcquisitionSourceService.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Application.MiniApp.Commands;
+
+/// <summary>
+/// Records where a user first came from — the /start deep-link payload (e.g.
+/// "site", "channel_neuralfordevs") or the mini-app start_param. First-touch
+/// attribution: written once and never overwritten, so a later visit through a
+/// different link doesn't rewrite the original source.
+/// </summary>
+public class RecordAcquisitionSourceService(ITraleDbContext db, ILoggerFactory loggerFactory)
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<RecordAcquisitionSourceService>();
+
+    private const int MaxLength = 64;
+
+    // Telegram already restricts start params to [A-Za-z0-9_-]; mirror that and
+    // drop anything else so a malformed tag can never reach the column.
+    private static readonly Regex Allowed = new("^[A-Za-z0-9_-]{1,64}$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Normalizes a raw source tag to the stored form, or null if it isn't a valid
+    /// source tag (empty, too long, or contains disallowed characters).
+    /// </summary>
+    public static string? Sanitize(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        var trimmed = raw.Trim();
+        if (trimmed.Length > MaxLength) return null;
+        if (!Allowed.IsMatch(trimmed)) return null;
+        return trimmed.ToLowerInvariant();
+    }
+
+    public async Task<RecordAcquisitionSourceResult> ExecuteAsync(
+        Guid userId, string? rawSource, CancellationToken ct)
+    {
+        var source = Sanitize(rawSource);
+        if (source == null) return RecordAcquisitionSourceResult.InvalidSource;
+
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Id == userId, ct);
+        if (user == null) return RecordAcquisitionSourceResult.UserNotFound;
+
+        // First-touch wins — never overwrite an existing source.
+        if (!string.IsNullOrEmpty(user.AcquisitionSource))
+        {
+            return RecordAcquisitionSourceResult.AlreadySet;
+        }
+
+        user.AcquisitionSource = source;
+        await db.SaveChangesAsync(ct);
+        _logger.LogInformation("Acquisition source recorded: {User} <- {Source}", userId, source);
+        return RecordAcquisitionSourceResult.Recorded;
+    }
+}
+
+public enum RecordAcquisitionSourceResult
+{
+    Recorded,
+    AlreadySet,
+    InvalidSource,
+    UserNotFound
+}

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -26,6 +26,15 @@ public class User
     public bool NotificationsEnabled { get; set; } = true;
     public DateTime? ProPurchasedAtUtc { get; set; }
     public SubscriptionPlan? SubscriptionPlan { get; set; }
+
+    /// <summary>
+    /// First-touch acquisition source, captured from the /start deep-link payload
+    /// (e.g. "site", "channel_neuralfordevs") or the mini-app start_param. Null for
+    /// users who arrived before attribution shipped or with no source tag. Set once
+    /// and never overwritten, so it reflects where the user originally came from.
+    /// Sanitized to [A-Za-z0-9_-], lower-cased, max 64 chars.
+    /// </summary>
+    public string? AcquisitionSource { get; set; }
     public virtual UserSettings Settings { get; set; }
     public virtual ICollection<VocabularyEntry> VocabularyEntries { get; set; }
     public virtual ICollection<Quiz> Quizzes { get; set; }

--- a/src/Infrastructure/Telegram/BotCommands/StartCommand.cs
+++ b/src/Infrastructure/Telegram/BotCommands/StartCommand.cs
@@ -17,6 +17,7 @@ public class StartCommand(
     IMediator mediator,
     BotConfiguration botConfig,
     RecordReferralLinkService referralRecorder,
+    RecordAcquisitionSourceService acquisitionRecorder,
     ILoggerFactory loggerFactory) : IBotCommand
 {
     private const string ReferralPrefix = "ref_";
@@ -64,12 +65,12 @@ public class StartCommand(
                         user.Id, referrerTelegramId, refResult);
                 }
             }
-            else
+            else if (Guid.TryParse(arg, out var shareableQuizId))
             {
                 var result = await mediator.Send(new CreateQuizFromShareableCommand
                 {
                     UserId = request.User?.Id ?? user!.Id,
-                    ShareableQuizId = Guid.Parse(arg)
+                    ShareableQuizId = shareableQuizId
                 }, token);
 
                 await (result switch
@@ -80,6 +81,17 @@ public class StartCommand(
                 });
 
                 return;
+            }
+            else
+            {
+                // Any other payload is an acquisition source tag from a deep-link,
+                // e.g. t.me/trale_bot?start=site. First-touch only — the service
+                // ignores it if malformed or the user already has a source. Falls
+                // through to the normal welcome flow below.
+                var srcResult = await acquisitionRecorder.ExecuteAsync(user!.Id, arg, token);
+                _logger.LogInformation(
+                    "Acquisition source from /start: user {User} tag {Tag} → {Result}",
+                    user.Id, arg, srcResult);
             }
         }
 

--- a/src/Persistence/Migrations/20260619164028_AddUserAcquisitionSource.Designer.cs
+++ b/src/Persistence/Migrations/20260619164028_AddUserAcquisitionSource.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Persistence;
@@ -11,9 +12,11 @@ using Persistence;
 namespace Persistence.Migrations
 {
     [DbContext(typeof(TraleDbContext))]
-    partial class TraleDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619164028_AddUserAcquisitionSource")]
+    partial class AddUserAcquisitionSource
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/Migrations/20260619164028_AddUserAcquisitionSource.cs
+++ b/src/Persistence/Migrations/20260619164028_AddUserAcquisitionSource.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserAcquisitionSource : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AcquisitionSource",
+                table: "Users",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AcquisitionSource",
+                table: "Users");
+        }
+    }
+}

--- a/src/Trale/Controllers/MiniAppController.cs
+++ b/src/Trale/Controllers/MiniAppController.cs
@@ -56,6 +56,7 @@ public class MiniAppController : Controller
     private readonly MonetizationMetrics _metrics;
     private readonly ILogger<MiniAppController> _logger;
     private readonly FeedTreatService _feedTreatService;
+    private readonly RecordAcquisitionSourceService _acquisitionRecorder;
 
     public MiniAppController(
         IGeorgianQuestionsLoaderFactory questionsLoaderFactory,
@@ -66,7 +67,8 @@ public class MiniAppController : Controller
         ITelegramBotClient telegramBotClient,
         MonetizationMetrics metrics,
         ILogger<MiniAppController> logger,
-        FeedTreatService feedTreatService)
+        FeedTreatService feedTreatService,
+        RecordAcquisitionSourceService acquisitionRecorder)
     {
         _questionsLoaderFactory = questionsLoaderFactory;
         _dbContext = dbContext;
@@ -77,6 +79,7 @@ public class MiniAppController : Controller
         _metrics = metrics;
         _logger = logger;
         _feedTreatService = feedTreatService;
+        _acquisitionRecorder = acquisitionRecorder;
     }
 
     [HttpGet("ping")]
@@ -737,6 +740,18 @@ public class MiniAppController : Controller
         var user = await _dbContext.Users
             .Include(u => u.Settings)
             .FirstOrDefaultAsync(u => u.TelegramId == telegramId.Value, ct);
+
+        // First-touch attribution for users who arrive straight into the mini-app via
+        // a t.me/bot/app?startapp=<source> deep-link. Only when the user has no source
+        // yet; the service no-ops otherwise, so this stays a one-time write.
+        if (user != null && string.IsNullOrEmpty(user.AcquisitionSource))
+        {
+            var startParam = TelegramInitDataValidator.TryGetStartParam(initData);
+            if (startParam != null)
+            {
+                await _acquisitionRecorder.ExecuteAsync(user.Id, startParam, ct);
+            }
+        }
 
         return user;
     }

--- a/src/Trale/Services/TelegramInitDataValidator.cs
+++ b/src/Trale/Services/TelegramInitDataValidator.cs
@@ -79,4 +79,18 @@ public static class TelegramInitDataValidator
 
         return null;
     }
+
+    /// <summary>
+    /// Extracts the mini-app start_param (from a t.me/bot/app?startapp=... deep-link)
+    /// out of initData. Does NOT validate the hash — call only after
+    /// <see cref="ValidateAndGetUserId"/> has authenticated the same initData string.
+    /// Returns null when absent.
+    /// </summary>
+    public static string? TryGetStartParam(string initData)
+    {
+        if (string.IsNullOrWhiteSpace(initData)) return null;
+        var parsed = HttpUtility.ParseQueryString(initData);
+        var startParam = parsed["start_param"];
+        return string.IsNullOrWhiteSpace(startParam) ? null : startParam;
+    }
 }

--- a/src/Trale/miniapp-src/src/screens/LandingScreen.tsx
+++ b/src/Trale/miniapp-src/src/screens/LandingScreen.tsx
@@ -136,7 +136,9 @@ const FAQ_ITEMS = [
 // ── Main screen ──────────────────────────────────────────────────────────────
 
 export default function LandingScreen({ botUsername }: Props) {
-  const tgLink = `https://t.me/${botUsername ?? 'trale_bot'}`
+  // ?start=site tags everyone who opens the bot from this landing, so acquisition
+  // analytics can tell site visitors apart from channel/post/direct traffic.
+  const tgLink = `https://t.me/${botUsername ?? 'trale_bot'}?start=site`
 
   return (
     <div className="flex flex-col min-h-full bg-cream">

--- a/tests/Application.UnitTests/Tests/RecordAcquisitionSourceServiceTests.cs
+++ b/tests/Application.UnitTests/Tests/RecordAcquisitionSourceServiceTests.cs
@@ -1,0 +1,82 @@
+using Application.MiniApp.Commands;
+using Application.UnitTests.Common;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace Application.UnitTests.Tests;
+
+public class RecordAcquisitionSourceServiceTests : CommandTestsBase
+{
+    private RecordAcquisitionSourceService _sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _sut = new RecordAcquisitionSourceService(Context, NullLoggerFactory.Instance);
+    }
+
+    [Test]
+    public async Task Records_source_on_first_touch()
+    {
+        var user = await CreateFreeUser();
+        user.AcquisitionSource = null;
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.ExecuteAsync(user.Id, "site", CancellationToken.None);
+
+        result.ShouldBe(RecordAcquisitionSourceResult.Recorded);
+        Context.Users.First(u => u.Id == user.Id).AcquisitionSource.ShouldBe("site");
+    }
+
+    [Test]
+    public async Task Does_not_overwrite_existing_source()
+    {
+        var user = await CreateFreeUser();
+        user.AcquisitionSource = "channel_neuralfordevs";
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.ExecuteAsync(user.Id, "site", CancellationToken.None);
+
+        result.ShouldBe(RecordAcquisitionSourceResult.AlreadySet);
+        Context.Users.First(u => u.Id == user.Id).AcquisitionSource.ShouldBe("channel_neuralfordevs");
+    }
+
+    [Test]
+    public async Task Rejects_malformed_tag_and_leaves_source_null()
+    {
+        var user = await CreateFreeUser();
+        user.AcquisitionSource = null;
+        await Context.SaveChangesAsync();
+
+        var result = await _sut.ExecuteAsync(user.Id, "drop table users;", CancellationToken.None);
+
+        result.ShouldBe(RecordAcquisitionSourceResult.InvalidSource);
+        Context.Users.First(u => u.Id == user.Id).AcquisitionSource.ShouldBeNull();
+    }
+
+    [TestCase("Site", "site")]                       // lower-cased
+    [TestCase("  channel_x  ", "channel_x")]         // trimmed
+    [TestCase("post-2026_06", "post-2026_06")]       // allowed punctuation
+    public void Sanitize_normalizes_valid_tags(string raw, string expected)
+    {
+        RecordAcquisitionSourceService.Sanitize(raw).ShouldBe(expected);
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase(null)]
+    [TestCase("has space")]
+    [TestCase("emoji🚀")]
+    [TestCase("with/slash")]
+    public void Sanitize_rejects_invalid_tags(string? raw)
+    {
+        RecordAcquisitionSourceService.Sanitize(raw).ShouldBeNull();
+    }
+
+    [Test]
+    public void Sanitize_rejects_overlong_tag()
+    {
+        var tooLong = new string('a', 65);
+        RecordAcquisitionSourceService.Sanitize(tooLong).ShouldBeNull();
+    }
+}

--- a/tests/Infrastructure.UnitTests/BotCommands/StartCommandShould.cs
+++ b/tests/Infrastructure.UnitTests/BotCommands/StartCommandShould.cs
@@ -55,9 +55,10 @@ public class StartCommandShould
             MiniAppEnabled = miniAppEnabled
         };
 
-        // RecordReferralLinkService is never called in the returning-user /start flow
-        // (only triggered when args contain "ref_" prefix). Safe to pass null.
-        return new StartCommand(_mockClient.Object, _mockMediator.Object, botConfig, null!, NullLoggerFactory.Instance);
+        // RecordReferralLinkService / RecordAcquisitionSourceService are never called
+        // in the returning-user /start flow (only on "ref_" / source-tag args). Safe
+        // to pass null.
+        return new StartCommand(_mockClient.Object, _mockMediator.Object, botConfig, null!, null!, NullLoggerFactory.Instance);
     }
 
     private static TelegramRequest BuildReturningUserRequest(long telegramId, Language language)

--- a/tests/Infrastructure.UnitTests/MiniApp/TelegramInitDataStartParamTests.cs
+++ b/tests/Infrastructure.UnitTests/MiniApp/TelegramInitDataStartParamTests.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using Shouldly;
+using Trale.Services;
+
+namespace Infrastructure.UnitTests.MiniApp;
+
+[TestFixture]
+public class TelegramInitDataStartParamTests
+{
+    [Test]
+    public void Extracts_start_param_from_init_data()
+    {
+        const string initData = "auth_date=123&start_param=site&user=%7B%22id%22%3A1%7D&hash=abc";
+        TelegramInitDataValidator.TryGetStartParam(initData).ShouldBe("site");
+    }
+
+    [Test]
+    public void Returns_null_when_no_start_param()
+    {
+        const string initData = "auth_date=123&user=%7B%22id%22%3A1%7D&hash=abc";
+        TelegramInitDataValidator.TryGetStartParam(initData).ShouldBeNull();
+    }
+
+    [Test]
+    public void Returns_null_for_empty_init_data()
+    {
+        TelegramInitDataValidator.TryGetStartParam("").ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Зачем
Не было способа понять, откуда приходят регистрации — с лендинга, из канала, из поста или напрямую. Единственная атрибуция — внутренняя реферальная программа (6 человек за всё время). Хуже того: произвольный `/start`-параметр падал на `Guid.Parse`, то есть любая source-метка в ссылке **ломала** команду, а не записывалась.

## Что сделано (MVP)
- **`User.AcquisitionSource`** (nullable) — first-touch источник: ставится один раз, не перезаписывается. Миграция `AddUserAcquisitionSource`.
- **`RecordAcquisitionSourceService`** — санитизация метки до `[A-Za-z0-9_-]`, lower-case, ≤64 символов (как требует Telegram к start-param); пишет только если пусто.
- **`StartCommand`** — не-`ref_`, не-GUID payload теперь трактуется как source-метка (напр. `t.me/trale_bot?start=site`), а не валит команду. Парсинг расшаренного квиза переведён на `Guid.TryParse` (фикс краша).
- **`MiniAppController.ResolveUserAsync`** — ловит `start_param` из `t.me/bot/app?startapp=<source>` для юзеров без источника (`TelegramInitDataValidator.TryGetStartParam`).
- **Лендинг** — CTA теперь ведёт на `t.me/trale_bot?start=site`, чтобы трафик с сайта отличался от канала/поста/прямого.

## Как смотреть
Пока запросом по БД — разбивка регистраций по `AcquisitionSource`. Дальше можно навесить плитку в админке и разнести метки лендинга (`site_hero`/`site_faq`/`site_pricing`) и завести ссылки под каждый канал/пост.

## Тесты
- `RecordAcquisitionSourceServiceTests` (13) — first-touch, не-перезапись, отклонение мусора, санитизация.
- `TelegramInitDataStartParamTests` (3) — извлечение `start_param`.
- `StartCommandShould` — обновлён конструктор.
- Frontend: 33 теста зелёные, build ок.

Миграция: `AddUserAcquisitionSource` (один nullable text-столбец на Users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)