### PR TITLE
Доделка эпика #936 · 2026-07-02

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -145,6 +145,7 @@ Location: `src/Trale/miniapp-src/src/`. The test greps the base file name (e.g. 
 | `ChipPool.tsx` | Scrollable pool of WordChip tokens for sentence-builder drag-to-slot interaction. |
 | `WordChip.tsx` | Tappable chip representing one Georgian word token; selected/used states. |
 | `TheoryAccordion.tsx` | Collapsible section used on LessonTheory to hide secondary theory behind a tap on first visit (label «📖 Объяснение» / «📖 Остальные буквы»). |
+| `FirstLessonHeroCta.tsx` | Navy hero-CTA rendered on the Dashboard for brand-new users (`completedLessons === {}`). Surfaces «გამარჯობა!» + first lesson title; tap navigates to lesson-theory of the first module's first lesson. |
 
 ### Data (`src/data/`)
 - `dialogs.ts` — 20 daily dialogues for `DialogOfDayCard`; rotates by calendar day.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -89,7 +89,7 @@ Location: `src/Trale/miniapp-src/src/`. The test greps the base file name (e.g. 
 |---|---|---|
 | `Dashboard.tsx` | `dashboard` | Main hub: launch-path bar, module tiles, streak, XP, mascot. |
 | `ModuleMap.tsx` | `module` | Lesson list for a module. |
-| `LessonTheory.tsx` | `lesson-theory` | Theory blocks + reveal overlay; launches Practice. On first visit to alphabet-progressive L1 renders a preview-split: 3 letter cards up front + a «📖 Остальные буквы» accordion hiding the rest. |
+| `LessonTheory.tsx` | `lesson-theory` | Theory blocks + reveal overlay; launches Practice. On first visit to alphabet-progressive L1 renders a preview-split: 3 letter cards up front + a «📖 Остальные буквы» accordion hiding the rest. On first visit to every other lesson (non alphabet L1) hides the theory under a plain «📖 Объяснение» accordion. CTA reads «Поехали →» on first visit, «к практике →» once completed. |
 | `Practice.tsx` | `practice` | Question-answer loop for a lesson. |
 | `Result.tsx` | `result` | Lesson result summary with kilim strip. |
 | `PracticeMistakes.tsx` | `practice-mistakes` | Redo previously-failed questions. |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -89,7 +89,7 @@ Location: `src/Trale/miniapp-src/src/`. The test greps the base file name (e.g. 
 |---|---|---|
 | `Dashboard.tsx` | `dashboard` | Main hub: launch-path bar, module tiles, streak, XP, mascot. |
 | `ModuleMap.tsx` | `module` | Lesson list for a module. |
-| `LessonTheory.tsx` | `lesson-theory` | Theory blocks + reveal overlay; launches Practice. |
+| `LessonTheory.tsx` | `lesson-theory` | Theory blocks + reveal overlay; launches Practice. On first visit to alphabet-progressive L1 renders a preview-split: 3 letter cards up front + a «📖 Остальные буквы» accordion hiding the rest. |
 | `Practice.tsx` | `practice` | Question-answer loop for a lesson. |
 | `Result.tsx` | `result` | Lesson result summary with kilim strip. |
 | `PracticeMistakes.tsx` | `practice-mistakes` | Redo previously-failed questions. |
@@ -144,6 +144,7 @@ Location: `src/Trale/miniapp-src/src/`. The test greps the base file name (e.g. 
 | `SentenceSlot.tsx` | Single droppable slot in the sentence-builder (empty / preset / filled states). |
 | `ChipPool.tsx` | Scrollable pool of WordChip tokens for sentence-builder drag-to-slot interaction. |
 | `WordChip.tsx` | Tappable chip representing one Georgian word token; selected/used states. |
+| `TheoryAccordion.tsx` | Collapsible section used on LessonTheory to hide secondary theory behind a tap on first visit (label «📖 Объяснение» / «📖 Остальные буквы»). |
 
 ### Data (`src/data/`)
 - `dialogs.ts` — 20 daily dialogues for `DialogOfDayCard`; rotates by calendar day.

--- a/design-specs/936-first-lesson-ux-fix.md
+++ b/design-specs/936-first-lesson-ux-fix.md
@@ -1,0 +1,348 @@
+# Первый-урок UX фикс — конверсия picked_level → started_lesson
+
+**Задача:** GitHub epic #936  
+**Статус:** ready
+
+## Обучающий элемент
+
+**Hero-CTA:** первое грузинское слово, которое видит новый пользователь — «გამარჯობა!» (Гамарджоба!) в подписи CTA. Reveal-момент: когда юзер пройдёт урок «Знакомство» и встретит это приветствие в теории, он почувствует узнавание — «я уже видел это слово на экране входа».
+
+**ModuleMap pulse:** первый кружок сохраняет georgian numeral «ა» (ა = 1) — тот же символ, что на badge модуля. Пульсирующая анимация делает очевидным: «путь начинается здесь». Reveal-момент: после первого урока ა превращается в зелёную галочку — число стало достижением.
+
+---
+
+## Экраны и состояния
+
+### Экран: Dashboard — Hero-CTA для нового пользователя
+
+**Условие активации:** `Object.keys(progress.completedLessons).length === 0`
+
+**Layout (375px, верхняя часть — всё видно без скролла):**
+
+```
+┌──────────────────────────────────────────┐
+│ [DashboardTopBar: XP · streak]           │ ~48px
+├──────────────────────────────────────────┤
+│                                          │
+│     [Mascot — compact, 80px]             │
+│      Привет!  ·  готова к знакомству     │
+│                                          │ ~120px
+├──────────────────────────────────────────┤
+│  ┌────────────────────────────────────┐  │
+│  │ 🎯    первый урок          ▼ →    │  │
+│  │       [Название урока]             │  │ min 100px
+│  │       გამარჯობა! · Алфавит, урок 1│  │
+│  └────────────────────────────────────┘  │
+├──────────────────────────────────────────┤
+│ [секция «основы» и модули ниже]          │
+└──────────────────────────────────────────┘
+```
+
+Сумма до скролла: 48 + 120 + 100 = ~268px из 667px — всё входит в viewport.
+
+#### Компонент `FirstLessonHeroCta`
+
+**Props:**
+```tsx
+interface FirstLessonHeroCtaProps {
+  firstLesson: {
+    moduleId: string
+    lessonId: number
+    title: string
+    moduleTitle: string
+  }
+  onStart: () => void
+}
+```
+
+**Стиль карточки:**
+- Класс: `jewel-tile jewel-pressable` (1.5px ink border + 3px offset shadow)
+- Фон: `bg-navy` — контрастный navy, чтобы выделяться среди cream-фоновых тайлов
+- Padding: `px-5 py-5`
+- Минимальная высота: `min-h-[100px]`
+- Ширина: `w-full`
+
+**Внутренняя структура (flex row, items-center, gap-4):**
+
+1. **Иконка-кружок:**
+   - `w-12 h-12 rounded-xl bg-cream border-[1.5px] border-jewelInk`
+   - `style={{ boxShadow: '2px 2px 0 #15100A' }}`
+   - Внутри: `🎯` — font-size 22px
+
+2. **Текстовый блок (flex-1):**
+   - Eyebrow: `mn-eyebrow text-cream/70` → «первый урок»
+   - Title: `font-sans text-[18px] font-extrabold text-cream leading-tight` → `firstLesson.title`
+   - Subtitle: `font-geo text-[11px] text-cream/60 mt-0.5` → «გამარჯობა! · {firstLesson.moduleTitle}, урок {firstLesson.lessonId}»
+
+3. **Chevron:**
+   - SVG стрелка → (18×18), `text-cream/70`
+
+**On tap:**
+1. `window.Telegram?.WebApp?.HapticFeedback?.impactOccurred('medium')`
+2. `onStart()` → navigate к `{ kind: 'lesson-theory', moduleId, lessonId }`
+
+**Анимация:** `jewel-pressable` обеспечивает scale-95 при нажатии — дополнительных анимаций нет.
+
+---
+
+#### Mascot в режиме нового пользователя
+
+- **Размер:** `size={80}` (вместо 120)
+- **Mood:** `cheer` (как сейчас для `totalDone === 0`)
+- **Bowl-indicator:** скрыт (три точки не показываем при 0 прогрессе — нечего показывать)
+- Greeting строки без изменений: «Привет!» / «готова к знакомству»
+
+---
+
+#### Состояния Dashboard по прогрессу
+
+| Состояние | Условие | Hero | Mascot | Покормить |
+|---|---|---|---|---|
+| Новый пользователь | `completedLessons = {}` + `availableXp = 0` | `FirstLessonHeroCta` (navy) | 80px, cheer | Хинт (нет кнопки) |
+| Новый пользователь с XP | `completedLessons = {}` + `availableXp > 0` | `FirstLessonHeroCta` (navy) | 80px, cheer | Кнопка (edge case: мало вероятен, но XP может быть от реферала) |
+| Вернувшийся | `completedLessons != {}` | Обычный suggestion-tile | 120px, contextual | Кнопка если XP > 0 |
+| Вернувшийся, 0 XP | `completedLessons != {}` + `availableXp = 0` | Обычный suggestion-tile | 120px, contextual | Хинт (нет кнопки) |
+
+---
+
+### Экран: Dashboard — кнопка «Покормить» (Scenario 1)
+
+**Условие скрытия:** `availableXp === 0` (независимо от hero-состояния).
+
+**Состояние default (availableXp > 0):** без изменений — кнопка с «🍖 Покормить · ⭐ N».
+
+**Состояние hidden (availableXp === 0):**
+
+Вместо кнопки рендерится однострочный текст-подсказка:
+
+```tsx
+<div className="mt-3 flex justify-center">
+  <p className="font-sans text-[12px] text-center text-jewelInk-hint leading-snug px-6">
+    Заработай XP первым уроком — получишь угощения для Бомборы
+  </p>
+</div>
+```
+
+- Цвет: `text-jewelInk-hint` (самый тихий тон, не конкурирует с hero-CTA)
+- Анимации нет — просто conditional render
+
+---
+
+### Экран: ModuleMap — пульсирующий кружок (Scenario 3)
+
+**Условие активации:**
+```
+completedLessons[moduleId]?.length === 0
+  && !localStorage.getItem(`bombora_module_started_${moduleId}`)
+```
+
+Проверяется на mount через useState + useEffect.
+
+#### Пульсирующая обводка
+
+CSS animation `pulse-ring` добавляется к первому кружку (idx === 0):
+
+```css
+@keyframes pulse-ring {
+  0%   { box-shadow: 0 0 0 0 {accentHex}66, 2px 2px 0 #15100A; }
+  70%  { box-shadow: 0 0 0 8px {accentHex}00, 2px 2px 0 #15100A; }
+  100% { box-shadow: 0 0 0 0 {accentHex}00, 2px 2px 0 #15100A; }
+}
+```
+
+- Длительность: 1.5s ease-out infinite
+- `accentHex` = цвет акцента модуля (navy/ruby/gold)
+- Поверх существующего box-shadow (2px 2px offset), не вместо
+
+Реализация: первый кружок получает prop `isPulsing: boolean` → инлайн-стиль с animation и особым box-shadow.
+
+#### Badge «Начни здесь»
+
+Вставляется в label-блок рядом с первым кружком (под subtitle урока):
+
+```tsx
+{idx === 0 && isPristine && (
+  <span className="inline-flex items-center gap-1 font-sans text-[10px] font-extrabold
+    text-accent bg-accent/10 rounded-md px-1.5 py-0.5 mt-1 border border-accent/30">
+    ▶ Начни здесь
+  </span>
+)}
+```
+
+- `accent` = moduleAccent (navy/ruby/gold)
+- Для `text-navy`: `text-navy bg-navy/10 border-navy/30`
+- Для `text-ruby`: `text-ruby bg-ruby/10 border-ruby/30`
+- Для `text-gold-deep`: `text-gold-deep bg-gold/10 border-gold/30`
+
+#### Снятие пульсации
+
+При клике на **любой** кружок/label-кнопку в этом модуле:
+
+```tsx
+localStorage.setItem(`bombora_module_started_${moduleId}`, '1')
+```
+
+Затем useState обновляется → пульсация и badge исчезают немедленно (без задержки).
+
+#### Состояния ModuleMap
+
+| Состояние | Условие | Кружок 1 |
+|---|---|---|
+| Pristine | 0 completed + не кликали | pulse-ring animation + badge «Начни здесь» |
+| Started | любой клик в этой сессии | без пульсации, без badge |
+| In progress | есть completed | галочки на done, accentBg на current — как сейчас |
+
+---
+
+### Экран: LessonTheory — свёрнутая теория (Scenario 4, не-алфавит)
+
+**Условие свёртывания:**
+- `!(moduleId === 'alphabet-progressive' && lessonId === module.lessons[0]?.id)`  
+- AND `!progress.completedLessons[moduleId]?.includes(lessonId)` (урок не пройден)
+
+**Layout (collapsed):**
+
+```
+[Header: урок N из M]
+[kilim strip]
+
+┌─────────────────────────────────────────┐
+│  урок № N                               │ jewel-tile
+│  [Название урока]                       │
+│  ─────────────────────────────────────  │
+│  цель                                   │
+│  [Текст цели урока]                     │
+└─────────────────────────────────────────┘
+
+┌─────────────────────────────────────────┐
+│  📖 Объяснение                      ▼  │ accordion trigger
+└─────────────────────────────────────────┘
+   (закрыт по умолчанию)
+
+[kilim strip opacity-70]
+
+──────────────────────────────── fixed bar
+[         Поехали →              ]  jewel-btn primary
+```
+
+#### Компонент `TheoryAccordion`
+
+```tsx
+interface TheoryAccordionProps {
+  label: string        // «Объяснение» | «Остальные буквы»
+  defaultOpen?: boolean  // false (default) = свёрнут
+  icon?: string        // «📖» (default)
+  children: React.ReactNode
+}
+```
+
+**Trigger-кнопка:**
+- `w-full flex items-center justify-between px-5 py-4`
+- Фон: `bg-cream` + border: `border-[1px] border-jewelInk/20 rounded-xl`
+- Shadow: `1px 1px 0 rgba(21,16,10,0.1)` (мягкий, вторичный)
+- Текст: `font-sans text-[15px] font-bold text-jewelInk`
+- Chevron: SVG 16×16, поворот 0° (закрыт) → 180° (открыт), transition 200ms
+
+**Body:**
+- При закрытом: `max-height: 0; overflow: hidden; opacity: 0`
+- При открытом: `max-height: none; opacity: 1`
+- Transition: `max-height 300ms ease, opacity 200ms ease`
+- Внутри: `flex flex-col gap-4 pt-4`
+
+**CTA в bottom bar (при первом визите):**
+- Текст: «Поехали →» (вместо «к практике →»)
+- Стиль: `variant="primary"` — без изменений
+
+---
+
+### Экран: LessonTheory — alphabet-progressive урок 1 (Scenario 4, исключение)
+
+**Условие:** `moduleId === 'alphabet-progressive' && lessonId === module.lessons[0]?.id`
+
+Теория НЕ сворачивается в accordion. Показывается preview: первые 3 буквы из блока `type=letters`, остальное — за accordion.
+
+**Layout (preview):**
+
+```
+[Header]
+[kilim strip]
+
+[Title card: jewel-tile — название + цель]
+
+[grid 2-col: первые 3 letter-card из letters-блока]
+(если letters-блок не первый — показываем первый блок целиком)
+
+┌─────────────────────────────────────────┐
+│  📖 Остальные буквы                 ▼  │ accordion (закрыт)
+└─────────────────────────────────────────┘
+   (все буквы 4+ и остальные блоки)
+
+[kilim strip opacity-70]
+
+──────────────────────────────── fixed bar
+[          Поехали →             ]
+```
+
+**Логика preview-сплита:**
+
+```
+lettersBlock = theory.blocks.find(b => b.type === 'letters')
+previewLetters = lettersBlock?.letters?.slice(0, 3) ?? []
+restLetters    = lettersBlock?.letters?.slice(3) ?? []
+restBlocks     = theory.blocks.filter(b => b !== lettersBlock)
+```
+
+Accordion `«📖 Остальные буквы»` содержит:
+- `letters`-блок с `restLetters` (если `restLetters.length > 0`)
+- все `restBlocks`
+
+---
+
+#### Состояния LessonTheory по условиям
+
+| Условие | Theory layout | CTA |
+|---|---|---|
+| Первый визит, не алфавит L1 | Title card + accordion (закрыт) | «Поехали →» |
+| Первый визит, алфавит L1 | Title card + preview 3 букв + accordion (закрыт) | «Поехали →» |
+| Урок уже пройден (любой модуль) | Полная теория раскрыта — как сейчас | «к практике →» |
+
+---
+
+## Копирайтинг
+
+| Место | Текст |
+|---|---|
+| Hero-CTA eyebrow | «первый урок» |
+| Hero-CTA title | `{firstLesson.title}` (из API) |
+| Hero-CTA subtitle | «გამარჯობა! · {moduleTitle}, урок {lessonId}» |
+| Хинт вместо «Покормить» | «Заработай XP первым уроком — получишь угощения для Бомборы» |
+| ModuleMap badge | «▶ Начни здесь» |
+| Accordion trigger (не-алфавит) | «📖 Объяснение» |
+| Accordion trigger (алфавит L1) | «📖 Остальные буквы» |
+| LessonTheory CTA (первый визит) | «Поехали →» |
+| LessonTheory CTA (возврат) | «к практике →» — без изменений |
+
+**Запрещено:** «маладэц», «поехали!» с восклицанием в духе имитации акцента. «Поехали →» со стрелкой — нейтральный и современный тон.
+
+---
+
+## Адаптивность (375px)
+
+- TopBar ~48px + Mascot 80px + greeting ~40px + Hero-CTA 100px = ~268px < 667px ✓ (всё без скролла)
+- Hero-CTA: `w-full min-h-[100px]` — без фиксированной высоты, растягивается под текст
+- Accordion trigger: `py-4` → ~56px tap-target ✓ (≥ 44px)
+- Hero-CTA: `py-5` → ~66px tap-target ✓
+- ModuleMap badge «Начни здесь»: не интерактивен (декоративный), малый шрифт допустим
+- Пульсирующий кружок: CIRCLE_SIZE 48–56px — tap-target в норме ✓
+
+---
+
+## Чеклист перед отправкой
+
+- [x] Использует только Minankari-палитру (navy, cream, jewelInk, gold, ruby)
+- [x] Типографика: eyebrow mn-eyebrow, T1=26px, T2=22px, T3=18px, T4=15-17px, T5=13px, T6=10-12px — в шкале
+- [x] Обучающий элемент: «გამარჯობა!» в CTA, «ა» нумерал в пульсирующем кружке
+- [x] Reveal-момент: greeting → lesson recognition; pulse-badge → checkmark progression
+- [x] Все состояния описаны: new/returning, xp=0/xp>0, pristine/started module, first-visit theory/returning
+- [x] Работает на 375px — верхняя часть без скролла проверена
+- [x] Не нарушает продуктовую философию — контент теории не удаляется, только сворачивается

--- a/src/Trale/miniapp-src/e2e/first-lesson-alphabet-preview.spec.ts
+++ b/src/Trale/miniapp-src/e2e/first-lesson-alphabet-preview.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from '@playwright/test'
+
+// Verifies the alphabet-progressive L1 "preview split" theory layout:
+// a first-visit user sees only 3 letter cards up front, the rest hidden
+// behind an «📖 Остальные буквы» accordion. Reveals full content on tap.
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    ;(window as any).Telegram = {
+      WebApp: {
+        initData: 'user=%7B%22id%22%3A123456%7D',
+        BackButton: { show: () => {}, hide: () => {}, onClick: () => {}, offClick: () => {} },
+        MainButton: { show: () => {}, hide: () => {} },
+        HapticFeedback: { impactOccurred: () => {}, notificationOccurred: () => {} },
+        openTelegramLink: () => {},
+      },
+    }
+    // Kill the one-time "reveal kani" overlay — irrelevant here.
+    try { localStorage.setItem('bombora_kani_reveal_shown', '1') } catch {}
+  })
+})
+
+const letters = [
+  { letter: 'ა', name: 'ани', translit: 'a', exampleGe: 'აი', exampleRu: 'вот' },
+  { letter: 'ბ', name: 'бани', translit: 'b', exampleGe: 'ბაბუა', exampleRu: 'дедушка' },
+  { letter: 'გ', name: 'гани', translit: 'g', exampleGe: 'გამარჯობა', exampleRu: 'здравствуй' },
+  { letter: 'დ', name: 'дони', translit: 'd', exampleGe: 'დედა', exampleRu: 'мама' },
+  { letter: 'ე', name: 'ени', translit: 'e', exampleGe: 'ერთი', exampleRu: 'один' },
+]
+
+const catalog = {
+  botUsername: 'TraleBot',
+  miniAppEnabled: true,
+  modules: [
+    {
+      id: 'alphabet-progressive',
+      title: 'Алфавит',
+      emoji: '🔤',
+      description: 'Грузинский алфавит',
+      lessons: [
+        {
+          id: 1,
+          title: 'Первые буквы',
+          short: 'L1',
+          theory: {
+            title: 'Первые буквы',
+            goal: 'Запомнить первые буквы алфавита',
+            blocks: [
+              { type: 'letters', letters },
+              { type: 'paragraph', text: 'Грузинский алфавит красив и логичен.' },
+            ],
+          },
+        },
+        {
+          id: 2,
+          title: 'Ещё буквы',
+          short: 'L2',
+          theory: { title: 'Ещё буквы', goal: 'g', blocks: [] },
+        },
+      ],
+    },
+  ],
+}
+
+// Post-welcome user: level chosen, welcome completed (some XP), no alphabet progress yet.
+// This is exactly the state where the alphabet-L1 preview should fire on first visit.
+const postWelcomeMe = {
+  authenticated: true,
+  level: 'beginner',
+  isPro: false,
+  isTrialActive: false,
+  trialDaysLeft: 0,
+  vocabularyCount: 0,
+  onboardingHint: null,
+  progress: {
+    xp: 20,
+    streak: 0,
+    lastPlayedAtUtc: null,
+    completedLessons: { welcome: [1] },
+    xpSpent: 0,
+    totalTreatsGiven: 0,
+    lastFedAtUtc: null,
+    lastTreatIndex: null,
+  },
+}
+
+async function setupApi(page: any) {
+  await page.route('**/api/miniapp/content', (route: any) => route.fulfill({ json: catalog }))
+  await page.route('**/api/miniapp/me', (route: any) => route.fulfill({ json: postWelcomeMe }))
+  await page.route('**/api/miniapp/activity-days*', (route: any) =>
+    route.fulfill({ json: { dates: [] } })
+  )
+}
+
+test('first-visit alphabet L1 shows 3 preview letters + accordion; tapping accordion reveals the rest', async ({ page }) => {
+  await setupApi(page)
+  await page.goto('/?playwright=1')
+
+  // Dashboard first — click the suggestion (next lesson = alphabet L1).
+  await page.getByTestId('dashboard-suggestion').click()
+
+  // LessonTheory rendered. Three letter cards up front...
+  await expect(page.getByText('ა', { exact: true })).toBeVisible()
+  await expect(page.getByText('ბ', { exact: true })).toBeVisible()
+  await expect(page.getByText('გ', { exact: true })).toBeVisible()
+
+  // ...but not the rest, nor the paragraph — those live inside the closed accordion.
+  await expect(page.getByText('დ', { exact: true })).toHaveCount(0)
+  await expect(page.getByText('ე', { exact: true })).toHaveCount(0)
+  await expect(page.getByText(/Грузинский алфавит красив/)).toHaveCount(0)
+
+  // Accordion trigger is present and closed.
+  const trigger = page.getByRole('button', { name: /Остальные буквы/ })
+  await expect(trigger).toBeVisible()
+  await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+  // CTA is «Поехали →», not «к практике →».
+  await expect(page.getByRole('button', { name: /Поехали/ })).toBeVisible()
+
+  // Open the accordion → the rest of the letters and the paragraph appear.
+  await trigger.click()
+  await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+  await expect(page.getByText('დ', { exact: true })).toBeVisible()
+  await expect(page.getByText('ე', { exact: true })).toBeVisible()
+  await expect(page.getByText(/Грузинский алфавит красив/)).toBeVisible()
+})

--- a/src/Trale/miniapp-src/e2e/first-lesson-hero-cta.spec.ts
+++ b/src/Trale/miniapp-src/e2e/first-lesson-hero-cta.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from '@playwright/test'
+
+// #1002: brand-new dashboard visitor (no completed lessons) sees the navy
+// FirstLessonHeroCta with «გამარჯობა!» subtitle and tap goes straight into
+// lesson-theory of the first module's first lesson. A returning user with any
+// completed lessons falls back to the regular suggestion tile — hero absent.
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    ;(window as any).Telegram = {
+      WebApp: {
+        initData: 'user=%7B%22id%22%3A123456%7D',
+        BackButton: { show: () => {}, hide: () => {}, onClick: () => {}, offClick: () => {} },
+        MainButton: { show: () => {}, hide: () => {} },
+        HapticFeedback: { impactOccurred: () => {}, notificationOccurred: () => {} },
+        openTelegramLink: () => {},
+      },
+    }
+    try { localStorage.setItem('bombora_kani_reveal_shown', '1') } catch {}
+  })
+})
+
+const catalog = {
+  botUsername: 'TraleBot',
+  miniAppEnabled: true,
+  modules: [
+    {
+      id: 'alphabet-progressive',
+      title: 'Алфавит',
+      emoji: '🔤',
+      description: 'Грузинский алфавит',
+      lessons: [
+        {
+          id: 1,
+          title: 'Первые буквы',
+          short: 'L1',
+          theory: { title: 'Первые буквы', goal: 'g', blocks: [] },
+        },
+        {
+          id: 2,
+          title: 'Ещё буквы',
+          short: 'L2',
+          theory: { title: 'Ещё буквы', goal: 'g', blocks: [] },
+        },
+      ],
+    },
+    {
+      id: 'intro',
+      title: 'Знакомство',
+      emoji: '👋',
+      description: 'Первые фразы',
+      lessons: [
+        { id: 1, title: 'Привет', short: 'I1', theory: { title: 'Привет', goal: 'g', blocks: [] } },
+      ],
+    },
+  ],
+}
+
+// Brand-new user who somehow lands on the dashboard with 0 completedLessons.
+// XP > 0 keeps them past the pre-welcome gate (entryFlow), while an empty
+// completedLessons map keeps the hero-gate active — the design's "new user
+// with XP from referral" edge case (see spec table).
+const newUserMe = {
+  authenticated: true,
+  level: 'beginner',
+  isPro: false,
+  isTrialActive: false,
+  trialDaysLeft: 0,
+  vocabularyCount: 0,
+  onboardingHint: null,
+  progress: {
+    xp: 20,
+    streak: 0,
+    lastPlayedAtUtc: null,
+    completedLessons: {},
+    xpSpent: 0,
+    totalTreatsGiven: 0,
+    lastFedAtUtc: null,
+    lastTreatIndex: null,
+  },
+}
+
+const returningMe = {
+  ...newUserMe,
+  progress: {
+    ...newUserMe.progress,
+    xp: 100,
+    completedLessons: { 'alphabet-progressive': [1] },
+  },
+}
+
+async function setupApi(page: any, me: any) {
+  await page.route('**/api/miniapp/content', (route: any) => route.fulfill({ json: catalog }))
+  await page.route('**/api/miniapp/me', (route: any) => route.fulfill({ json: me }))
+  await page.route('**/api/miniapp/activity-days*', (route: any) =>
+    route.fulfill({ json: { dates: [] } })
+  )
+}
+
+test('brand-new user sees the navy hero-CTA and tapping it opens lesson-theory of the first lesson', async ({ page }) => {
+  await setupApi(page, newUserMe)
+  await page.goto('/?playwright=1')
+
+  const hero = page.getByTestId('dashboard-first-lesson-hero')
+  await expect(hero).toBeVisible()
+  await expect(hero).toContainText('первый урок')
+  await expect(hero).toContainText('Первые буквы')
+  await expect(hero).toContainText('გამარჯობა!')
+  await expect(hero).toContainText('Алфавит')
+  await expect(hero).toContainText('урок 1')
+
+  // No regular suggestion tile while hero is showing.
+  await expect(page.getByTestId('dashboard-suggestion')).toHaveCount(0)
+
+  // Tap → LessonTheory for alphabet-progressive lesson 1.
+  await hero.click()
+  await expect(page.getByRole('heading', { name: /Первые буквы/ })).toBeVisible()
+})
+
+test('returning user with completed lessons sees the regular suggestion tile — no hero', async ({ page }) => {
+  await setupApi(page, returningMe)
+  await page.goto('/?playwright=1')
+
+  await expect(page.getByTestId('dashboard-suggestion')).toBeVisible()
+  await expect(page.getByTestId('dashboard-first-lesson-hero')).toHaveCount(0)
+})

--- a/src/Trale/miniapp-src/e2e/lesson-theory-non-alphabet-accordion.spec.ts
+++ b/src/Trale/miniapp-src/e2e/lesson-theory-non-alphabet-accordion.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test'
+
+// #1004: on the first visit to any non-(alphabet L1) lesson, LessonTheory
+// hides theory blocks behind a «📖 Объяснение» accordion and the CTA
+// reads «Поехали →». Verifies the alphabet L2 flow named in the AC —
+// user has already completed L1, taps the dashboard suggestion (L2),
+// sees the collapsed accordion, opens it, and hits «Поехали →» to land
+// in the Practice screen.
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    ;(window as any).Telegram = {
+      WebApp: {
+        initData: 'user=%7B%22id%22%3A123456%7D',
+        BackButton: { show: () => {}, hide: () => {}, onClick: () => {}, offClick: () => {} },
+        MainButton: { show: () => {}, hide: () => {} },
+        HapticFeedback: { impactOccurred: () => {}, notificationOccurred: () => {} },
+        openTelegramLink: () => {},
+      },
+    }
+    // Suppress the one-time reveal overlay so it can't cover the action bar.
+    try { localStorage.setItem('bombora_kani_reveal_shown', '1') } catch {}
+  })
+})
+
+const catalog = {
+  botUsername: 'TraleBot',
+  miniAppEnabled: true,
+  modules: [
+    {
+      id: 'alphabet-progressive',
+      title: 'Алфавит',
+      emoji: '🔤',
+      description: 'Грузинский алфавит',
+      lessons: [
+        {
+          id: 1,
+          title: 'Первые буквы',
+          short: 'L1',
+          theory: { title: 'Первые буквы', goal: 'g', blocks: [] },
+        },
+        {
+          id: 2,
+          title: 'Ещё буквы',
+          short: 'L2',
+          theory: {
+            title: 'Ещё буквы',
+            goal: 'Запомнить следующие буквы алфавита',
+            blocks: [
+              { type: 'paragraph', text: 'Второй набор букв — вот что нас ждёт.' },
+              { type: 'example', ge: 'დედა', ru: 'мама' },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+}
+
+const l1DoneMe = {
+  authenticated: true,
+  level: 'beginner',
+  isPro: false,
+  isTrialActive: false,
+  trialDaysLeft: 0,
+  vocabularyCount: 0,
+  onboardingHint: null,
+  progress: {
+    xp: 60,
+    streak: 1,
+    lastPlayedAtUtc: null,
+    completedLessons: { 'alphabet-progressive': [1] },
+    xpSpent: 0,
+    totalTreatsGiven: 0,
+    lastFedAtUtc: null,
+    lastTreatIndex: null,
+  },
+}
+
+async function setupApi(page: any) {
+  await page.route('**/api/miniapp/content', (route: any) => route.fulfill({ json: catalog }))
+  await page.route('**/api/miniapp/me', (route: any) => route.fulfill({ json: l1DoneMe }))
+  await page.route('**/api/miniapp/activity-days*', (route: any) =>
+    route.fulfill({ json: { dates: [] } })
+  )
+  // Practice screen loads questions — stub with a single item so the screen renders.
+  await page.route('**/api/miniapp/modules/alphabet-progressive/lessons/2/questions', (route: any) =>
+    route.fulfill({
+      json: [
+        {
+          id: 'q1',
+          lemma: 'დედა',
+          question: 'Что означает «დედა»?',
+          options: ['мама', 'папа', 'сестра', 'брат'],
+          answerIndex: 0,
+          explanation: '',
+          questionType: 'multiple-choice',
+        },
+      ],
+    })
+  )
+}
+
+test('first-visit alphabet L2 hides theory behind «📖 Объяснение»; tapping «Поехали →» opens Practice', async ({ page }) => {
+  await setupApi(page)
+  await page.goto('/?playwright=1')
+
+  // Dashboard suggests the next lesson (L2) since L1 is already done.
+  await page.getByTestId('dashboard-suggestion').click()
+
+  // LessonTheory rendered. Title card shows the lesson goal.
+  await expect(page.getByText(/Запомнить следующие буквы алфавита/)).toBeVisible()
+
+  // Theory content is hidden inside the closed accordion.
+  await expect(page.getByText(/Второй набор букв — вот что нас ждёт\./)).toHaveCount(0)
+  await expect(page.getByText('დედა', { exact: true })).toHaveCount(0)
+
+  // Accordion trigger is «📖 Объяснение» and closed.
+  const trigger = page.getByRole('button', { name: /Объяснение/ })
+  await expect(trigger).toBeVisible()
+  await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+  // CTA is «Поехали →», not «к практике →».
+  const cta = page.getByRole('button', { name: /Поехали/ })
+  await expect(cta).toBeVisible()
+  await expect(page.getByRole('button', { name: /к практике/ })).toHaveCount(0)
+
+  // Open the accordion → theory blocks appear.
+  await trigger.click()
+  await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+  await expect(page.getByText(/Второй набор букв — вот что нас ждёт\./)).toBeVisible()
+  await expect(page.getByText('დედა', { exact: true })).toBeVisible()
+
+  // Tapping «Поехали →» takes the user to Practice — the mocked question renders.
+  await cta.click()
+  await expect(page.getByText(/Что означает «დედა»\?/)).toBeVisible()
+})

--- a/src/Trale/miniapp-src/e2e/module-map-pristine-pulse.spec.ts
+++ b/src/Trale/miniapp-src/e2e/module-map-pristine-pulse.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test'
+
+// #1003: on ModuleMap, the very first circle of a pristine module (0 completed
+// lessons + no per-module "started" flag) pulses and shows a «▶ Начни здесь»
+// badge. After the user taps anything in that module, the flag flips and the
+// badge is gone — surviving a reload.
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    ;(window as any).Telegram = {
+      WebApp: {
+        initData: 'user=%7B%22id%22%3A123456%7D',
+        BackButton: { show: () => {}, hide: () => {}, onClick: () => {}, offClick: () => {} },
+        MainButton: { show: () => {}, hide: () => {} },
+        HapticFeedback: { impactOccurred: () => {}, notificationOccurred: () => {} },
+        openTelegramLink: () => {},
+      },
+    }
+    try { localStorage.setItem('bombora_kani_reveal_shown', '1') } catch {}
+  })
+})
+
+const catalog = {
+  botUsername: 'TraleBot',
+  miniAppEnabled: true,
+  modules: [
+    {
+      id: 'alphabet-progressive',
+      title: 'Алфавит',
+      emoji: '🔤',
+      description: 'Грузинский алфавит',
+      lessons: [
+        { id: 1, title: 'Первые буквы', short: 'L1', theory: { title: 't', goal: 'g', blocks: [] } },
+      ],
+    },
+    {
+      id: 'intro',
+      title: 'Знакомство',
+      emoji: '👋',
+      description: 'Первые фразы',
+      lessons: [
+        { id: 1, title: 'Привет', short: 'L1', theory: { title: 'Привет', goal: 'g', blocks: [] } },
+        { id: 2, title: 'Как дела', short: 'L2', theory: { title: 'Как дела', goal: 'g', blocks: [] } },
+      ],
+    },
+  ],
+}
+
+// Returning user who has already earned XP (dashboard gate is passed) and has
+// completed alphabet L1 — but has NOT touched the "intro" module yet, so it's
+// still pristine.
+const me = {
+  authenticated: true,
+  level: 'beginner',
+  isPro: true, // intro is a Pro module; Pro flag avoids paywall detours in the deep-link.
+  isTrialActive: false,
+  trialDaysLeft: 0,
+  vocabularyCount: 0,
+  onboardingHint: null,
+  progress: {
+    xp: 100,
+    streak: 1,
+    lastPlayedAtUtc: null,
+    completedLessons: { 'alphabet-progressive': [1] },
+    xpSpent: 0,
+    totalTreatsGiven: 0,
+    lastFedAtUtc: null,
+    lastTreatIndex: null,
+  },
+}
+
+async function setupApi(page: any) {
+  await page.route('**/api/miniapp/content', (route: any) => route.fulfill({ json: catalog }))
+  await page.route('**/api/miniapp/me', (route: any) => route.fulfill({ json: me }))
+  await page.route('**/api/miniapp/activity-days*', (route: any) =>
+    route.fulfill({ json: { dates: [] } })
+  )
+}
+
+test('pristine module — first circle pulses with «▶ Начни здесь»; tapping it clears the badge and reload keeps it cleared', async ({ page }) => {
+  await setupApi(page)
+  await page.goto('/?playwright=1&moduleId=intro')
+
+  // Badge is visible while the module is pristine.
+  await expect(page.getByText(/Начни здесь/)).toBeVisible()
+
+  // First-lesson button carries the pulse-ring animation as an inline style.
+  const firstBtn = page.getByTestId('lesson-btn-1')
+  await expect(firstBtn).toHaveCSS('animation-name', /pulse-ring/)
+
+  // Tapping the second circle (any circle in the module) marks the module started.
+  // We check the intent via localStorage instead of navigating, because navigation
+  // away would unmount ModuleMap before we can assert cleared state on it.
+  await firstBtn.click()
+
+  // Reload the module (deep-link back). The badge must NOT appear anymore, and
+  // the animation must be gone.
+  await page.goto('/?playwright=1&moduleId=intro')
+
+  await expect(page.getByText(/Начни здесь/)).toHaveCount(0)
+  const firstBtnAfter = page.getByTestId('lesson-btn-1')
+  await expect(firstBtnAfter).not.toHaveCSS('animation-name', /pulse-ring/)
+})
+
+test('module with completed lessons never pulses even without the start flag', async ({ page }) => {
+  await page.route('**/api/miniapp/content', (route: any) => route.fulfill({ json: catalog }))
+  await page.route('**/api/miniapp/me', (route: any) =>
+    route.fulfill({
+      json: {
+        ...me,
+        progress: { ...me.progress, completedLessons: { 'alphabet-progressive': [1], intro: [1] } },
+      },
+    })
+  )
+  await page.route('**/api/miniapp/activity-days*', (route: any) =>
+    route.fulfill({ json: { dates: [] } })
+  )
+
+  await page.goto('/?playwright=1&moduleId=intro')
+
+  // ModuleMap rendered — lesson buttons are the reliable anchor.
+  await expect(page.getByTestId('lesson-btn-1')).toBeVisible()
+  await expect(page.getByText(/Начни здесь/)).toHaveCount(0)
+})

--- a/src/Trale/miniapp-src/src/components/FirstLessonHeroCta.test.tsx
+++ b/src/Trale/miniapp-src/src/components/FirstLessonHeroCta.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import FirstLessonHeroCta from './FirstLessonHeroCta'
+
+// #1002: navy hero-CTA rendered for brand-new users on the dashboard.
+// It surfaces the very first Georgian word («გამარჯობა!») users see and drives
+// them straight into lesson-theory of module.lessons[0] — the single conversion
+// action for a fresh session.
+
+describe('FirstLessonHeroCta', () => {
+  const firstLesson = {
+    moduleId: 'alphabet-progressive',
+    lessonId: 1,
+    title: 'Первые буквы',
+    moduleTitle: 'Алфавит',
+  }
+
+  const originalTelegram = (window as any).Telegram
+
+  beforeEach(() => {
+    ;(window as any).Telegram = {
+      WebApp: {
+        HapticFeedback: { impactOccurred: vi.fn() },
+      },
+    }
+  })
+
+  afterEach(() => {
+    ;(window as any).Telegram = originalTelegram
+  })
+
+  it('renders the eyebrow, title and Georgian subtitle from props', () => {
+    render(<FirstLessonHeroCta firstLesson={firstLesson} onStart={vi.fn()} />)
+
+    expect(screen.getByText('первый урок')).toBeInTheDocument()
+    expect(screen.getByText('Первые буквы')).toBeInTheDocument()
+    // Subtitle: «გამარჯობა! · Алфавит, урок 1»
+    expect(
+      screen.getByText(/გამარჯობა!\s*·\s*Алфавит,\s*урок\s*1/)
+    ).toBeInTheDocument()
+  })
+
+  it('calls onStart and fires medium haptic feedback on tap', async () => {
+    const user = userEvent.setup()
+    const onStart = vi.fn()
+    render(<FirstLessonHeroCta firstLesson={firstLesson} onStart={onStart} />)
+
+    await user.click(screen.getByTestId('dashboard-first-lesson-hero'))
+
+    expect(onStart).toHaveBeenCalledTimes(1)
+    const haptic = (window as any).Telegram.WebApp.HapticFeedback.impactOccurred
+    expect(haptic).toHaveBeenCalledWith('medium')
+  })
+
+  it('still calls onStart when Telegram HapticFeedback is unavailable', async () => {
+    ;(window as any).Telegram = undefined
+    const user = userEvent.setup()
+    const onStart = vi.fn()
+    render(<FirstLessonHeroCta firstLesson={firstLesson} onStart={onStart} />)
+
+    await user.click(screen.getByTestId('dashboard-first-lesson-hero'))
+
+    expect(onStart).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/Trale/miniapp-src/src/components/FirstLessonHeroCta.tsx
+++ b/src/Trale/miniapp-src/src/components/FirstLessonHeroCta.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+
+interface FirstLessonHeroCtaProps {
+  firstLesson: {
+    moduleId: string
+    lessonId: number
+    title: string
+    moduleTitle: string
+  }
+  onStart: () => void
+}
+
+// Navy hero-CTA rendered on the dashboard for brand-new users
+// (completedLessons empty). Surfaces the first Georgian word users will meet
+// («გამარჯობა!») and drives them straight into lesson-theory of the first
+// lesson — a single, unambiguous conversion action. See design-specs/936.
+export default function FirstLessonHeroCta({ firstLesson, onStart }: FirstLessonHeroCtaProps) {
+  const handleTap = () => {
+    try {
+      ;(window as any).Telegram?.WebApp?.HapticFeedback?.impactOccurred?.('medium')
+    } catch { /* haptic is optional */ }
+    onStart()
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid="dashboard-first-lesson-hero"
+      onClick={handleTap}
+      className="jewel-tile jewel-pressable mt-4 w-full min-h-[100px] bg-navy text-left px-5 py-5 flex items-center gap-4"
+    >
+      <div className="relative z-[1] shrink-0">
+        <div
+          className="w-12 h-12 rounded-xl bg-cream border-[1.5px] border-jewelInk flex items-center justify-center"
+          style={{ boxShadow: '2px 2px 0 #15100A' }}
+        >
+          <span className="text-[22px] leading-none" aria-hidden="true">🎯</span>
+        </div>
+      </div>
+      <div className="flex-1 min-w-0 relative z-[1]">
+        <div className="mn-eyebrow text-cream/70">первый урок</div>
+        <div className="font-sans text-[18px] font-extrabold text-cream leading-tight">
+          {firstLesson.title}
+        </div>
+        <div className="font-geo text-[11px] text-cream/60 mt-0.5">
+          გამარჯობა! · {firstLesson.moduleTitle}, урок {firstLesson.lessonId}
+        </div>
+      </div>
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        className="shrink-0 text-cream/70 relative z-[1]"
+        aria-hidden="true"
+      >
+        <path
+          d="M8 5 L16 12 L8 19"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </button>
+  )
+}

--- a/src/Trale/miniapp-src/src/components/TheoryAccordion.tsx
+++ b/src/Trale/miniapp-src/src/components/TheoryAccordion.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react'
+
+interface Props {
+  label: string
+  defaultOpen?: boolean
+  icon?: string
+  children: React.ReactNode
+}
+
+// Collapsible section used on LessonTheory for the first-visit UX:
+// hides secondary theory (rest letters / explanation) behind a tap.
+// Trigger is a full-width jewel-tile button; body slides open with a fade.
+export default function TheoryAccordion({
+  label,
+  defaultOpen = false,
+  icon = '📖',
+  children,
+}: Props) {
+  const [open, setOpen] = useState(defaultOpen)
+
+  return (
+    <div className="w-full">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between px-5 py-4 bg-cream border-[1px] border-jewelInk/20 rounded-xl font-sans text-[15px] font-bold text-jewelInk"
+        style={{ boxShadow: '1px 1px 0 rgba(21,16,10,0.1)' }}
+      >
+        <span className="flex items-center gap-2">
+          <span aria-hidden="true">{icon}</span>
+          <span>{label}</span>
+        </span>
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+          style={{
+            transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
+            transition: 'transform 200ms ease',
+          }}
+        >
+          <path
+            d="M4 6l4 4 4-4"
+            stroke="#15100A"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+      {open && (
+        <div className="flex flex-col gap-4 pt-4">
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/Trale/miniapp-src/src/index.css
+++ b/src/Trale/miniapp-src/src/index.css
@@ -535,6 +535,15 @@ input:focus-visible {
   animation: goldFlash 600ms ease-in-out both;
 }
 
+/* ModuleMap pristine-module pulse ring — first lesson circle pulses so users
+   see where the path starts. Uses --pulse-start / --pulse-end CSS vars set
+   inline per accent so the same keyframe works for navy/ruby/gold. */
+@keyframes pulse-ring {
+  0%   { box-shadow: 0 0 0 0   var(--pulse-start, rgba(27,95,176,0.4)), 2px 2px 0 #15100A; }
+  70%  { box-shadow: 0 0 0 8px var(--pulse-end,   rgba(27,95,176,0)),   2px 2px 0 #15100A; }
+  100% { box-shadow: 0 0 0 0   var(--pulse-end,   rgba(27,95,176,0)),   2px 2px 0 #15100A; }
+}
+
 /* Full-viewport-width kilim strip — breaks out of max-width:480px container.
    Used only on LandingScreen where kilim must span the full browser window. */
 .mn-kilim-full {

--- a/src/Trale/miniapp-src/src/screens/Dashboard.tsx
+++ b/src/Trale/miniapp-src/src/screens/Dashboard.tsx
@@ -9,6 +9,7 @@ import OnboardingSpotlight from '../components/OnboardingSpotlight'
 import MilestoneBanner, { XP_MILESTONES, STREAK_MILESTONES } from '../components/MilestoneBanner'
 import TreatShop from '../components/TreatShop'
 import FeedingAnimation from '../components/FeedingAnimation'
+import FirstLessonHeroCta from '../components/FirstLessonHeroCta'
 import { CatalogDto, ModuleDto, ProgressState, Screen, PRO_MODULE_IDS } from '../types'
 import { UserLevel } from './Onboarding'
 
@@ -231,6 +232,22 @@ export default function Dashboard({ catalog, progress, todayLessons, userLevel, 
         {(() => {
           const { greeting, mascotMood: baseMood, satiety, satietyText, suggestion } = computeHero(catalog, progress, todayLessons)
           const availableXp = Math.max(0, progress.xp - progress.xpSpent)
+          // #1002: brand-new user gate — no completed lessons in any module.
+          // Drives a single, unambiguous conversion action (FirstLessonHeroCta)
+          // instead of the regular suggestion tile; mascot shrinks to 80px and
+          // the bowl indicator is hidden (nothing to show at 0 progress).
+          const isNewUser = Object.keys(progress.completedLessons).length === 0
+          const firstModule = catalog.modules.find((m) => m.lessons.length > 0) ?? null
+          const firstLesson = firstModule ? firstModule.lessons[0] : null
+          const heroFirstLesson = isNewUser && firstModule && firstLesson
+            ? {
+                moduleId: firstModule.id,
+                lessonId: firstLesson.id,
+                title: firstLesson.title,
+                moduleTitle: firstModule.title,
+              }
+            : null
+          const mascotSize = heroFirstLesson ? 80 : 120
           const hoursSinceFed = progress.lastFedAtUtc
             ? (Date.now() - new Date(progress.lastFedAtUtc).getTime()) / (1000 * 60 * 60)
             : null
@@ -268,19 +285,24 @@ export default function Dashboard({ catalog, progress, todayLessons, userLevel, 
                 onClick={() => navigate({ kind: 'profile' })}
                 className="w-full flex flex-col items-center gap-2 text-center active:opacity-80 transition-opacity"
               >
-                <div className="relative">
-                  <Mascot mood={mascotMood} satietyTier={satietyTier} size={120} />
-                  {/* Bowl indicator */}
-                  <div className="absolute -bottom-1 left-1/2 -translate-x-1/2 flex gap-1">
-                    {[0, 1, 2].map((i) => (
-                      <div
-                        key={i}
-                        className={`w-3 h-3 rounded-full border-2 transition-all ${
-                          i < bowlFill ? 'bg-gold border-gold shadow-sm' : 'bg-cream-deep border-jewelInk/30'
-                        }`}
-                      />
-                    ))}
-                  </div>
+                <div className="relative" data-testid="dashboard-mascot">
+                  <Mascot mood={mascotMood} satietyTier={satietyTier} size={mascotSize} />
+                  {/* Bowl indicator — hidden for brand-new users (nothing to fill yet). */}
+                  {!heroFirstLesson && (
+                    <div
+                      className="absolute -bottom-1 left-1/2 -translate-x-1/2 flex gap-1"
+                      data-testid="dashboard-bowl-indicator"
+                    >
+                      {[0, 1, 2].map((i) => (
+                        <div
+                          key={i}
+                          className={`w-3 h-3 rounded-full border-2 transition-all ${
+                            i < bowlFill ? 'bg-gold border-gold shadow-sm' : 'bg-cream-deep border-jewelInk/30'
+                          }`}
+                        />
+                      ))}
+                    </div>
+                  )}
                 </div>
                 <div>
                   <div className="font-sans font-extrabold text-[20px] leading-[1.1] text-jewelInk tracking-tight">
@@ -306,7 +328,20 @@ export default function Dashboard({ catalog, progress, todayLessons, userLevel, 
                 </button>
               </div>
 
-              {suggestion && (
+              {heroFirstLesson && (
+                <FirstLessonHeroCta
+                  firstLesson={heroFirstLesson}
+                  onStart={() =>
+                    navigate({
+                      kind: 'lesson-theory',
+                      moduleId: heroFirstLesson.moduleId,
+                      lessonId: heroFirstLesson.lessonId,
+                    })
+                  }
+                />
+              )}
+
+              {!heroFirstLesson && suggestion && (
                 <button
                   data-testid="dashboard-suggestion"
                   onClick={() => navigate(suggestion.screen)}

--- a/src/Trale/miniapp-src/src/screens/Dashboard.tsx
+++ b/src/Trale/miniapp-src/src/screens/Dashboard.tsx
@@ -314,19 +314,30 @@ export default function Dashboard({ catalog, progress, todayLessons, userLevel, 
                 </div>
               </button>
 
-              {/* ── Feed button ── */}
-              <div className="mt-3 flex justify-center" onClick={(e) => e.stopPropagation()}>
-                <button
-                  data-testid="dashboard-feed-button"
-                  onClick={() => setTreatShopOpen(true)}
-                  className="px-4 py-2 rounded-xl font-sans text-[13px] font-extrabold bg-gold text-jewelInk border-[1.5px] border-jewelInk active:scale-95 transition-transform flex items-center gap-2"
-                  style={{ boxShadow: '2px 2px 0 #15100A' }}
-                >
-                  <span className="text-[16px] leading-none">🍖</span>
-                  <span>Покормить</span>
-                  <span className="text-jewelInk/70 font-bold">· ⭐ {availableXp}</span>
-                </button>
-              </div>
+              {/* ── Feed button (or hint when there's no XP to spend, #1001) ── */}
+              {availableXp > 0 ? (
+                <div className="mt-3 flex justify-center" onClick={(e) => e.stopPropagation()}>
+                  <button
+                    data-testid="dashboard-feed-button"
+                    onClick={() => setTreatShopOpen(true)}
+                    className="px-4 py-2 rounded-xl font-sans text-[13px] font-extrabold bg-gold text-jewelInk border-[1.5px] border-jewelInk active:scale-95 transition-transform flex items-center gap-2"
+                    style={{ boxShadow: '2px 2px 0 #15100A' }}
+                  >
+                    <span className="text-[16px] leading-none">🍖</span>
+                    <span>Покормить</span>
+                    <span className="text-jewelInk/70 font-bold">· ⭐ {availableXp}</span>
+                  </button>
+                </div>
+              ) : (
+                <div className="mt-3 flex justify-center">
+                  <p
+                    data-testid="dashboard-feed-hint"
+                    className="font-sans text-[12px] text-center text-jewelInk-hint leading-snug px-6"
+                  >
+                    Заработай XP первым уроком — получишь угощения для Бомборы
+                  </p>
+                </div>
+              )}
 
               {heroFirstLesson && (
                 <FirstLessonHeroCta

--- a/src/Trale/miniapp-src/src/screens/LessonTheory.tsx
+++ b/src/Trale/miniapp-src/src/screens/LessonTheory.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import Header from '../components/Header'
 import Button from '../components/Button'
 import RevealKaniOverlay from '../components/RevealKaniOverlay'
+import TheoryAccordion from '../components/TheoryAccordion'
 import { CatalogDto, ProgressState, Screen, TheoryBlockDto } from '../types'
 
 interface Props {
@@ -57,6 +58,17 @@ export default function LessonTheory({
     )
   }
 
+  const isFirstVisit = !(progress.completedLessons[moduleId] ?? []).includes(lessonId)
+  const isAlphabetL1 =
+    moduleId === 'alphabet-progressive' && lessonId === module.lessons[0]?.id
+  // Preview-split layout: first 3 letters up front, rest behind an accordion.
+  const showAlphabetPreview = isAlphabetL1 && isFirstVisit
+
+  const lettersBlock = theory.blocks.find((b) => b.type === 'letters')
+  const previewLetters = lettersBlock?.letters?.slice(0, 3) ?? []
+  const restLetters = lettersBlock?.letters?.slice(3) ?? []
+  const restBlocks = theory.blocks.filter((b) => b !== lettersBlock)
+
   return (
     <div className="flex flex-col min-h-full bg-cream">
       <Header
@@ -89,12 +101,20 @@ export default function LessonTheory({
           </div>
         </div>
 
-        {/* Theory blocks */}
-        <div className="flex flex-col gap-4">
-          {theory.blocks.map((b, i) => (
-            <TheoryBlock key={i} block={b} />
-          ))}
-        </div>
+        {showAlphabetPreview ? (
+          <AlphabetPreviewLayout
+            previewLetters={previewLetters}
+            restLetters={restLetters}
+            restBlocks={restBlocks}
+            hasLettersBlock={Boolean(lettersBlock)}
+          />
+        ) : (
+          <div className="flex flex-col gap-4">
+            {theory.blocks.map((b, i) => (
+              <TheoryBlock key={i} block={b} />
+            ))}
+          </div>
+        )}
 
         <div className="mn-kilim opacity-70 mt-6" />
       </article>
@@ -108,13 +128,60 @@ export default function LessonTheory({
           variant="primary"
           onClick={() => navigate({ kind: 'practice', moduleId, lessonId })}
         >
-          к практике →
+          {isFirstVisit ? 'Поехали →' : 'к практике →'}
         </Button>
       </div>
 
       {/* Reveal moment: letter ქ connection to ქართული (Georgian) */}
       {showReveal && (
         <RevealKaniOverlay onClose={() => setShowReveal(false)} />
+      )}
+    </div>
+  )
+}
+
+interface AlphabetPreviewLayoutProps {
+  previewLetters: NonNullable<TheoryBlockDto['letters']>
+  restLetters: NonNullable<TheoryBlockDto['letters']>
+  restBlocks: TheoryBlockDto[]
+  hasLettersBlock: boolean
+}
+
+function AlphabetPreviewLayout({
+  previewLetters,
+  restLetters,
+  restBlocks,
+  hasLettersBlock,
+}: AlphabetPreviewLayoutProps) {
+  // If there's no letters block at all, fall back to a plain «📖 Объяснение»
+  // accordion that hides every theory block.
+  if (!hasLettersBlock) {
+    if (restBlocks.length === 0) return null
+    return (
+      <TheoryAccordion label="Объяснение">
+        {restBlocks.map((b, i) => (
+          <TheoryBlock key={i} block={b} />
+        ))}
+      </TheoryAccordion>
+    )
+  }
+
+  const hasHiddenContent = restLetters.length > 0 || restBlocks.length > 0
+
+  return (
+    <div className="flex flex-col gap-4">
+      {previewLetters.length > 0 && (
+        <TheoryBlock block={{ type: 'letters', letters: previewLetters }} />
+      )}
+      {hasHiddenContent && (
+        <TheoryAccordion label="Остальные буквы">
+          {restLetters.length > 0 && (
+            <TheoryBlock block={{ type: 'letters', letters: restLetters }} />
+          )}
+          {restBlocks.map((b, i) => (
+            <TheoryBlock key={i} block={b} />
+          ))}
+        </TheoryAccordion>
       )}
     </div>
   )

--- a/src/Trale/miniapp-src/src/screens/LessonTheory.tsx
+++ b/src/Trale/miniapp-src/src/screens/LessonTheory.tsx
@@ -63,6 +63,9 @@ export default function LessonTheory({
     moduleId === 'alphabet-progressive' && lessonId === module.lessons[0]?.id
   // Preview-split layout: first 3 letters up front, rest behind an accordion.
   const showAlphabetPreview = isAlphabetL1 && isFirstVisit
+  // Non-alphabet first-visit gate: hide the whole theory behind «📖 Объяснение»
+  // so the title card and CTA are what the user sees first.
+  const showTheoryAccordion = !isAlphabetL1 && isFirstVisit
 
   const lettersBlock = theory.blocks.find((b) => b.type === 'letters')
   const previewLetters = lettersBlock?.letters?.slice(0, 3) ?? []
@@ -108,6 +111,12 @@ export default function LessonTheory({
             restBlocks={restBlocks}
             hasLettersBlock={Boolean(lettersBlock)}
           />
+        ) : showTheoryAccordion && theory.blocks.length > 0 ? (
+          <TheoryAccordion label="Объяснение">
+            {theory.blocks.map((b, i) => (
+              <TheoryBlock key={i} block={b} />
+            ))}
+          </TheoryAccordion>
         ) : (
           <div className="flex flex-col gap-4">
             {theory.blocks.map((b, i) => (

--- a/src/Trale/miniapp-src/src/screens/ModuleMap.tsx
+++ b/src/Trale/miniapp-src/src/screens/ModuleMap.tsx
@@ -1,8 +1,10 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import Header from '../components/Header'
 import KilimProgress from '../components/KilimProgress'
 import ModulePhraseBanner from '../components/ModulePhraseBanner'
 import { CatalogDto, ProgressState, Screen } from '../types'
+
+const moduleStartedKey = (moduleId: string) => `bombora_module_started_${moduleId}`
 
 interface Props {
   catalog: CatalogDto
@@ -37,6 +39,31 @@ export default function ModuleMap({
   const completed = new Set(progress.completedLessons[moduleId] ?? [])
   const done = completed.size
   const firstIncomplete = lessons.find((l) => !completed.has(l.id))?.id ?? -1
+
+  // Pristine = no completed lessons in this module AND user hasn't tapped anything yet.
+  // Tracked in localStorage so the pulse survives a reload but disappears after the
+  // first interaction (per-moduleId so other modules keep pulsing independently).
+  const isModulePristine = () => {
+    if (done > 0) return false
+    try {
+      return !localStorage.getItem(moduleStartedKey(moduleId))
+    } catch {
+      return true
+    }
+  }
+  const [isPristine, setIsPristine] = useState<boolean>(isModulePristine)
+  useEffect(() => {
+    setIsPristine(isModulePristine())
+    // moduleId change re-evaluates; done recomputed each render is fine.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [moduleId, done])
+
+  const markModuleStarted = () => {
+    try {
+      localStorage.setItem(moduleStartedKey(moduleId), '1')
+    } catch {}
+    setIsPristine(false)
+  }
 
   const geoLabels: Record<string, string> = {
     'alphabet-progressive': 'ანბანი',
@@ -213,6 +240,7 @@ export default function ModuleMap({
             const isCurrent = lesson.id === firstIncomplete
             const isEven = idx % 2 === 0
             const topY = idx * STEP_Y
+            const isFirstAndPulsing = idx === 0 && isPristine
 
             // Circle positioning: even = left of center, odd = right
             const circleLeft = isEven
@@ -248,18 +276,31 @@ export default function ModuleMap({
                 ? '2px 2px 0 #15100A'
                 : '1px 1px 0 rgba(21,16,10,0.25)'
 
+            // Pulse ring vars — accentHex with alpha 40% at start, transparent at peak.
+            // Only applied to the first circle when the module is pristine (see spec §936).
+            const pulseVars: React.CSSProperties = isFirstAndPulsing
+              ? ({
+                  ['--pulse-start' as any]: `${accentHex}66`,
+                  ['--pulse-end' as any]: `${accentHex}00`,
+                  animation: 'pulse-ring 1.5s ease-out infinite',
+                } as React.CSSProperties)
+              : {}
+
+            const onLessonTap = () => {
+              if (isPristine) markModuleStarted()
+              navigate({
+                kind: 'lesson-theory',
+                moduleId,
+                lessonId: lesson.id,
+              })
+            }
+
             return (
               <div key={lesson.id} className="absolute" style={{ top: topY, left: 0, right: 0, height: CIRCLE_SIZE }}>
                 {/* Tappable circle */}
                 <button
                   data-testid={`lesson-btn-${lesson.id}`}
-                  onClick={() =>
-                    navigate({
-                      kind: 'lesson-theory',
-                      moduleId,
-                      lessonId: lesson.id
-                    })
-                  }
+                  onClick={onLessonTap}
                   className={`absolute ${circleBg} border-[1.5px] ${circleBorder} rounded-full flex items-center justify-center transition-transform active:scale-95`}
                   style={{
                     width: CIRCLE_SIZE,
@@ -267,7 +308,8 @@ export default function ModuleMap({
                     top: 0,
                     left: circleLeft,
                     boxShadow: circleShadow,
-                    WebkitTapHighlightColor: 'transparent'
+                    WebkitTapHighlightColor: 'transparent',
+                    ...pulseVars,
                   }}
                 >
                   {isDone ? (
@@ -293,13 +335,7 @@ export default function ModuleMap({
 
                 {/* Label next to circle */}
                 <button
-                  onClick={() =>
-                    navigate({
-                      kind: 'lesson-theory',
-                      moduleId,
-                      lessonId: lesson.id
-                    })
-                  }
+                  onClick={onLessonTap}
                   className="absolute flex flex-col justify-center"
                   style={{
                     top: 0,
@@ -326,6 +362,17 @@ export default function ModuleMap({
                   >
                     {lesson.short}
                   </div>
+                  {isFirstAndPulsing && (
+                    <span
+                      className={`inline-flex items-center gap-1 font-sans text-[10px] font-extrabold ${accentText} rounded-md px-1.5 py-0.5 mt-1 self-start border`}
+                      style={{
+                        backgroundColor: `${accentHex}1A`,
+                        borderColor: `${accentHex}4D`,
+                      }}
+                    >
+                      ▶ Начни здесь
+                    </span>
+                  )}
                 </button>
               </div>
             )

--- a/src/Trale/miniapp-src/src/screens/__tests__/DashboardFeedHint.test.tsx
+++ b/src/Trale/miniapp-src/src/screens/__tests__/DashboardFeedHint.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import Dashboard from '../Dashboard'
+import type { CatalogDto, ProgressState } from '../../types'
+
+// #1001: When availableXp === 0, hide the «Покормить» button and render a
+// one-line hint in its place. When availableXp > 0, keep the button as-is.
+
+function makeCatalog(): CatalogDto {
+  return {
+    botUsername: 'TraleBot',
+    miniAppEnabled: true,
+    modules: [
+      {
+        id: 'alphabet-progressive',
+        title: 'Алфавит',
+        emoji: '🔤',
+        description: 'Грузинский алфавит',
+        lessons: [
+          {
+            id: 1,
+            title: 'Первые буквы',
+            short: 'L1',
+            theory: { title: 't', goal: 'g', blocks: [] },
+          },
+        ],
+      },
+    ],
+  }
+}
+
+function makeProgress(overrides: Partial<ProgressState> = {}): ProgressState {
+  return {
+    xp: 0,
+    streak: 0,
+    completedLessons: {},
+    lastPlayedDate: null,
+    xpSpent: 0,
+    totalTreatsGiven: 0,
+    lastFedAtUtc: null,
+    lastTreatIndex: null,
+    ...overrides,
+  }
+}
+
+describe('Dashboard — Feed button hint gate (#1001)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    ;(window as any).Telegram = {
+      WebApp: {
+        HapticFeedback: { impactOccurred: vi.fn() },
+      },
+    }
+  })
+
+  it('brand-new user with availableXp = 0 → no «Покормить» button, hint shown', () => {
+    render(
+      <Dashboard
+        catalog={makeCatalog()}
+        progress={makeProgress({ xp: 0, xpSpent: 0 })}
+        todayLessons={0}
+        userLevel="beginner"
+        isPro={false}
+        onPurchaseSuccess={vi.fn()}
+        navigate={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('dashboard-feed-button')).not.toBeInTheDocument()
+
+    const hint = screen.getByTestId('dashboard-feed-hint')
+    expect(hint).toBeInTheDocument()
+    expect(hint).toHaveTextContent('Заработай XP первым уроком — получишь угощения для Бомборы')
+    expect(hint.tagName.toLowerCase()).toBe('p')
+    expect(hint.className).toContain('text-jewelInk-hint')
+    expect(hint.className).toContain('text-[12px]')
+  })
+
+  it('returning user with availableXp = 0 (all XP spent) → hint shown, button hidden', () => {
+    render(
+      <Dashboard
+        catalog={makeCatalog()}
+        progress={makeProgress({
+          xp: 10,
+          xpSpent: 10,
+          completedLessons: { 'alphabet-progressive': [1] },
+        })}
+        todayLessons={1}
+        userLevel="beginner"
+        isPro={false}
+        onPurchaseSuccess={vi.fn()}
+        navigate={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('dashboard-feed-button')).not.toBeInTheDocument()
+    expect(screen.getByTestId('dashboard-feed-hint')).toBeInTheDocument()
+  })
+
+  it('availableXp = 5 → «Покормить» button shown with ⭐ 5, no hint', () => {
+    render(
+      <Dashboard
+        catalog={makeCatalog()}
+        progress={makeProgress({ xp: 5, xpSpent: 0 })}
+        todayLessons={0}
+        userLevel="beginner"
+        isPro={false}
+        onPurchaseSuccess={vi.fn()}
+        navigate={vi.fn()}
+      />
+    )
+
+    const btn = screen.getByTestId('dashboard-feed-button')
+    expect(btn).toBeInTheDocument()
+    expect(btn).toHaveTextContent('Покормить')
+    expect(btn).toHaveTextContent('⭐ 5')
+
+    expect(screen.queryByTestId('dashboard-feed-hint')).not.toBeInTheDocument()
+  })
+})

--- a/src/Trale/miniapp-src/src/screens/__tests__/DashboardFirstLessonHero.test.tsx
+++ b/src/Trale/miniapp-src/src/screens/__tests__/DashboardFirstLessonHero.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Dashboard from '../Dashboard'
+import type { CatalogDto, ProgressState } from '../../types'
+
+// #1002: Dashboard shows the FirstLessonHeroCta only for brand-new users
+// (completedLessons empty). Returning users see the regular suggestion tile.
+
+function makeCatalog(): CatalogDto {
+  return {
+    botUsername: 'TraleBot',
+    miniAppEnabled: true,
+    modules: [
+      {
+        id: 'alphabet-progressive',
+        title: 'Алфавит',
+        emoji: '🔤',
+        description: 'Грузинский алфавит',
+        lessons: [
+          {
+            id: 1,
+            title: 'Первые буквы',
+            short: 'L1',
+            theory: { title: 't', goal: 'g', blocks: [] },
+          },
+          {
+            id: 2,
+            title: 'Ещё буквы',
+            short: 'L2',
+            theory: { title: 't', goal: 'g', blocks: [] },
+          },
+        ],
+      },
+      {
+        id: 'intro',
+        title: 'Знакомство',
+        emoji: '👋',
+        description: 'Первые фразы',
+        lessons: [
+          { id: 1, title: 'Привет', short: 'I1', theory: { title: 't', goal: 'g', blocks: [] } },
+        ],
+      },
+    ],
+  }
+}
+
+function makeProgress(overrides: Partial<ProgressState> = {}): ProgressState {
+  return {
+    xp: 0,
+    streak: 0,
+    completedLessons: {},
+    lastPlayedDate: null,
+    xpSpent: 0,
+    totalTreatsGiven: 0,
+    lastFedAtUtc: null,
+    lastTreatIndex: null,
+    ...overrides,
+  }
+}
+
+describe('Dashboard — FirstLessonHeroCta gate', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    ;(window as any).Telegram = {
+      WebApp: {
+        HapticFeedback: { impactOccurred: vi.fn() },
+      },
+    }
+  })
+
+  it('brand-new user (completedLessons = {}) sees hero, no suggestion tile, mascot 80px, bowl hidden', () => {
+    render(
+      <Dashboard
+        catalog={makeCatalog()}
+        progress={makeProgress()}
+        todayLessons={0}
+        userLevel="beginner"
+        isPro={false}
+        onPurchaseSuccess={vi.fn()}
+        navigate={vi.fn()}
+      />
+    )
+
+    // Hero visible …
+    const hero = screen.getByTestId('dashboard-first-lesson-hero')
+    expect(hero).toBeInTheDocument()
+    expect(hero).toHaveTextContent('первый урок')
+    expect(hero).toHaveTextContent('Первые буквы')
+
+    // … regular suggestion tile hidden.
+    expect(screen.queryByTestId('dashboard-suggestion')).not.toBeInTheDocument()
+
+    // Mascot shrinks to 80px and bowl indicator is hidden.
+    const mascot = screen.getByTestId('dashboard-mascot').querySelector('svg')
+    expect(mascot).toHaveAttribute('width', '80')
+    expect(screen.queryByTestId('dashboard-bowl-indicator')).not.toBeInTheDocument()
+  })
+
+  it('hero click navigates to lesson-theory of the first module\'s first lesson', async () => {
+    const user = userEvent.setup()
+    const navigate = vi.fn()
+
+    render(
+      <Dashboard
+        catalog={makeCatalog()}
+        progress={makeProgress()}
+        todayLessons={0}
+        userLevel="beginner"
+        isPro={false}
+        onPurchaseSuccess={vi.fn()}
+        navigate={navigate}
+      />
+    )
+
+    await user.click(screen.getByTestId('dashboard-first-lesson-hero'))
+
+    expect(navigate).toHaveBeenCalledWith({
+      kind: 'lesson-theory',
+      moduleId: 'alphabet-progressive',
+      lessonId: 1,
+    })
+  })
+
+  it('returning user (completedLessons non-empty) sees regular suggestion tile and mascot 120px', () => {
+    render(
+      <Dashboard
+        catalog={makeCatalog()}
+        progress={makeProgress({
+          completedLessons: { 'alphabet-progressive': [1] },
+          xp: 15,
+        })}
+        todayLessons={0}
+        userLevel="beginner"
+        isPro={false}
+        onPurchaseSuccess={vi.fn()}
+        navigate={vi.fn()}
+      />
+    )
+
+    // Hero absent.
+    expect(screen.queryByTestId('dashboard-first-lesson-hero')).not.toBeInTheDocument()
+
+    // Regular suggestion tile visible.
+    expect(screen.getByTestId('dashboard-suggestion')).toBeInTheDocument()
+
+    // Mascot back to 120px, bowl indicator present.
+    const mascot = screen.getByTestId('dashboard-mascot').querySelector('svg')
+    expect(mascot).toHaveAttribute('width', '120')
+    expect(screen.getByTestId('dashboard-bowl-indicator')).toBeInTheDocument()
+  })
+})

--- a/src/Trale/miniapp-src/src/screens/__tests__/LessonTheory.test.tsx
+++ b/src/Trale/miniapp-src/src/screens/__tests__/LessonTheory.test.tsx
@@ -181,7 +181,7 @@ describe('LessonTheory — alphabet-progressive L1 preview split', () => {
     expect(screen.getByText(/Только текст\./)).toBeInTheDocument()
   })
 
-  it('renders the full expanded layout for alphabet-progressive lesson 2 (gate does not apply)', () => {
+  it('alphabet-progressive lesson 2 first visit uses the «📖 Объяснение» accordion (preview split is L1-only)', () => {
     const letters = ['ვ', 'ზ', 'თ', 'ი'].map(letter)
     const paragraph: TheoryBlockDto = { type: 'paragraph', text: 'Продолжаем алфавит.' }
     // Lesson 2 is the target — put L1 as a stub with empty theory so module.lessons[0].id === 1.
@@ -221,12 +221,12 @@ describe('LessonTheory — alphabet-progressive L1 preview split', () => {
       />
     )
 
-    // Everything is expanded: all letters and the paragraph are directly visible,
-    // no accordion trigger renders.
-    letters.forEach((l) => expect(screen.getByText(l.letter)).toBeInTheDocument())
-    expect(screen.getByText(/Продолжаем алфавит\./)).toBeInTheDocument()
+    // Preview split does NOT fire (that's L1-only) — everything is folded under
+    // the plain «📖 Объяснение» accordion instead.
+    letters.forEach((l) => expect(screen.queryByText(l.letter)).not.toBeInTheDocument())
+    expect(screen.queryByText(/Продолжаем алфавит\./)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Остальные буквы/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /Объяснение/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Объяснение/ })).toBeInTheDocument()
   })
 
   it('renders the full layout when alphabet L1 is already completed (no first-visit gate)', () => {

--- a/src/Trale/miniapp-src/src/screens/__tests__/LessonTheory.test.tsx
+++ b/src/Trale/miniapp-src/src/screens/__tests__/LessonTheory.test.tsx
@@ -1,0 +1,307 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import LessonTheory from '../LessonTheory'
+import type {
+  AlphabetLetterDto,
+  CatalogDto,
+  ProgressState,
+  TheoryBlockDto,
+} from '../../types'
+
+// Suppress the alphabet reveal overlay across tests — it fires on setTimeout for
+// lesson 1 letters block and would race with our render assertions.
+try {
+  localStorage.setItem('bombora_kani_reveal_shown', '1')
+} catch {}
+
+function letter(l: string): AlphabetLetterDto {
+  return {
+    letter: l,
+    name: `name-${l}`,
+    translit: `t-${l}`,
+    exampleGe: `ex-${l}`,
+    exampleRu: `пример-${l}`,
+  }
+}
+
+function makeCatalog(opts: {
+  moduleId?: string
+  lessonId?: number
+  blocks: TheoryBlockDto[]
+  extraLessons?: number
+}): CatalogDto {
+  const moduleId = opts.moduleId ?? 'alphabet-progressive'
+  const lessonId = opts.lessonId ?? 1
+  const lessons = [
+    {
+      id: lessonId,
+      title: 'Первые буквы',
+      short: 'L1',
+      theory: {
+        title: 'Первые буквы',
+        goal: 'Запомнить первые буквы алфавита',
+        blocks: opts.blocks,
+      },
+    },
+  ]
+  if (opts.extraLessons) {
+    for (let i = 0; i < opts.extraLessons; i++) {
+      lessons.push({
+        id: lessonId + i + 1,
+        title: `Урок ${lessonId + i + 1}`,
+        short: `L${lessonId + i + 1}`,
+        theory: { title: 't', goal: 'g', blocks: [] },
+      })
+    }
+  }
+  return {
+    botUsername: 'TraleBot',
+    miniAppEnabled: true,
+    modules: [
+      {
+        id: moduleId,
+        title: 'Алфавит',
+        emoji: '🔤',
+        description: 'Грузинский алфавит',
+        lessons,
+      },
+    ],
+  }
+}
+
+function makeProgress(overrides: Partial<ProgressState> = {}): ProgressState {
+  return {
+    xp: 0,
+    streak: 0,
+    completedLessons: {},
+    lastPlayedDate: null,
+    xpSpent: 0,
+    totalTreatsGiven: 0,
+    lastFedAtUtc: null,
+    lastTreatIndex: null,
+    ...overrides,
+  }
+}
+
+describe('LessonTheory — alphabet-progressive L1 preview split', () => {
+  it('shows first 3 letters up front and hides rest + other blocks in the "Остальные буквы" accordion', async () => {
+    const user = userEvent.setup()
+    const letters = ['ა', 'ბ', 'გ', 'დ', 'ე'].map(letter)
+    const paragraph: TheoryBlockDto = {
+      type: 'paragraph',
+      text: 'Грузинский алфавит красив.',
+    }
+    const catalog = makeCatalog({
+      blocks: [
+        { type: 'letters', letters },
+        paragraph,
+      ],
+      extraLessons: 1,
+    })
+
+    render(
+      <LessonTheory
+        catalog={catalog}
+        moduleId="alphabet-progressive"
+        lessonId={1}
+        progress={makeProgress()}
+        navigate={vi.fn()}
+      />
+    )
+
+    // First 3 letters visible immediately.
+    expect(screen.getByText('ა')).toBeInTheDocument()
+    expect(screen.getByText('ბ')).toBeInTheDocument()
+    expect(screen.getByText('გ')).toBeInTheDocument()
+
+    // Rest is inside the closed accordion and not initially visible.
+    expect(screen.queryByText('დ')).not.toBeInTheDocument()
+    expect(screen.queryByText('ე')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Грузинский алфавит красив\./)).not.toBeInTheDocument()
+
+    // Accordion labelled «📖 Остальные буквы» exists and is closed.
+    const trigger = screen.getByRole('button', { name: /Остальные буквы/ })
+    expect(trigger).toBeInTheDocument()
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+    // Open the accordion.
+    await user.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('დ')).toBeInTheDocument()
+    expect(screen.getByText('ე')).toBeInTheDocument()
+    expect(screen.getByText(/Грузинский алфавит красив\./)).toBeInTheDocument()
+  })
+
+  it('does not render the accordion when there is nothing to hide (letters ≤ 3 and no other blocks)', () => {
+    const catalog = makeCatalog({
+      blocks: [{ type: 'letters', letters: ['ა', 'ბ', 'გ'].map(letter) }],
+    })
+
+    render(
+      <LessonTheory
+        catalog={catalog}
+        moduleId="alphabet-progressive"
+        lessonId={1}
+        progress={makeProgress()}
+        navigate={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('ა')).toBeInTheDocument()
+    expect(screen.getByText('ბ')).toBeInTheDocument()
+    expect(screen.getByText('გ')).toBeInTheDocument()
+    // Neither accordion label should appear.
+    expect(screen.queryByRole('button', { name: /Остальные буквы/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Объяснение/ })).not.toBeInTheDocument()
+  })
+
+  it('falls back to «📖 Объяснение» accordion when there is no letters block', async () => {
+    const user = userEvent.setup()
+    const paragraph: TheoryBlockDto = { type: 'paragraph', text: 'Только текст.' }
+    const catalog = makeCatalog({
+      blocks: [paragraph],
+    })
+
+    render(
+      <LessonTheory
+        catalog={catalog}
+        moduleId="alphabet-progressive"
+        lessonId={1}
+        progress={makeProgress()}
+        navigate={vi.fn()}
+      />
+    )
+
+    // No preview letters → the paragraph is hidden inside «📖 Объяснение».
+    expect(screen.queryByText(/Только текст\./)).not.toBeInTheDocument()
+    const trigger = screen.getByRole('button', { name: /Объяснение/ })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    await user.click(trigger)
+    expect(screen.getByText(/Только текст\./)).toBeInTheDocument()
+  })
+
+  it('renders the full expanded layout for alphabet-progressive lesson 2 (gate does not apply)', () => {
+    const letters = ['ვ', 'ზ', 'თ', 'ი'].map(letter)
+    const paragraph: TheoryBlockDto = { type: 'paragraph', text: 'Продолжаем алфавит.' }
+    // Lesson 2 is the target — put L1 as a stub with empty theory so module.lessons[0].id === 1.
+    const catalog: CatalogDto = {
+      botUsername: 'TraleBot',
+      miniAppEnabled: true,
+      modules: [
+        {
+          id: 'alphabet-progressive',
+          title: 'Алфавит',
+          emoji: '🔤',
+          description: '',
+          lessons: [
+            { id: 1, title: 'L1', short: 'L1', theory: { title: 't', goal: 'g', blocks: [] } },
+            {
+              id: 2,
+              title: 'Ещё буквы',
+              short: 'L2',
+              theory: {
+                title: 'Ещё буквы',
+                goal: 'g',
+                blocks: [{ type: 'letters', letters }, paragraph],
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    render(
+      <LessonTheory
+        catalog={catalog}
+        moduleId="alphabet-progressive"
+        lessonId={2}
+        progress={makeProgress()}
+        navigate={vi.fn()}
+      />
+    )
+
+    // Everything is expanded: all letters and the paragraph are directly visible,
+    // no accordion trigger renders.
+    letters.forEach((l) => expect(screen.getByText(l.letter)).toBeInTheDocument())
+    expect(screen.getByText(/Продолжаем алфавит\./)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Остальные буквы/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Объяснение/ })).not.toBeInTheDocument()
+  })
+
+  it('renders the full layout when alphabet L1 is already completed (no first-visit gate)', () => {
+    const letters = ['ა', 'ბ', 'გ', 'დ', 'ე'].map(letter)
+    const paragraph: TheoryBlockDto = { type: 'paragraph', text: 'Уже пройдено.' }
+    const catalog = makeCatalog({
+      blocks: [{ type: 'letters', letters }, paragraph],
+    })
+
+    render(
+      <LessonTheory
+        catalog={catalog}
+        moduleId="alphabet-progressive"
+        lessonId={1}
+        progress={makeProgress({ completedLessons: { 'alphabet-progressive': [1] } })}
+        navigate={vi.fn()}
+      />
+    )
+
+    letters.forEach((l) => expect(screen.getByText(l.letter)).toBeInTheDocument())
+    expect(screen.getByText(/Уже пройдено\./)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Остальные буквы/ })).not.toBeInTheDocument()
+  })
+
+  it('shows «Поехали →» CTA on first visit and «к практике →» when lesson is completed', () => {
+    const letters = ['ა', 'ბ', 'გ', 'დ', 'ე'].map(letter)
+    const catalog = makeCatalog({
+      blocks: [{ type: 'letters', letters }],
+    })
+
+    const { rerender } = render(
+      <LessonTheory
+        catalog={catalog}
+        moduleId="alphabet-progressive"
+        lessonId={1}
+        progress={makeProgress()}
+        navigate={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('button', { name: /Поехали/i })).toBeInTheDocument()
+
+    rerender(
+      <LessonTheory
+        catalog={catalog}
+        moduleId="alphabet-progressive"
+        lessonId={1}
+        progress={makeProgress({ completedLessons: { 'alphabet-progressive': [1] } })}
+        navigate={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('button', { name: /к практике/i })).toBeInTheDocument()
+  })
+
+  it('accordion body wires the letters block and other blocks together', async () => {
+    const user = userEvent.setup()
+    const letters = ['ა', 'ბ', 'გ', 'დ'].map(letter)
+    const example: TheoryBlockDto = { type: 'example', ge: 'გამარჯობა', ru: 'здравствуйте' }
+    const catalog = makeCatalog({
+      blocks: [{ type: 'letters', letters }, example],
+    })
+
+    render(
+      <LessonTheory
+        catalog={catalog}
+        moduleId="alphabet-progressive"
+        lessonId={1}
+        progress={makeProgress()}
+        navigate={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /Остальные буквы/ }))
+
+    // Both restLetter and the example block are inside the opened accordion.
+    expect(screen.getByText('დ')).toBeInTheDocument()
+    expect(screen.getByText('გამარჯობა')).toBeInTheDocument()
+  })
+})

--- a/src/Trale/miniapp-src/src/screens/__tests__/LessonTheory.test.tsx
+++ b/src/Trale/miniapp-src/src/screens/__tests__/LessonTheory.test.tsx
@@ -305,3 +305,106 @@ describe('LessonTheory — alphabet-progressive L1 preview split', () => {
     expect(screen.getByText('გამარჯობა')).toBeInTheDocument()
   })
 })
+
+describe('LessonTheory — non-alphabet first-visit accordion', () => {
+  it('hides theory blocks behind «📖 Объяснение» on first visit to a non-alphabet module', async () => {
+    const user = userEvent.setup()
+    const paragraph: TheoryBlockDto = { type: 'paragraph', text: 'Падеж — это форма слова.' }
+    const example: TheoryBlockDto = { type: 'example', ge: 'წიგნი', ru: 'книга' }
+    const catalog = makeCatalog({
+      moduleId: 'cases-nominative',
+      lessonId: 1,
+      blocks: [paragraph, example],
+    })
+
+    render(
+      <LessonTheory
+        catalog={catalog}
+        moduleId="cases-nominative"
+        lessonId={1}
+        progress={makeProgress()}
+        navigate={vi.fn()}
+      />
+    )
+
+    // Title card is shown (goal is part of it).
+    expect(screen.getByText(/Запомнить первые буквы алфавита/)).toBeInTheDocument()
+
+    // Theory content is hidden inside the closed accordion.
+    expect(screen.queryByText(/Падеж — это форма слова\./)).not.toBeInTheDocument()
+    expect(screen.queryByText('წიგნი')).not.toBeInTheDocument()
+
+    const trigger = screen.getByRole('button', { name: /Объяснение/ })
+    expect(trigger).toBeInTheDocument()
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+    // Tapping the trigger reveals the theory blocks.
+    await user.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText(/Падеж — это форма слова\./)).toBeInTheDocument()
+    expect(screen.getByText('წიგნი')).toBeInTheDocument()
+
+    // CTA is «Поехали →» on first visit.
+    expect(screen.getByRole('button', { name: /Поехали/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /к практике/i })).not.toBeInTheDocument()
+  })
+
+  it('renders the full expanded layout for a non-alphabet lesson that is already completed', () => {
+    const paragraph: TheoryBlockDto = { type: 'paragraph', text: 'Повторение — мать учения.' }
+    const catalog = makeCatalog({
+      moduleId: 'cases-nominative',
+      lessonId: 1,
+      blocks: [paragraph],
+    })
+
+    render(
+      <LessonTheory
+        catalog={catalog}
+        moduleId="cases-nominative"
+        lessonId={1}
+        progress={makeProgress({ completedLessons: { 'cases-nominative': [1] } })}
+        navigate={vi.fn()}
+      />
+    )
+
+    // Theory is expanded — no accordion trigger.
+    expect(screen.getByText(/Повторение — мать учения\./)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Объяснение/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /к практике/i })).toBeInTheDocument()
+  })
+
+  it('non-alphabet first visit uses «Объяснение» accordion even when a letters block is present', async () => {
+    const user = userEvent.setup()
+    const letters = ['ა', 'ბ'].map(letter)
+    const paragraph: TheoryBlockDto = { type: 'paragraph', text: 'Смешанный урок.' }
+    // Non-alphabet module that happens to include a letters block in theory —
+    // the alphabet preview split must NOT be applied here.
+    const catalog = makeCatalog({
+      moduleId: 'intro',
+      lessonId: 1,
+      blocks: [{ type: 'letters', letters }, paragraph],
+    })
+
+    render(
+      <LessonTheory
+        catalog={catalog}
+        moduleId="intro"
+        lessonId={1}
+        progress={makeProgress()}
+        navigate={vi.fn()}
+      />
+    )
+
+    // No preview letters up front — everything is hidden behind «📖 Объяснение».
+    expect(screen.queryByText('ა')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Смешанный урок\./)).not.toBeInTheDocument()
+
+    const trigger = screen.getByRole('button', { name: /Объяснение/ })
+    expect(trigger).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Остальные буквы/ })).not.toBeInTheDocument()
+
+    await user.click(trigger)
+    expect(screen.getByText('ა')).toBeInTheDocument()
+    expect(screen.getByText(/Смешанный урок\./)).toBeInTheDocument()
+  })
+})

--- a/src/Trale/miniapp-src/src/screens/__tests__/ModuleMap.test.tsx
+++ b/src/Trale/miniapp-src/src/screens/__tests__/ModuleMap.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ModuleMap from '../ModuleMap'
+import type { CatalogDto, ProgressState } from '../../types'
+
+// Two-lesson stub module — pulsation targets the first circle (idx=0),
+// and we need a second circle to prove that tapping any circle clears the flag.
+function makeCatalog(moduleId: string = 'intro'): CatalogDto {
+  return {
+    botUsername: 'TraleBot',
+    miniAppEnabled: true,
+    modules: [
+      {
+        id: moduleId,
+        title: 'Знакомство',
+        emoji: '👋',
+        description: 'Первые фразы',
+        lessons: [
+          { id: 1, title: 'Привет', short: 'L1', theory: { title: 't', goal: 'g', blocks: [] } },
+          { id: 2, title: 'Как дела', short: 'L2', theory: { title: 't', goal: 'g', blocks: [] } },
+        ],
+      },
+      {
+        id: 'other',
+        title: 'Другой',
+        emoji: '🎯',
+        description: 'Другой раздел',
+        lessons: [
+          { id: 1, title: 'A', short: 'A1', theory: { title: 't', goal: 'g', blocks: [] } },
+        ],
+      },
+    ],
+  }
+}
+
+function makeProgress(overrides: Partial<ProgressState> = {}): ProgressState {
+  return {
+    xp: 0,
+    streak: 0,
+    completedLessons: {},
+    lastPlayedDate: null,
+    xpSpent: 0,
+    totalTreatsGiven: 0,
+    lastFedAtUtc: null,
+    lastTreatIndex: null,
+    ...overrides,
+  }
+}
+
+const STARTED_KEY = (moduleId: string) => `bombora_module_started_${moduleId}`
+
+describe('ModuleMap — «Начни здесь» pulsation & badge for pristine module', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('pristine module (0 completed + no start flag) pulses first circle and shows «Начни здесь» badge', () => {
+    const catalog = makeCatalog('intro')
+    render(
+      <ModuleMap
+        catalog={catalog}
+        moduleId="intro"
+        progress={makeProgress()}
+        navigate={vi.fn()}
+      />
+    )
+
+    // The first-circle button gets an inline animation shorthand referencing pulse-ring.
+    const firstBtn = screen.getByTestId('lesson-btn-1')
+    const animation =
+      firstBtn.style.animation || firstBtn.style.getPropertyValue('animation') || ''
+    expect(animation).toMatch(/pulse-ring/)
+
+    // The «▶ Начни здесь» badge is visible in the label block.
+    expect(screen.getByText(/Начни здесь/)).toBeInTheDocument()
+  })
+
+  it('does NOT pulse when the module has completed lessons (even without the start flag)', () => {
+    const catalog = makeCatalog('intro')
+    render(
+      <ModuleMap
+        catalog={catalog}
+        moduleId="intro"
+        progress={makeProgress({ completedLessons: { intro: [1] } })}
+        navigate={vi.fn()}
+      />
+    )
+
+    const firstBtn = screen.getByTestId('lesson-btn-1')
+    const animation =
+      firstBtn.style.animation || firstBtn.style.getPropertyValue('animation') || ''
+    expect(animation).not.toMatch(/pulse-ring/)
+    expect(screen.queryByText(/Начни здесь/)).not.toBeInTheDocument()
+  })
+
+  it('does NOT pulse when the start flag is set for this module', () => {
+    localStorage.setItem(STARTED_KEY('intro'), '1')
+    const catalog = makeCatalog('intro')
+    render(
+      <ModuleMap
+        catalog={catalog}
+        moduleId="intro"
+        progress={makeProgress()}
+        navigate={vi.fn()}
+      />
+    )
+
+    const firstBtn = screen.getByTestId('lesson-btn-1')
+    const animation =
+      firstBtn.style.animation || firstBtn.style.getPropertyValue('animation') || ''
+    expect(animation).not.toMatch(/pulse-ring/)
+    expect(screen.queryByText(/Начни здесь/)).not.toBeInTheDocument()
+  })
+
+  it('clicking any circle in the module sets the localStorage flag and clears pulsation + badge immediately', async () => {
+    const user = userEvent.setup()
+    const catalog = makeCatalog('intro')
+    render(
+      <ModuleMap
+        catalog={catalog}
+        moduleId="intro"
+        progress={makeProgress()}
+        navigate={vi.fn()}
+      />
+    )
+
+    // Sanity: pristine.
+    expect(screen.getByText(/Начни здесь/)).toBeInTheDocument()
+
+    // Tap the SECOND circle (not the first) — badge must still clear because the AC
+    // says any tap in the module sets the flag.
+    await user.click(screen.getByTestId('lesson-btn-2'))
+
+    expect(localStorage.getItem(STARTED_KEY('intro'))).toBe('1')
+    expect(screen.queryByText(/Начни здесь/)).not.toBeInTheDocument()
+
+    const firstBtn = screen.getByTestId('lesson-btn-1')
+    const animation =
+      firstBtn.style.animation || firstBtn.style.getPropertyValue('animation') || ''
+    expect(animation).not.toMatch(/pulse-ring/)
+  })
+
+  it('start flag is per moduleId — pulsation in another module is independent', () => {
+    // Mark "intro" as started, but "other" is still pristine.
+    localStorage.setItem(STARTED_KEY('intro'), '1')
+    const catalog = makeCatalog('intro')
+
+    const { unmount } = render(
+      <ModuleMap
+        catalog={catalog}
+        moduleId="intro"
+        progress={makeProgress()}
+        navigate={vi.fn()}
+      />
+    )
+    expect(screen.queryByText(/Начни здесь/)).not.toBeInTheDocument()
+    unmount()
+
+    render(
+      <ModuleMap
+        catalog={catalog}
+        moduleId="other"
+        progress={makeProgress()}
+        navigate={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/Начни здесь/)).toBeInTheDocument()
+  })
+})

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,8 +46,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TraleBot — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-umLPcfVU.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-cCzNMN1f.css">
+    <script type="module" crossorigin src="/assets/index-34SSxwp2.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-C1TJda4t.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,8 +46,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TraleBot — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-DvWx7s5-.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-Djt-DEi0.css">
+    <script type="module" crossorigin src="/assets/index-umLPcfVU.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-cCzNMN1f.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,7 +46,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TraleBot — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-BfzXAw_l.js"></script>
+    <script type="module" crossorigin src="/assets/index-B0g9SL1i.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Bjy571eU.css">
   </head>
   <body>

--- a/src/Trale/wwwroot/index.html
+++ b/src/Trale/wwwroot/index.html
@@ -46,8 +46,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+Georgian:wght@400..900&family=Noto+Serif+Georgian:wght@400..900&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Figtree:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <title>TraleBot — учи грузинский язык в Telegram | ქართული ენა</title>
-    <script type="module" crossorigin src="/assets/index-34SSxwp2.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-C1TJda4t.css">
+    <script type="module" crossorigin src="/assets/index-BfzXAw_l.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-Bjy571eU.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Доделка эпика #936 — [epic] Первый-урок UX фикс — конверсия picked_level → started_lesson с 48% до 65%+

Запущено из Dev Tycoon («Доделать эпик»). Агент-разработчик добивал незаконченные
задачи прямо на ночной ветке `agents/nightly-2026-07-02`.

**Дочерние задачи:** 5/5 done
**Доделаны в этом прогоне:**  #1005 #1004 #1003 #1002 #1001
**Ещё открыты:** —

Когда CI зелёный и PR станет ready — смержи в main и передвинь эпик #936
в Done на доске.

_(Automated · dispatch-epic-finish)_