### PR TITLE
security: bump vulnerable deps (Crypto.Xml 8.0.3, OpenTelemetry 1.15.3)

### DIFF
--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -19,7 +19,7 @@
         <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
         <PackageReference Include="OpenAI" Version="2.10.0" />
         <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
@@ -28,6 +28,8 @@
         <PackageReference Include="Prometheus.Client.HttpRequestDurations" Version="3.6.0" />
         <PackageReference Include="Telegram.Bot" Version="19.0.0" />
         <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+        <!-- Security pin: overrides transitive 8.0.2 pulled via Microsoft.AspNetCore.Authentication (CVE-2026-33116, CVE-2026-26171) -->
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Что
Бамп уязвимых транзитивных зависимостей до пропатченных версий.

- **System.Security.Cryptography.Xml** 8.0.2 → 8.0.3 — CVE-2026-33116, CVE-2026-26171 (DoS в EncryptedXml). Тёк транзитивно через Microsoft.AspNetCore.Authentication, запинен прямой ссылкой в Infrastructure.
- **OpenTelemetry.Extensions.Hosting** 1.15.2 → 1.15.3 — CVE-2026-40894 (подтягивает пропатченный OpenTelemetry.Api 1.15.3).

## Проверка
- `dotnet list package --vulnerable` — чисто во всех проектах.
- Тесты зелёные: Infrastructure.UnitTests 1243/1243, IntegrationTests 189/189, Domain/Application юниты — все проходят.

🤖 Generated with [Claude Code](https://claude.com/claude-code)